### PR TITLE
MCP server: typed tools for the Zhentan agent (stdio)

### DIFF
--- a/agent/SKILL.md
+++ b/agent/SKILL.md
@@ -22,6 +22,13 @@ Authorization: Bearer $AGENT_SECRET
 ```
 Always add `-H "Authorization: Bearer $AGENT_SECRET"` to every `curl` call.
 
+> 🔑 **The exec sandbox does not carry environment variables.** Prefix every `curl`
+> command with `. "$HOME/.nanobot/workspace/.env";` (or the equivalent path to your
+> workspace `.env`) so the shell loads `AGENT_SECRET` and `ZHENTAN_API_URL` itself.
+> Never read the `.env` file's contents and never substitute a literal secret value
+> into a command — the shell does the substitution. If a call returns "Unauthorized",
+> the `.env` is missing or stale; report that to the user instead of debugging the secret.
+
 **2. Caller identity** — identifies which Telegram user triggered the action. Extract the numeric user ID from your session context (`origin.from`) and build:
 ```json
 "callerId": "telegram:<origin.from>"
@@ -90,10 +97,16 @@ Run each command immediately, wait for the result, then report the actual outcom
 ### approve `tx-XXX`
 When the owner says "approve tx-XXX" or taps ✅ approve tx-XXX:
 
+> ⏱️ `/execute` waits for on-chain inclusion and can take up to ~2 minutes. Run this
+> curl with the exec tool's `timeout` parameter set to **180** — the default 60s kills
+> the call mid-execution. If it still times out or returns empty, do NOT re-call
+> `/execute` (it usually completed server-side) — check the outcome with
+> `GET /transactions/{txId}` and report the real status.
+
 If a tx-id is provided:
 1. Co-sign and execute via the server:
 ```bash
-curl -s -X POST ${ZHENTAN_API_URL:-https://api.zhentan.me}/execute \
+curl -s --max-time 150 -X POST ${ZHENTAN_API_URL:-https://api.zhentan.me}/execute \
   -H 'Content-Type: application/json' \
   -H "Authorization: Bearer $AGENT_SECRET" \
   -d '{"txId":"tx-XXX","callerId":"telegram:<origin.from>"}'
@@ -101,7 +114,7 @@ curl -s -X POST ${ZHENTAN_API_URL:-https://api.zhentan.me}/execute \
 
 If no tx-id is provided (e.g. bare "approve"), omit `txId` — the server resolves the most recent in-review transaction using the `callerId`:
 ```bash
-curl -s -X POST ${ZHENTAN_API_URL:-https://api.zhentan.me}/execute \
+curl -s --max-time 150 -X POST ${ZHENTAN_API_URL:-https://api.zhentan.me}/execute \
   -H 'Content-Type: application/json' \
   -H "Authorization: Bearer $AGENT_SECRET" \
   -d '{"callerId":"telegram:<origin.from>"}'

--- a/agent/SKILL.md
+++ b/agent/SKILL.md
@@ -1,385 +1,91 @@
 ---
 name: zhentan
-description: Zhentan is your personal onchain security agent and co-signer. It monitors pending multisig transactions, screens them against behavioral patterns and security risk data, and auto-signs safe ones — blocking or flagging suspicious activity before it executes. Use when the user wants to review pending transactions, approve or reject a transaction, check risk scores, toggle screening mode, view transaction history, or queue and process payment requests (invoices or transfer instructions).
-metadata:
-  openclaw:
-    requires:
-      bins: ["curl"]
-      env: ["AGENT_SECRET"]
-    optionalEnv: ["ZHENTAN_API_URL"]
-    primaryEnv: "AGENT_SECRET"
+description: Zhentan is your personal onchain security agent and co-signer. It monitors pending multisig transactions, screens them against behavioral patterns and security risk data, and auto-signs safe ones — blocking or flagging suspicious activity before it executes. Use when the user wants to review pending transactions, approve or reject a transaction, check risk scores, toggle screening mode, view transaction history, manage screening rules, or queue and process payment requests (invoices or transfer instructions).
 ---
 
 # Zhentan — Onchain Security Agent & Co-Signer
 
-## Authentication & caller identity
-
-Every request to the server MUST include two things:
-
-**1. Agent secret** — proves the request came from this skill (not a random caller):
-```
-Authorization: Bearer $AGENT_SECRET
-```
-Always add `-H "Authorization: Bearer $AGENT_SECRET"` to every `curl` call.
-
-> 🔑 **The exec sandbox does not carry environment variables.** Prefix every `curl`
-> command with `. "$HOME/.nanobot/workspace/.env";` (or the equivalent path to your
-> workspace `.env`) so the shell loads `AGENT_SECRET` and `ZHENTAN_API_URL` itself.
-> Never read the `.env` file's contents and never substitute a literal secret value
-> into a command — the shell does the substitution. If a call returns "Unauthorized",
-> the `.env` is missing or stale; report that to the user instead of debugging the secret.
-
-**2. Caller identity** — identifies which Telegram user triggered the action. Extract the numeric user ID from your session context (`origin.from`) and build:
-```json
-"callerId": "telegram:<origin.from>"
-```
-Include this in all POST and PATCH request bodies, and as `?callerId=telegram:<origin.from>` on GET requests.
-
-If `origin.from` is unavailable, omit `callerId` rather than sending a placeholder.
-
-Zhentan acts as an intelligent co-signer on your Safe smart account. It learns how you transact — amounts, timing, tokens and recipients — and screens every pending transaction against your behavioral profile and external security scanners (GoPlus, Honeypot.is, De.fi) before execution.
-
-Safe transactions are auto-signed and executed instantly. Borderline ones are surfaced for your review. Clearly malicious transactions are blocked outright.
-
-**Base URL** — every `curl` below uses `${ZHENTAN_API_URL:-https://api.zhentan.me}`: the
-`ZHENTAN_API_URL` environment variable when set, falling back to production
-(`https://api.zhentan.me`). For local development set `ZHENTAN_API_URL=http://localhost:3001`;
-no edits to this file are needed. Copy the command templates exactly — the shell expands the default.
-
-## How it works
-
-1. **Owner** proposes a transaction — signs 1-of-2, POSTs to `POST /queue`
-2. **Server** runs inline risk analysis and either:
-   - **APPROVE** (risk < 40): auto-executes on-chain, sends Telegram notification
-   - **REVIEW** (risk 40–70): marks `inReview`, sends Telegram asking owner to approve/reject
-   - **BLOCK** (risk > 70): marks `inReview`, sends urgent Telegram alert
-3. **Agent** (you) handles owner commands via Telegram — execute scripts, call endpoints, report results
-
-Your role is **conversational** — the server owns the deterministic pipeline.
-
-## Transaction lifecycle
-
-- `pending` → queued, not yet processed
-- `in_review` → flagged by server (REVIEW or BLOCK), awaiting owner decision
-- `executed` → co-signed and submitted on-chain
-- `rejected` → owner rejected it
-
----
-
-## First message — `/start`
-
-When a user opens the bot for the first time, Telegram delivers a `/start` message. Call `/bot-ping` with their chat ID to mark the bot as connected and retrieve their details:
-
-```bash
-curl -s -X POST ${ZHENTAN_API_URL:-https://api.zhentan.me}/bot-ping \
-  -H 'Content-Type: application/json' \
-  -H "Authorization: Bearer $AGENT_SECRET" \
-  -d '{"chatId":"<origin.chat.id>"}'
-```
-
-**Response when user is found** (`found: true`):
-```json
-{ "ok": true, "found": true, "safeAddress": "0x...", "name": "Alice", "username": "alice" }
-```
-
-Use the returned details to greet them, for example:
-> "👋 Hey Alice! Zhentan is connected to your Safe `0xABCD…1234`. I'll notify you here for any transactions that need review. Send **help** to see what I can do."
-
-**Response when user is not found** (`found: false`): the user hasn't linked their Telegram account in the Zhentan app yet. Reply:
-> "👋 Hi! To connect your Safe, please link your Telegram account first from the Zhentan app settings."
-
----
-
-## Owner commands
-
-Run each command immediately, wait for the result, then report the actual outcome. Never fabricate results.
-
-### approve `tx-XXX`
-When the owner says "approve tx-XXX" or taps ✅ approve tx-XXX:
-
-> ⏱️ `/execute` waits for on-chain inclusion and can take up to ~2 minutes. Run this
-> curl with the exec tool's `timeout` parameter set to **180** — the default 60s kills
-> the call mid-execution. If it still times out or returns empty, do NOT re-call
-> `/execute` (it usually completed server-side) — check the outcome with
-> `GET /transactions/{txId}` and report the real status.
-
-If a tx-id is provided:
-1. Co-sign and execute via the server:
-```bash
-curl -s --max-time 150 -X POST ${ZHENTAN_API_URL:-https://api.zhentan.me}/execute \
-  -H 'Content-Type: application/json' \
-  -H "Authorization: Bearer $AGENT_SECRET" \
-  -d '{"txId":"tx-XXX","callerId":"telegram:<origin.from>"}'
-```
-
-If no tx-id is provided (e.g. bare "approve"), omit `txId` — the server resolves the most recent in-review transaction using the `callerId`:
-```bash
-curl -s --max-time 150 -X POST ${ZHENTAN_API_URL:-https://api.zhentan.me}/execute \
-  -H 'Content-Type: application/json' \
-  -H "Authorization: Bearer $AGENT_SECRET" \
-  -d '{"callerId":"telegram:<origin.from>"}'
-```
-
-Parse the JSON: on success `status` is `executed` and `txHash` is the on-chain hash; if `status` is `already_executed`, use the returned `txHash`. On failure the body includes `error`.
-
-2. Update the Telegram notification with the tx hash from step 1:
-```bash
-curl -s -X POST ${ZHENTAN_API_URL:-https://api.zhentan.me}/notify-resolve \
-  -H 'Content-Type: application/json' \
-  -H "Authorization: Bearer $AGENT_SECRET" \
-  -d '{"txId":"tx-XXX","action":"approved","txHash":"THE_TX_HASH","callerId":"telegram:<origin.from>"}'
-```
-3. Reply with the actual tx hash.
-
-The tx-id includes the `tx-` prefix (e.g. `tx-cc34ee59`). Pass it exactly as written.
-
-### reject `tx-XXX`
-When the owner says "reject tx-XXX" or taps ❌ reject tx-XXX:
-
-If a tx-id is provided:
-1. Mark rejected (optionally include a reason):
-```bash
-curl -s -X PATCH ${ZHENTAN_API_URL:-https://api.zhentan.me}/transactions/tx-XXX \
-  -H 'Content-Type: application/json' \
-  -H "Authorization: Bearer $AGENT_SECRET" \
-  -d '{"action":"reject","reason":"Rejected by owner","callerId":"telegram:<origin.from>"}'
-```
-
-If no tx-id is provided (e.g. bare "reject"), use `latest` as the id — the server resolves the most recent in-review transaction using the `callerId`:
-```bash
-curl -s -X PATCH ${ZHENTAN_API_URL:-https://api.zhentan.me}/transactions/latest \
-  -H 'Content-Type: application/json' \
-  -H "Authorization: Bearer $AGENT_SECRET" \
-  -d '{"action":"reject","reason":"Rejected by owner","callerId":"telegram:<origin.from>"}'
-```
-
-2. Update the Telegram notification:
-```bash
-curl -s -X POST ${ZHENTAN_API_URL:-https://api.zhentan.me}/notify-resolve \
-  -H 'Content-Type: application/json' \
-  -H "Authorization: Bearer $AGENT_SECRET" \
-  -d '{"txId":"tx-XXX","action":"rejected","callerId":"telegram:<origin.from>"}'
-```
-3. Reply confirming the rejection.
-
-### mark for review `tx-XXX`
-When you need to flag a transaction for manual review:
-```bash
-curl -s -X PATCH ${ZHENTAN_API_URL:-https://api.zhentan.me}/transactions/tx-XXX \
-  -H 'Content-Type: application/json' \
-  -H "Authorization: Bearer $AGENT_SECRET" \
-  -d '{"action":"review","reason":"Flagged for manual review","callerId":"telegram:<origin.from>"}'
-```
-
-### get my profile
-When the user asks "who am I", "my wallet", "my details", "show my account", or anything about their own profile:
-
-```bash
-curl -s -H "Authorization: Bearer $AGENT_SECRET" \
-  "${ZHENTAN_API_URL:-https://api.zhentan.me}/me?chatId=<origin.chat.id>"
-```
-
-Response:
-```json
-{
-  "safeAddress": "0x...",
-  "signerAddress": "0x...",
-  "name": "Alice",
-  "username": "alice",
-  "email": "alice@example.com"
-}
-```
-
-Present the relevant fields clearly. If `email` is null, omit it.
-
-### check pending
-Check if there are pending transactions for a Safe:
-```bash
-# 1. Check screening mode
-curl -s -H "Authorization: Bearer $AGENT_SECRET" "${ZHENTAN_API_URL:-https://api.zhentan.me}/status?safe=0xSAFE_ADDRESS"
-
-# 2. List transactions (filter client-side for !executedAt && !inReview && !rejected)
-curl -s -H "Authorization: Bearer $AGENT_SECRET" "${ZHENTAN_API_URL:-https://api.zhentan.me}/transactions?safeAddress=0xSAFE_ADDRESS"
-```
-
-### get status
-Get screening mode, patterns, and global limits for a Safe:
-```bash
-curl -s -H "Authorization: Bearer $AGENT_SECRET" "${ZHENTAN_API_URL:-https://api.zhentan.me}/status?safe=0xSAFE_ADDRESS"
-```
-
-### toggle screening
-Turn screening on or off for a Safe:
-```bash
-# Turn on
-curl -s -X PATCH ${ZHENTAN_API_URL:-https://api.zhentan.me}/status \
-  -H 'Content-Type: application/json' \
-  -H "Authorization: Bearer $AGENT_SECRET" \
-  -d '{"safe":"0xSAFE_ADDRESS","screeningMode":true,"callerId":"telegram:<origin.from>"}'
-
-# Turn off
-curl -s -X PATCH ${ZHENTAN_API_URL:-https://api.zhentan.me}/status \
-  -H 'Content-Type: application/json' \
-  -H "Authorization: Bearer $AGENT_SECRET" \
-  -d '{"safe":"0xSAFE_ADDRESS","screeningMode":false,"callerId":"telegram:<origin.from>"}'
-```
-
-### update limits
-Update global limits for a Safe (any combination of fields):
-```bash
-curl -s -X PATCH ${ZHENTAN_API_URL:-https://api.zhentan.me}/status \
-  -H 'Content-Type: application/json' \
-  -H "Authorization: Bearer $AGENT_SECRET" \
-  -d '{
-    "safe": "0xSAFE_ADDRESS",
-    "maxSingleTx": "5000",
-    "maxDailyVolume": "20000",
-    "riskThresholdApprove": 40,
-    "riskThresholdBlock": 70,
-    "learningEnabled": true,
-    "callerId": "telegram:<origin.from>"
-  }'
-```
-
----
-
-## Analysis commands
-
-### quick risk score
-Fetch the stored risk score for a transaction (computed at queue time):
-```bash
-curl -s -H "Authorization: Bearer $AGENT_SECRET" "${ZHENTAN_API_URL:-https://api.zhentan.me}/transactions/tx-XXX"
-# Returns: riskScore, riskVerdict, riskReasons
-```
-
-### deep analyze `tx-XXX`
-Run immediately, wait for the response (5–15s), then report the actual findings.
-
-When the owner taps 🔎 deep-analyze tx-XXX or asks "analyze tx-XXX", "is this safe?", "why was this flagged?":
-
-If a tx-id is provided:
-```bash
-curl -s -H "Authorization: Bearer $AGENT_SECRET" "${ZHENTAN_API_URL:-https://api.zhentan.me}/analyze/tx-XXX?callerId=telegram:<origin.from>"
-```
-
-If no tx-id is provided (e.g. bare "analyze" or "deep-analyze"), use `latest` — the server resolves the most recent in-review transaction using the `callerId`:
-```bash
-curl -s -H "Authorization: Bearer $AGENT_SECRET" "${ZHENTAN_API_URL:-https://api.zhentan.me}/analyze/latest?callerId=telegram:<origin.from>"
-```
-
-Parse the JSON and present:
-- `addressSecurity.flags` — scam, phishing, sanctions, money laundering
-- `tokenSecurity.flags` — honeypot, mintable, blacklist, hidden owner, tax rates
-- `honeypot` — simulation results (non-stablecoins only)
-- `recipient.known` / `recipient.totalTxCount` — behavioral history
-
-Highlight red flags prominently. If `safe: true` and `totalFlags: 0`, reassure the owner.
-
-### behavioral event log
-View the event history for a Safe:
-```bash
-curl -s -H "Authorization: Bearer $AGENT_SECRET" "${ZHENTAN_API_URL:-https://api.zhentan.me}/events?safe=0xSAFE_ADDRESS&limit=50"
-```
-
----
-
-## Rules management
-
-### list rules
-```bash
-curl -s -H "Authorization: Bearer $AGENT_SECRET" "${ZHENTAN_API_URL:-https://api.zhentan.me}/rules?safe=0xSAFE_ADDRESS"
-```
-
-### create rule
-```bash
-curl -s -X POST ${ZHENTAN_API_URL:-https://api.zhentan.me}/rules \
-  -H 'Content-Type: application/json' \
-  -H "Authorization: Bearer $AGENT_SECRET" \
-  -d '{
-    "safe": "0xSAFE_ADDRESS",
-    "name": "Block large transfers",
-    "ruleType": "amount_limit",
-    "conditions": {"maxAmount": "1000"},
-    "action": "block",
-    "priority": 10,
-    "callerId": "telegram:<origin.from>"
-  }'
-```
-Valid `ruleType`: `amount_limit`, `recipient_block`, `recipient_whitelist`, `time_restriction`, `velocity_limit`, `token_restriction`, `custom`
-Valid `action`: `approve`, `review`, `block`
-
-### update rule
-```bash
-curl -s -X PATCH ${ZHENTAN_API_URL:-https://api.zhentan.me}/rules/RULE_ID \
-  -H 'Content-Type: application/json' \
-  -H "Authorization: Bearer $AGENT_SECRET" \
-  -d '{"isActive": false, "callerId": "telegram:<origin.from>"}'
-```
-
-### delete rule
-```bash
-curl -s -X DELETE -H "Authorization: Bearer $AGENT_SECRET" ${ZHENTAN_API_URL:-https://api.zhentan.me}/rules/RULE_ID
-```
-
----
-
-## Request detection (invoices & transfer instructions)
-
-A **request** is any incoming payment ask: a parsed invoice file OR a general
-transfer instruction ("pay Alice 50 USDC", "send 0.1 BNB to 0x... tomorrow").
-Both are queued to the user's Zhentan dashboard for approval — never execute
-them directly.
-
-When a user sends an invoice file, payment message, or transfer instruction:
-
-1. Extract fields:
-   - **type** — `"invoice"` for invoice documents, `"transfer"` for general instructions
-   - **to** (wallet address, required)
-   - **amount** (required), **token** (default: USDC)
-   - **description** — for transfers: the user's instruction in one sentence
-   - Invoice-only: **invoiceNumber**, **issueDate**, **dueDate**,
-     **billedFrom**/**billedTo** — `{name, email}` objects,
-     **services** — `[{description, quantity, rate, total}]`
-   - **riskScore** (0–100) — assess based on: known vs unknown recipient (check `GET /status`), amount vs history, due date urgency
-   - **riskNotes** — brief explanation
-
-2. Queue it:
-```bash
-# Invoice
-curl -s -X POST ${ZHENTAN_API_URL:-https://api.zhentan.me}/requests \
-  -H 'Content-Type: application/json' \
-  -H "Authorization: Bearer $AGENT_SECRET" \
-  -d '{"type":"invoice","to":"0x...","amount":"500","token":"USDC","invoiceNumber":"INV-001","riskScore":20,"sourceChannel":"telegram","callerId":"telegram:<origin.from>"}'
-
-# General transfer instruction
-curl -s -X POST ${ZHENTAN_API_URL:-https://api.zhentan.me}/requests \
-  -H 'Content-Type: application/json' \
-  -H "Authorization: Bearer $AGENT_SECRET" \
-  -d '{"type":"transfer","to":"0x...","amount":"50","token":"USDC","description":"Pay Alice 50 USDC for design work","riskScore":15,"sourceChannel":"telegram","callerId":"telegram:<origin.from>"}'
-```
-
-3. Confirm: "Request for [amount] [token] queued. Check your Zhentan dashboard to approve."
-
-If the request is missing a wallet address, ask the user to provide one.
-
-### list requests
-```bash
-curl -s -H "Authorization: Bearer $AGENT_SECRET" "${ZHENTAN_API_URL:-https://api.zhentan.me}/requests?callerId=telegram:<origin.from>"
-```
-
-### update request status
-```bash
-curl -s -X PATCH ${ZHENTAN_API_URL:-https://api.zhentan.me}/requests \
-  -H 'Content-Type: application/json' \
-  -H "Authorization: Bearer $AGENT_SECRET" \
-  -d '{"id":"req-XXXXXXXX","status":"approved","txId":"tx-XXX","callerId":"telegram:<origin.from>"}'
-```
-Valid `status`: `queued`, `approved`, `executed`, `rejected`
-Valid `type`: `invoice`, `transfer`
-
-(`/invoices` remains a legacy alias for `/requests`.)
-
----
+Zhentan acts as the second signer on the owner's Safe smart account (2-of-2 multisig
+on BNB Chain). The server screens every proposed transaction against the owner's
+behavioral profile and external security scanners; your role is **conversational** —
+you act on owner commands through the **zhentan MCP tools** and report results.
+
+> **All server operations go through the `zhentan` MCP tools** (`mcp_zhentan_*`).
+> Never call the API with curl or raw HTTP — the tools handle authentication,
+> validation, base URLs, and timeouts. If a tool is missing or erroring, say so;
+> do not improvise an HTTP call.
+
+## How the pipeline works
+
+1. **Owner** proposes a transaction in the app — signs 1-of-2.
+2. **Server** runs inline risk analysis:
+   - **APPROVE** (risk < 40): auto-executes on-chain, notifies via Telegram
+   - **REVIEW** (risk 40–70): marks in-review, asks the owner to approve/reject
+   - **BLOCK** (risk > 70): marks in-review with an urgent alert
+3. **You** handle the owner's decision and any follow-up commands.
+
+Transaction lifecycle: `pending` → `in_review` → `executed` | `rejected`.
+Only in-review transactions can be approved or rejected. Rejection is final.
+
+## Caller identity
+
+Most tools take `callerId` = `telegram:<origin.from>` (the numeric Telegram user id
+from session context). Tools that take `chatId` want just the number. Pass it so the
+server resolves the right Safe — never ask the user for their Safe address; fetch it
+with `get_user_profile` when a tool needs a `safe` parameter.
+
+## Command → tool map
+
+| Owner says | Do |
+|---|---|
+| /start, "connect" | `handle_bot_start(chatId)` → greet by name, or tell them to link Telegram in app Settings |
+| "approve [tx-XXX]" | `execute_transaction` → then `resolve_notification(action:"approved", txHash)` → reply with hash + BscScan link |
+| "reject [tx-XXX]" | `reject_transaction` → then `resolve_notification(action:"rejected")` → confirm |
+| "mark for review tx-XXX" | `review_transaction` |
+| "deep analyze [tx-XXX]" | `analyze_transaction` → format per the analysis layout in your soul |
+| "risk score of tx-XXX" / "status of tx-XXX" | `check_transaction_status` |
+| "check pending" / "my transactions" | `get_user_profile(chatId)` for the Safe → `list_transactions(safeAddress, onlyOpen: true)` |
+| "enable/disable screening", "update limits" | `update_screening_settings` (get the Safe via `get_user_profile`) |
+| "screening status" | `get_screening_status` |
+| "send/pay X to Y" or an invoice | see **Payment requests** below |
+| "list requests / invoices" | `list_requests(callerId)` |
+| "who am I" / "my wallet" | `get_user_profile(chatId)` |
+| "list/create/update/delete rule" | `list_rules` / `create_rule` / `update_rule` / `delete_rule` |
+| "activity history" / "event log" | `get_event_log(safe)` |
+
+Omitting `txId` on execute/reject/review/analyze targets the owner's most recent
+in-review transaction (pass `callerId`). Pass tx-ids exactly as written, including
+the `tx-` prefix.
+
+## Approve / reject rules (critical)
+
+- **Approve** = `execute_transaction` — irreversible, moves funds. Only on an
+  explicit approve. **Reject** = `reject_transaction` — never anything else.
+- After either, call `resolve_notification` so the pending Telegram message updates.
+- If `execute_transaction` reports a timeout, it has already checked the real
+  outcome for you — report what it says. Never call it a second time for the
+  same transaction.
+- A rejected transaction is final. If the owner then wants to pay that recipient,
+  queue a **new** payment request instead.
+
+## Payment requests (invoices & transfer instructions)
+
+A request is any incoming payment ask. It is **queued to the dashboard for the
+owner to approve** — queueing never moves funds.
+
+1. If the recipient is a name ("alice.eth", "@koshik", "alice.bnb"), call
+   `resolve_recipient(name)` and **show the owner the resolved address** before queueing.
+   If it can't be resolved, ask for the address — never guess.
+2. Extract fields:
+   - `type`: `"invoice"` for invoice documents, `"transfer"` for send/pay instructions
+   - `to` (address, required), `amount` (required), `token` (default "USDC")
+   - transfers: `description` — the instruction in one sentence
+   - invoices: `invoiceNumber`, `issueDate`, `dueDate`, `billedFrom`/`billedTo`,
+     `services` `[{description, qty, rate, total}]`
+   - `riskScore` (0–100, your assessment: known vs unknown recipient via
+     `get_screening_status` patterns, amount vs history, urgency) and `riskNotes`
+3. `queue_request(...)` → confirm: "Request for [amount] [token] queued — approve it
+   in your Zhentan dashboard."
 
 ## Risk scoring reference
 
@@ -392,5 +98,13 @@ Valid `type`: `invoice`, `transfer`
 | Would exceed daily volume | +20 |
 | Custom rule triggered | varies |
 
-Verdicts: **APPROVE** (<40) · **REVIEW** (40–70) · **BLOCK** (>70)
-Thresholds are per-Safe and configurable via `PATCH /status`.
+Verdicts: **APPROVE** (<40) · **REVIEW** (40–70) · **BLOCK** (>70).
+Thresholds are per-Safe — change them with `update_screening_settings`.
+
+## Rules management
+
+Rule types: `amount_limit`, `recipient_block`, `recipient_whitelist`,
+`time_restriction`, `velocity_limit`, `token_restriction`, `custom`.
+Actions: `approve`, `review`, `block`. Lower `priority` evaluates first.
+Confirm with the owner before creating `block` rules or deleting rules
+(get the rule id from `list_rules`).

--- a/mcp/.gitignore
+++ b/mcp/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist/

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,90 @@
+# zhentan-mcp
+
+Typed MCP tools for the Zhentan agent. A **pure client** of the existing Zhentan
+server API — no endpoint changes; the markdown skill's curl commands keep working
+in parallel, so rollback is just removing the MCP config block.
+
+Why this exists: with curl-based skills the model composes endpoints and auth
+headers itself, which produced three real incidents — a reject routed to
+`/execute`, silent timeouts, and a leaked `AGENT_SECRET`. With typed tools the
+model picks from a labeled list, parameters are schema-validated before any HTTP,
+and the secret lives in this process's env where the model can never see it.
+
+## Tools
+
+| Tool | Wraps | Notes |
+|---|---|---|
+| `execute_transaction` | `POST /execute` | irreversible; 150s budget; on timeout auto-polls the real outcome, never resubmits |
+| `reject_transaction` | `PATCH /transactions/{id\|latest}` | structurally cannot touch `/execute` |
+| `review_transaction` | `PATCH /transactions/{id\|latest}` | |
+| `check_transaction_status` | `GET /transactions/:id` | status, txHash, risk verdict/reasons |
+| `queue_request` | `POST /requests` | invoice or transfer instruction; address/amount validated |
+| `list_requests` | `GET /requests?callerId=` | per-user scope |
+| `update_request_status` | `PATCH /requests` | bookkeeping only |
+| `update_screening_settings` | `PATCH /status` | screening toggle + limits/thresholds |
+
+## Build
+
+```bash
+pnpm install
+pnpm --filter zhentan-mcp build   # -> mcp/dist/index.js
+```
+
+## Environment
+
+| Var | Required | Meaning |
+|---|---|---|
+| `AGENT_SECRET` | yes | Bearer token for the Zhentan server (never enters the model) |
+| `ZHENTAN_API_URL` | no | Server base URL; defaults to `https://api.zhentan.me` |
+| `MCP_TRANSPORT` | no | `stdio` (default). Streamable HTTP is a planned follow-up — see the tracking issue |
+
+## nanobot configuration
+
+Add to `~/.nanobot/config.json` under `tools`:
+
+```json
+"tools": {
+  "mcpServers": {
+    "zhentan": {
+      "command": "node",
+      "args": ["/absolute/path/to/zhentan/mcp/dist/index.js"],
+      "env": {
+        "ZHENTAN_API_URL": "http://localhost:3001",
+        "AGENT_SECRET": "<your agent secret>"
+      },
+      "toolTimeout": 200
+    }
+  }
+}
+```
+
+- **`toolTimeout: 200` is required** — nanobot's default 30s would cancel
+  `execute_transaction` while it waits for on-chain inclusion.
+- Restart the gateway after editing. Tools appear as `mcp_zhentan_<tool>`.
+- Optional: `"enabledTools": [...]` to allow-list a subset.
+
+Claude Desktop / Cursor use the same `command`/`args`/`env` shape under their
+`mcpServers` key.
+
+## Smoke test
+
+```bash
+# handshake + tool list (no server needed)
+printf '%s\n' \
+ '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"t","version":"0"}}}' \
+ '{"jsonrpc":"2.0","method":"notifications/initialized"}' \
+ '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' \
+ | AGENT_SECRET=dummy node dist/index.js
+
+# end-to-end against a local server (expects clean "not found")
+# ... id=3 tools/call check_transaction_status {"txId":"tx-deadbeef"}
+```
+
+## Design notes
+
+- `src/server.ts` (`buildServer()`) is **transport-agnostic**: tools register once;
+  `src/index.ts` attaches the transport. Adding streamable HTTP later means a new
+  branch in `index.ts` plus auth middleware — zero tool changes.
+- Tool handlers own failure semantics: API errors come back as readable `isError`
+  results, and the execute-timeout recovery (poll status, never resubmit) is code,
+  not prompt guidance.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -29,10 +29,13 @@ and the secret lives in this process's env where the model can never see it.
 | `handle_bot_start` | `POST /bot-ping` | /start onboarding; marks bot connected, returns greeting details |
 | `get_user_profile` | `GET /me?chatId=` | friendly guidance when Telegram isn't linked |
 | `resolve_recipient` | `GET /resolve?name=` | generic: 0x address, ENS (.eth), SPACE ID (.bnb), or Zhentan username — same resolver as the UI |
+| `list_rules` / `create_rule` / `update_rule` / `delete_rule` | `/rules` | screening rules CRUD; delete is a soft-delete |
+| `get_event_log` | `GET /events?safe=` | behavioral audit trail (max 500) |
 
-Still curl-only (by design for now): rules CRUD (`/rules`) and the behavioral
-event log (`/events`). `POST /queue` is intentionally excluded — proposing
-signed transactions is the owner app's job, never the agent's.
+This covers the agent's full surface — the agent is **curl-free**; the markdown
+skill is now a pure playbook referencing these tools. `POST /queue` is
+intentionally excluded — proposing signed transactions is the owner app's job,
+never the agent's.
 
 ## Build
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -18,10 +18,20 @@ and the secret lives in this process's env where the model can never see it.
 | `reject_transaction` | `PATCH /transactions/{id\|latest}` | structurally cannot touch `/execute` |
 | `review_transaction` | `PATCH /transactions/{id\|latest}` | |
 | `check_transaction_status` | `GET /transactions/:id` | status, txHash, risk verdict/reasons |
+| `list_transactions` | `GET /transactions?safeAddress=` | trimmed fields; `onlyOpen` filter for "check pending" |
+| `analyze_transaction` | `GET /analyze/{id\|latest}` | deep analysis (GoPlus, honeypot); 60s budget |
+| `resolve_notification` | `POST /notify-resolve` | closes the approve/reject loop (edits the Telegram message) |
 | `queue_request` | `POST /requests` | invoice or transfer instruction; address/amount validated |
 | `list_requests` | `GET /requests?callerId=` | per-user scope |
 | `update_request_status` | `PATCH /requests` | bookkeeping only |
 | `update_screening_settings` | `PATCH /status` | screening toggle + limits/thresholds |
+| `get_screening_status` | `GET /status?safe=` | config + optional learned patterns (`includePatterns`) |
+| `handle_bot_start` | `POST /bot-ping` | /start onboarding; marks bot connected, returns greeting details |
+| `get_user_profile` | `GET /me?chatId=` | friendly guidance when Telegram isn't linked |
+
+Still curl-only (by design for now): rules CRUD (`/rules`) and the behavioral
+event log (`/events`). `POST /queue` is intentionally excluded — proposing
+signed transactions is the owner app's job, never the agent's.
 
 ## Build
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -28,6 +28,7 @@ and the secret lives in this process's env where the model can never see it.
 | `get_screening_status` | `GET /status?safe=` | config + optional learned patterns (`includePatterns`) |
 | `handle_bot_start` | `POST /bot-ping` | /start onboarding; marks bot connected, returns greeting details |
 | `get_user_profile` | `GET /me?chatId=` | friendly guidance when Telegram isn't linked |
+| `resolve_recipient` | `GET /resolve?name=` | generic: 0x address, ENS (.eth), SPACE ID (.bnb), or Zhentan username — same resolver as the UI |
 
 Still curl-only (by design for now): rules CRUD (`/rules`) and the behavioral
 event log (`/events`). `POST /queue` is intentionally excluded — proposing

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "zhentan-mcp",
+  "version": "0.1.0",
+  "description": "Typed MCP tools for the Zhentan agent — wraps the existing Zhentan server API",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "zhentan-mcp": "dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsx src/index.ts",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "zod": "^3.25.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "tsx": "^4.19.0",
+    "typescript": "^5"
+  }
+}

--- a/mcp/src/api.ts
+++ b/mcp/src/api.ts
@@ -1,0 +1,73 @@
+/**
+ * Thin HTTP client for the existing Zhentan server API.
+ *
+ * AGENT_SECRET lives in this process's environment (set via the MCP host's
+ * `env` config) — it never enters the model's context. ZHENTAN_API_URL
+ * selects the server (defaults to production).
+ */
+
+const BASE_URL = (process.env.ZHENTAN_API_URL ?? "https://api.zhentan.me").replace(/\/$/, "");
+const AGENT_SECRET = process.env.AGENT_SECRET;
+
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status?: number,
+  ) {
+    super(message);
+  }
+}
+
+export class ApiTimeoutError extends Error {
+  constructor(public readonly path: string) {
+    super(`Request to ${path} timed out`);
+  }
+}
+
+export async function callApi<T = Record<string, unknown>>(
+  method: "GET" | "POST" | "PATCH" | "DELETE",
+  path: string,
+  body?: Record<string, unknown>,
+  timeoutMs = 30_000,
+): Promise<T> {
+  if (!AGENT_SECRET) {
+    throw new ApiError(
+      "AGENT_SECRET is not set in the MCP server environment. Configure it in the MCP host's env block.",
+    );
+  }
+
+  let res: Response;
+  try {
+    res = await fetch(`${BASE_URL}${path}`, {
+      method,
+      headers: {
+        Authorization: `Bearer ${AGENT_SECRET}`,
+        ...(body ? { "Content-Type": "application/json" } : {}),
+      },
+      body: body ? JSON.stringify(body) : undefined,
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (err) {
+    if (err instanceof Error && err.name === "TimeoutError") {
+      throw new ApiTimeoutError(path);
+    }
+    throw new ApiError(
+      `Could not reach the Zhentan server at ${BASE_URL}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  const text = await res.text();
+  let json: Record<string, unknown>;
+  try {
+    json = text ? JSON.parse(text) : {};
+  } catch {
+    throw new ApiError(`Server returned non-JSON response (HTTP ${res.status}): ${text.slice(0, 200)}`, res.status);
+  }
+
+  if (!res.ok) {
+    const message = typeof json.error === "string" ? json.error : `HTTP ${res.status}`;
+    throw new ApiError(message, res.status);
+  }
+
+  return json as T;
+}

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+/**
+ * Zhentan MCP server entry point.
+ *
+ * Transport is selected by MCP_TRANSPORT (default: stdio).
+ * - stdio: spawned as a subprocess by the MCP host (nanobot, Claude Desktop, …)
+ * - http (future): streamable HTTP for remote hosts — see the tracking issue;
+ *   requires bearer auth on the endpoint before it can be enabled.
+ *
+ * Required env: AGENT_SECRET. Optional: ZHENTAN_API_URL (defaults to production).
+ */
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { buildServer } from "./server.js";
+
+async function main() {
+  const transport = process.env.MCP_TRANSPORT ?? "stdio";
+
+  if (transport !== "stdio") {
+    // Streamable HTTP slot: implement with StreamableHTTPServerTransport +
+    // auth middleware, reusing buildServer() unchanged.
+    console.error(`Unsupported MCP_TRANSPORT "${transport}" — only "stdio" is implemented.`);
+    process.exit(1);
+  }
+
+  const server = buildServer();
+  await server.connect(new StdioServerTransport());
+  // stdio note: stdout is the protocol channel — only ever log to stderr.
+  console.error("zhentan-mcp ready (stdio)");
+}
+
+main().catch((err) => {
+  console.error("zhentan-mcp failed to start:", err);
+  process.exit(1);
+});

--- a/mcp/src/result.ts
+++ b/mcp/src/result.ts
@@ -1,0 +1,24 @@
+import { ApiError, ApiTimeoutError } from "./api.js";
+
+export interface ToolResult {
+  [key: string]: unknown;
+  content: { type: "text"; text: string }[];
+  isError?: boolean;
+}
+
+/** Successful tool result: JSON payload the model can read directly. */
+export function ok(data: unknown): ToolResult {
+  return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+}
+
+/** Failed tool result with a plain-language message. */
+export function fail(message: string): ToolResult {
+  return { content: [{ type: "text", text: message }], isError: true };
+}
+
+/** Map thrown errors to a tool failure without leaking internals. */
+export function failFrom(err: unknown): ToolResult {
+  if (err instanceof ApiTimeoutError) return fail(err.message);
+  if (err instanceof ApiError) return fail(`Server error: ${err.message}`);
+  return fail(`Unexpected error: ${err instanceof Error ? err.message : String(err)}`);
+}

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -4,6 +4,7 @@ import { registerRequestTools } from "./tools/requests.js";
 import { registerScreeningTools } from "./tools/screening.js";
 import { registerProfileTools } from "./tools/profile.js";
 import { registerResolveTools } from "./tools/resolve.js";
+import { registerRuleTools } from "./tools/rules.js";
 
 /**
  * Build the Zhentan MCP server with all tools registered.
@@ -23,6 +24,7 @@ export function buildServer(): McpServer {
   registerScreeningTools(server);
   registerProfileTools(server);
   registerResolveTools(server);
+  registerRuleTools(server);
 
   return server;
 }

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -3,6 +3,7 @@ import { registerTransactionTools } from "./tools/transactions.js";
 import { registerRequestTools } from "./tools/requests.js";
 import { registerScreeningTools } from "./tools/screening.js";
 import { registerProfileTools } from "./tools/profile.js";
+import { registerResolveTools } from "./tools/resolve.js";
 
 /**
  * Build the Zhentan MCP server with all tools registered.
@@ -21,6 +22,7 @@ export function buildServer(): McpServer {
   registerRequestTools(server);
   registerScreeningTools(server);
   registerProfileTools(server);
+  registerResolveTools(server);
 
   return server;
 }

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -1,0 +1,24 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTransactionTools } from "./tools/transactions.js";
+import { registerRequestTools } from "./tools/requests.js";
+import { registerScreeningTools } from "./tools/screening.js";
+
+/**
+ * Build the Zhentan MCP server with all tools registered.
+ *
+ * Transport-agnostic on purpose: callers attach a transport (stdio today;
+ * streamable HTTP later) via `server.connect(transport)`. Adding a new
+ * transport must never require touching tool code.
+ */
+export function buildServer(): McpServer {
+  const server = new McpServer({
+    name: "zhentan",
+    version: "0.1.0",
+  });
+
+  registerTransactionTools(server);
+  registerRequestTools(server);
+  registerScreeningTools(server);
+
+  return server;
+}

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -2,6 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { registerTransactionTools } from "./tools/transactions.js";
 import { registerRequestTools } from "./tools/requests.js";
 import { registerScreeningTools } from "./tools/screening.js";
+import { registerProfileTools } from "./tools/profile.js";
 
 /**
  * Build the Zhentan MCP server with all tools registered.
@@ -19,6 +20,7 @@ export function buildServer(): McpServer {
   registerTransactionTools(server);
   registerRequestTools(server);
   registerScreeningTools(server);
+  registerProfileTools(server);
 
   return server;
 }

--- a/mcp/src/tools/profile.ts
+++ b/mcp/src/tools/profile.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { callApi, ApiError } from "../api.js";
+import { ok, fail, failFrom } from "../result.js";
+
+const CHAT_ID = z.string().regex(/^\d+$/, "chatId is the numeric Telegram chat id, e.g. 593960240");
+
+export function registerProfileTools(server: McpServer) {
+  server.registerTool(
+    "handle_bot_start",
+    {
+      title: "Handle /start (bot connect)",
+      description:
+        "Call when a user sends /start or asks to connect the Zhentan agent. Marks the bot as connected " +
+        "for the user's Safe and returns their name/username/safeAddress for a greeting. " +
+        "found:false means they haven't linked Telegram in the Zhentan app yet — tell them to link via " +
+        "app Settings → Telegram Link.",
+      inputSchema: {
+        chatId: CHAT_ID.describe("Numeric Telegram chat id from the session (origin.chat.id)"),
+      },
+    },
+    async ({ chatId }) => {
+      try {
+        const result = await callApi("POST", "/bot-ping", { chatId });
+        return ok(result);
+      } catch (err) {
+        return failFrom(err);
+      }
+    },
+  );
+
+  server.registerTool(
+    "get_user_profile",
+    {
+      title: "Get user profile",
+      description:
+        'Fetch the user\'s profile (name, username, email, safeAddress, signerAddress) by Telegram chat id. ' +
+        'Use when the user asks "who am I", "my wallet", "my details", or when you need their Safe address ' +
+        "for other tools.",
+      inputSchema: {
+        chatId: CHAT_ID,
+      },
+    },
+    async ({ chatId }) => {
+      try {
+        const result = await callApi("GET", `/me?chatId=${encodeURIComponent(chatId)}`);
+        return ok(result);
+      } catch (err) {
+        if (err instanceof ApiError && err.status === 404) {
+          return fail(
+            "No user is linked to this Telegram chat. Ask the user to link Telegram in the Zhentan app (Settings → Telegram Link).",
+          );
+        }
+        return failFrom(err);
+      }
+    },
+  );
+}

--- a/mcp/src/tools/requests.ts
+++ b/mcp/src/tools/requests.ts
@@ -1,0 +1,105 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { callApi } from "../api.js";
+import { ok, failFrom } from "../result.js";
+
+const ADDRESS = z.string().regex(/^0x[a-fA-F0-9]{40}$/, "must be a 0x… EVM address");
+const CALLER_ID = z
+  .string()
+  .regex(/^telegram:\d+$/, 'callerId must be "telegram:<numeric user id>"');
+const REQUEST_ID = z.string().regex(/^(req|inv)-[a-z0-9-]+$/i, "request id looks like req-XXXXXXXX");
+
+const SERVICE = z.object({
+  description: z.string(),
+  qty: z.number(),
+  rate: z.string(),
+  total: z.string(),
+});
+
+const PARTY = z.object({
+  name: z.string(),
+  email: z.string().optional(),
+  address: z.string().optional(),
+});
+
+export function registerRequestTools(server: McpServer) {
+  server.registerTool(
+    "queue_request",
+    {
+      title: "Queue a payment request",
+      description:
+        "Queue an incoming payment request (a parsed invoice or a general transfer instruction) to the user's " +
+        "Zhentan dashboard for approval. This does NOT move funds — the user approves it in the app. " +
+        "Use when the user forwards an invoice or asks to send/pay someone.",
+      inputSchema: {
+        type: z.enum(["invoice", "transfer"]).describe('"invoice" for invoice documents, "transfer" for send/pay instructions'),
+        to: ADDRESS.describe("Recipient wallet address"),
+        amount: z.string().regex(/^\d+(\.\d+)?$/, "amount must be a positive decimal string"),
+        token: z.string().min(1).describe('Token symbol, e.g. "USDC"'),
+        callerId: CALLER_ID.describe("Required — resolves which user's Safe owns this request"),
+        description: z.string().max(500).optional().describe("For transfers: the user's instruction in one sentence"),
+        invoiceNumber: z.string().optional(),
+        issueDate: z.string().optional(),
+        dueDate: z.string().optional(),
+        billedFrom: PARTY.optional(),
+        billedTo: PARTY.optional(),
+        services: z.array(SERVICE).optional(),
+        riskScore: z.number().int().min(0).max(100).optional(),
+        riskNotes: z.string().max(500).optional(),
+      },
+    },
+    async (args) => {
+      try {
+        const result = await callApi("POST", "/requests", { ...args, sourceChannel: "telegram" });
+        return ok(result);
+      } catch (err) {
+        return failFrom(err);
+      }
+    },
+  );
+
+  server.registerTool(
+    "list_requests",
+    {
+      title: "List payment requests",
+      description: "List the user's queued/approved/executed/rejected payment requests (invoices and transfers).",
+      inputSchema: {
+        callerId: CALLER_ID.describe("Scopes the list to this user's Safe"),
+      },
+    },
+    async ({ callerId }) => {
+      try {
+        const result = await callApi("GET", `/requests?callerId=${encodeURIComponent(callerId)}`);
+        return ok(result);
+      } catch (err) {
+        return failFrom(err);
+      }
+    },
+  );
+
+  server.registerTool(
+    "update_request_status",
+    {
+      title: "Update payment request status",
+      description:
+        "Update a queued payment request's status (approved / executed / rejected). " +
+        "This updates bookkeeping only — it does not execute anything on-chain.",
+      inputSchema: {
+        id: REQUEST_ID.describe("Request id, e.g. req-1a2b3c4d"),
+        status: z.enum(["queued", "approved", "executed", "rejected"]),
+        txId: z.string().optional().describe("Associated transaction id when approving"),
+        txHash: z.string().optional().describe("On-chain hash when marking executed"),
+        rejectReason: z.string().max(500).optional(),
+        callerId: CALLER_ID.optional(),
+      },
+    },
+    async (args) => {
+      try {
+        const result = await callApi("PATCH", "/requests", { ...args });
+        return ok(result);
+      } catch (err) {
+        return failFrom(err);
+      }
+    },
+  );
+}

--- a/mcp/src/tools/resolve.ts
+++ b/mcp/src/tools/resolve.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { callApi, ApiError } from "../api.js";
+import { ok, fail, failFrom } from "../result.js";
+
+export function registerResolveTools(server: McpServer) {
+  server.registerTool(
+    "resolve_recipient",
+    {
+      title: "Resolve recipient name to address",
+      description:
+        "Resolve a recipient into a wallet address. Accepts a raw 0x address (validated and passed through), " +
+        "an ENS name (alice.eth), a SPACE ID name (alice.bnb), or a Zhentan username. " +
+        'Use whenever the user names a recipient instead of giving an address ("pay alice.eth", "send 50 USDC to @koshik") ' +
+        "BEFORE calling queue_request. Returns the address and which source resolved it — " +
+        "always show the user the resolved address for confirmation before queueing a payment.",
+      inputSchema: {
+        name: z
+          .string()
+          .min(1)
+          .max(255)
+          .describe("0x address, ENS (.eth), SPACE ID (.bnb), or Zhentan username"),
+      },
+    },
+    async ({ name }) => {
+      try {
+        const result = await callApi<{ address: string; name?: string; source: string }>(
+          "GET",
+          `/resolve?name=${encodeURIComponent(name.trim())}`,
+          undefined,
+          45_000, // ENS/SPACE ID resolution walks RPC fallbacks — give it room
+        );
+        return ok(result);
+      } catch (err) {
+        if (err instanceof ApiError && err.status && err.status < 500) {
+          return fail(
+            `Could not resolve "${name}" (supported: 0x address, .eth, .bnb, or a Zhentan username). ` +
+              `Ask the user to double-check the name or provide the address directly.`,
+          );
+        }
+        return failFrom(err);
+      }
+    },
+  );
+}

--- a/mcp/src/tools/rules.ts
+++ b/mcp/src/tools/rules.ts
@@ -1,0 +1,147 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { callApi } from "../api.js";
+import { ok, failFrom } from "../result.js";
+
+const ADDRESS = z.string().regex(/^0x[a-fA-F0-9]{40}$/, "must be a 0x… EVM address");
+const RULE_ID = z.string().uuid("rule id is a UUID (from list_rules)");
+
+const RULE_TYPE = z.enum([
+  "amount_limit",
+  "recipient_block",
+  "recipient_whitelist",
+  "time_restriction",
+  "velocity_limit",
+  "token_restriction",
+  "custom",
+]);
+
+const RULE_ACTION = z.enum(["approve", "review", "block"]);
+
+const CONDITIONS_HINT =
+  'Shape depends on ruleType: amount_limit {"max":"500","token":"USDC"} · recipient_block/whitelist {"address":"0x…"} · ' +
+  'time_restriction {"hours":[0,1,2],"days":[6,0]} · velocity_limit {"window":"hourly","max_volume":"1000"} · ' +
+  'token_restriction {"token":"0x…","action":"block"} · custom: any object';
+
+export function registerRuleTools(server: McpServer) {
+  server.registerTool(
+    "list_rules",
+    {
+      title: "List screening rules",
+      description: "List the custom screening rules for a Safe (id, type, conditions, action, priority, active).",
+      inputSchema: {
+        safe: ADDRESS,
+      },
+    },
+    async ({ safe }) => {
+      try {
+        const result = await callApi("GET", `/rules?safe=${encodeURIComponent(safe)}`);
+        return ok(result);
+      } catch (err) {
+        return failFrom(err);
+      }
+    },
+  );
+
+  server.registerTool(
+    "create_rule",
+    {
+      title: "Create screening rule",
+      description:
+        "Create a custom screening rule for a Safe. The risk engine evaluates active rules on every transaction; " +
+        "the rule's action (approve/review/block) and riskScoreDelta influence the verdict. " +
+        "Confirm the rule's effect with the user before creating block rules.",
+      inputSchema: {
+        safe: ADDRESS,
+        name: z.string().min(1).max(120),
+        ruleType: RULE_TYPE,
+        conditions: z.record(z.unknown()).describe(CONDITIONS_HINT),
+        action: RULE_ACTION,
+        riskScoreDelta: z.number().int().min(-100).max(100).optional().describe("Added to the risk score when triggered (default 0)"),
+        priority: z.number().int().min(0).optional().describe("Lower = evaluated first (default 100)"),
+        description: z.string().max(500).optional(),
+      },
+    },
+    async (args) => {
+      try {
+        const result = await callApi("POST", "/rules", { ...args });
+        return ok(result);
+      } catch (err) {
+        return failFrom(err);
+      }
+    },
+  );
+
+  server.registerTool(
+    "update_rule",
+    {
+      title: "Update screening rule",
+      description:
+        "Update an existing rule — enable/disable (isActive), change priority, conditions, action, etc. " +
+        "Get the rule id from list_rules first.",
+      inputSchema: {
+        id: RULE_ID,
+        name: z.string().min(1).max(120).optional(),
+        ruleType: RULE_TYPE.optional(),
+        conditions: z.record(z.unknown()).optional().describe(CONDITIONS_HINT),
+        action: RULE_ACTION.optional(),
+        riskScoreDelta: z.number().int().min(-100).max(100).optional(),
+        priority: z.number().int().min(0).optional(),
+        description: z.string().max(500).optional(),
+        isActive: z.boolean().optional(),
+      },
+    },
+    async ({ id, ...patch }) => {
+      try {
+        const result = await callApi("PATCH", `/rules/${encodeURIComponent(id)}`, { ...patch });
+        return ok(result);
+      } catch (err) {
+        return failFrom(err);
+      }
+    },
+  );
+
+  server.registerTool(
+    "delete_rule",
+    {
+      title: "Delete screening rule",
+      description:
+        "Soft-delete (deactivate) a screening rule. Get the rule id from list_rules first, and confirm with " +
+        "the user which rule they mean before deleting.",
+      inputSchema: {
+        id: RULE_ID,
+      },
+    },
+    async ({ id }) => {
+      try {
+        const result = await callApi("DELETE", `/rules/${encodeURIComponent(id)}`);
+        return ok(result);
+      } catch (err) {
+        return failFrom(err);
+      }
+    },
+  );
+
+  server.registerTool(
+    "get_event_log",
+    {
+      title: "Get behavioral event log",
+      description:
+        "Fetch the behavioral event history for a Safe (proposals, approvals, rejections, rule triggers, " +
+        "pattern updates) — newest first. Use when the user asks for activity history or an audit trail.",
+      inputSchema: {
+        safe: ADDRESS,
+        limit: z.number().int().min(1).max(500).optional().describe("Max events to return (default 100)"),
+      },
+    },
+    async ({ safe, limit }) => {
+      try {
+        const query = `safe=${encodeURIComponent(safe)}${limit ? `&limit=${limit}` : ""}`;
+        const result = await callApi("GET", `/events?${query}`);
+        return ok(result);
+      } catch (err) {
+        return failFrom(err);
+      }
+    },
+  );
+}

--- a/mcp/src/tools/screening.ts
+++ b/mcp/src/tools/screening.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { callApi } from "../api.js";
+import { ok, fail, failFrom } from "../result.js";
+
+const ADDRESS = z.string().regex(/^0x[a-fA-F0-9]{40}$/, "must be a 0x… EVM address");
+const CALLER_ID = z
+  .string()
+  .regex(/^telegram:\d+$/, 'callerId must be "telegram:<numeric user id>"');
+
+export function registerScreeningTools(server: McpServer) {
+  server.registerTool(
+    "update_screening_settings",
+    {
+      title: "Update screening settings",
+      description:
+        "Toggle screening mode and/or update per-Safe limits and risk thresholds. " +
+        "Provide only the fields to change. Use when the user says enable/disable screening or update limits.",
+      inputSchema: {
+        safe: ADDRESS.describe("The user's Safe address"),
+        screeningMode: z.boolean().optional().describe("true = screening on, false = off"),
+        maxSingleTx: z.string().regex(/^\d+(\.\d+)?$/).optional(),
+        maxDailyVolume: z.string().regex(/^\d+(\.\d+)?$/).optional(),
+        riskThresholdApprove: z.number().int().min(0).max(100).optional(),
+        riskThresholdBlock: z.number().int().min(0).max(100).optional(),
+        learningEnabled: z.boolean().optional(),
+        callerId: CALLER_ID.optional(),
+      },
+    },
+    async ({ safe, callerId, ...settings }) => {
+      const changes = Object.entries(settings).filter(([, v]) => v !== undefined);
+      if (changes.length === 0) {
+        return fail("Provide at least one setting to change (screeningMode, maxSingleTx, riskThresholdApprove, …).");
+      }
+      try {
+        const result = await callApi("PATCH", "/status", {
+          safe,
+          ...Object.fromEntries(changes),
+          ...(callerId ? { callerId } : {}),
+        });
+        return ok(result);
+      } catch (err) {
+        return failFrom(err);
+      }
+    },
+  );
+}

--- a/mcp/src/tools/screening.ts
+++ b/mcp/src/tools/screening.ts
@@ -44,4 +44,30 @@ export function registerScreeningTools(server: McpServer) {
       }
     },
   );
+
+  server.registerTool(
+    "get_screening_status",
+    {
+      title: "Get screening status",
+      description:
+        "Fetch the screening configuration for a Safe: screening mode on/off, limits, thresholds, " +
+        "telegram connection state. Set includePatterns to true to also return the learned behavioral " +
+        "patterns (recipients, tokens, time grid) — large output, only when needed.",
+      inputSchema: {
+        safe: ADDRESS.describe("The user's Safe address"),
+        includePatterns: z.boolean().optional().describe("Include learned behavioral patterns (large)"),
+      },
+    },
+    async ({ safe, includePatterns }) => {
+      try {
+        const result = await callApi<Record<string, unknown>>("GET", `/status?safe=${encodeURIComponent(safe)}`);
+        if (!includePatterns) {
+          delete result.patterns;
+        }
+        return ok(result);
+      } catch (err) {
+        return failFrom(err);
+      }
+    },
+  );
 }

--- a/mcp/src/tools/transactions.ts
+++ b/mcp/src/tools/transactions.ts
@@ -187,4 +187,105 @@ export function registerTransactionTools(server: McpServer) {
       }
     },
   );
+
+  server.registerTool(
+    "list_transactions",
+    {
+      title: "List transactions for a Safe",
+      description:
+        "List transactions for a Safe address (newest first), trimmed to the essentials. " +
+        'Use for "check pending" / "show my transactions". Set onlyOpen to true to show only ' +
+        "transactions that have not executed and are not rejected.",
+      inputSchema: {
+        safeAddress: z.string().regex(/^0x[a-fA-F0-9]{40}$/, "must be a 0x… EVM address"),
+        onlyOpen: z.boolean().optional().describe("true = only not-yet-executed, not-rejected transactions"),
+      },
+    },
+    async ({ safeAddress, onlyOpen }) => {
+      try {
+        const { transactions } = await callApi<{ transactions: Record<string, unknown>[] }>(
+          "GET",
+          `/transactions?safeAddress=${encodeURIComponent(safeAddress)}`,
+        );
+        let list = (transactions ?? []).map((t) => ({
+          id: t.id,
+          status: t.status,
+          to: t.to,
+          amount: t.amount,
+          token: t.token,
+          proposedAt: t.proposedAt,
+          riskScore: t.riskScore,
+          riskVerdict: t.riskVerdict,
+          inReview: t.inReview,
+          rejected: t.rejected,
+          executedAt: t.executedAt,
+          txHash: t.txHash,
+        }));
+        if (onlyOpen) {
+          list = list.filter((t) => !t.executedAt && !t.rejected && t.id);
+        }
+        return ok({ count: list.length, transactions: list });
+      } catch (err) {
+        return failFrom(err);
+      }
+    },
+  );
+
+  server.registerTool(
+    "analyze_transaction",
+    {
+      title: "Deep security analysis",
+      description:
+        "Run a deep security analysis of a transaction: recipient history, address security (GoPlus), " +
+        "token safety, honeypot simulation, and an overall verdict with flags. " +
+        "Omit txId to analyze the user's most recent in-review transaction (callerId required in that case). " +
+        "External scanners are involved — this can take ~20 seconds.",
+      inputSchema: {
+        txId: TX_ID.optional(),
+        callerId: CALLER_ID.optional(),
+      },
+    },
+    async ({ txId, callerId }) => {
+      if (!txId && !callerId) {
+        return fail("Provide txId, or callerId so the server can resolve the latest in-review transaction.");
+      }
+      try {
+        const id = txId ?? "latest";
+        const query = callerId ? `?callerId=${encodeURIComponent(callerId)}` : "";
+        const result = await callApi("GET", `/analyze/${encodeURIComponent(id)}${query}`, undefined, 60_000);
+        return ok(result);
+      } catch (err) {
+        return failFrom(err);
+      }
+    },
+  );
+
+  server.registerTool(
+    "resolve_notification",
+    {
+      title: "Resolve Telegram notification",
+      description:
+        "Update the pending Telegram notification message after a transaction was approved or rejected. " +
+        "Call this right after execute_transaction succeeds (action approved, include txHash) or after " +
+        "reject_transaction (action rejected).",
+      inputSchema: {
+        txId: TX_ID,
+        action: z.enum(["approved", "rejected"]),
+        txHash: z.string().regex(/^0x[a-fA-F0-9]{64}$/).optional().describe("On-chain hash (for approved)"),
+        safeAddress: z
+          .string()
+          .regex(/^0x[a-fA-F0-9]{40}$/)
+          .optional()
+          .describe("Safe address — helps locate the chat if the message cache was lost"),
+      },
+    },
+    async (args) => {
+      try {
+        const result = await callApi("POST", "/notify-resolve", { ...args });
+        return ok(result);
+      } catch (err) {
+        return failFrom(err);
+      }
+    },
+  );
 }

--- a/mcp/src/tools/transactions.ts
+++ b/mcp/src/tools/transactions.ts
@@ -1,0 +1,190 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { callApi, ApiTimeoutError } from "../api.js";
+import { ok, fail, failFrom } from "../result.js";
+
+const TX_ID = z.string().regex(/^tx-[a-z0-9-]+$/i, "txId must look like tx-XXXXXXXX");
+const CALLER_ID = z
+  .string()
+  .regex(/^telegram:\d+$/, 'callerId must be "telegram:<numeric user id>"');
+
+interface TxStatus {
+  transaction?: {
+    id: string;
+    status?: string;
+    txHash?: string;
+    rejected?: boolean;
+    inReview?: boolean;
+    executedAt?: string;
+    riskScore?: number;
+    riskVerdict?: string;
+    riskReasons?: string[];
+    to?: string;
+    amount?: string;
+    token?: string;
+  };
+}
+
+async function fetchStatus(txId: string) {
+  const { transaction } = await callApi<TxStatus>("GET", `/transactions/${encodeURIComponent(txId)}`);
+  return transaction;
+}
+
+/**
+ * On-chain inclusion can outlive the HTTP call. If /execute times out, the
+ * server usually finished anyway — poll the transaction status instead of
+ * failing (and NEVER re-submit).
+ */
+async function recoverAfterTimeout(txId: string) {
+  for (let attempt = 0; attempt < 6; attempt++) {
+    await new Promise((r) => setTimeout(r, 5_000));
+    try {
+      const tx = await fetchStatus(txId);
+      if (tx?.txHash) {
+        return ok({
+          status: "executed",
+          txId,
+          txHash: tx.txHash,
+          note: "The execute call timed out but the transaction completed on-chain.",
+        });
+      }
+      if (tx?.rejected) {
+        return ok({ status: "rejected", txId });
+      }
+    } catch {
+      // transient — keep polling
+    }
+  }
+  return fail(
+    `The execute call for ${txId} timed out and the transaction has not confirmed yet. ` +
+      `Do NOT call execute_transaction again — use check_transaction_status in a minute to get the outcome.`,
+  );
+}
+
+export function registerTransactionTools(server: McpServer) {
+  server.registerTool(
+    "execute_transaction",
+    {
+      title: "Approve & execute transaction",
+      description:
+        "Co-sign and execute a pending Safe transaction on-chain. IRREVERSIBLE — moves funds. " +
+        "Call ONLY when the user explicitly asked to APPROVE. Never call this for a reject — use reject_transaction. " +
+        "Omit txId to execute the user's most recent in-review transaction (callerId required in that case). " +
+        "Waits for on-chain inclusion; on timeout it automatically checks the real outcome.",
+      inputSchema: {
+        txId: TX_ID.optional().describe("Transaction id, e.g. tx-cc34ee59. Omit to target the latest in-review tx."),
+        callerId: CALLER_ID.optional().describe("Telegram caller identity, e.g. telegram:593960240"),
+      },
+    },
+    async ({ txId, callerId }) => {
+      if (!txId && !callerId) {
+        return fail("Provide txId, or callerId so the server can resolve the latest in-review transaction.");
+      }
+      try {
+        const result = await callApi(
+          "POST",
+          "/execute",
+          { ...(txId ? { txId } : {}), ...(callerId ? { callerId } : {}) },
+          150_000,
+        );
+        return ok(result);
+      } catch (err) {
+        if (err instanceof ApiTimeoutError && txId) {
+          return recoverAfterTimeout(txId);
+        }
+        if (err instanceof ApiTimeoutError) {
+          return fail(
+            "The execute call timed out and no txId was provided, so the outcome can't be auto-checked. " +
+              "Do NOT call execute_transaction again — ask the user to check their dashboard, or find the txId and use check_transaction_status.",
+          );
+        }
+        return failFrom(err);
+      }
+    },
+  );
+
+  server.registerTool(
+    "reject_transaction",
+    {
+      title: "Reject transaction",
+      description:
+        "Reject a pending in-review Safe transaction so it will NOT execute. No funds move. " +
+        "Use whenever the user says reject/deny/block a transaction. " +
+        "Omit txId to reject the user's most recent in-review transaction (callerId required in that case).",
+      inputSchema: {
+        txId: TX_ID.optional().describe("Transaction id to reject. Omit to target the latest in-review tx."),
+        reason: z.string().max(500).optional().describe("Why it was rejected (shown to the user)."),
+        callerId: CALLER_ID.optional(),
+      },
+    },
+    async ({ txId, reason, callerId }) => {
+      if (!txId && !callerId) {
+        return fail("Provide txId, or callerId so the server can resolve the latest in-review transaction.");
+      }
+      try {
+        const id = txId ?? "latest";
+        const result = await callApi("PATCH", `/transactions/${encodeURIComponent(id)}`, {
+          action: "reject",
+          reason: reason ?? "Rejected by owner",
+          ...(callerId ? { callerId } : {}),
+        });
+        return ok(result);
+      } catch (err) {
+        return failFrom(err);
+      }
+    },
+  );
+
+  server.registerTool(
+    "review_transaction",
+    {
+      title: "Mark transaction for review",
+      description:
+        "Flag a pending Safe transaction for manual review. Does not execute or reject it. " +
+        "Omit txId to target the user's most recent in-review transaction (callerId required in that case).",
+      inputSchema: {
+        txId: TX_ID.optional(),
+        reason: z.string().max(500).optional(),
+        callerId: CALLER_ID.optional(),
+      },
+    },
+    async ({ txId, reason, callerId }) => {
+      if (!txId && !callerId) {
+        return fail("Provide txId, or callerId so the server can resolve the latest in-review transaction.");
+      }
+      try {
+        const id = txId ?? "latest";
+        const result = await callApi("PATCH", `/transactions/${encodeURIComponent(id)}`, {
+          action: "review",
+          reason: reason ?? "Flagged for manual review",
+          ...(callerId ? { callerId } : {}),
+        });
+        return ok(result);
+      } catch (err) {
+        return failFrom(err);
+      }
+    },
+  );
+
+  server.registerTool(
+    "check_transaction_status",
+    {
+      title: "Check transaction status",
+      description:
+        "Fetch the current status of a transaction: pending / in_review / executed (with txHash) / rejected, " +
+        "plus risk score, verdict and reasons. Use after an execute timeout, or whenever the user asks about a transaction.",
+      inputSchema: {
+        txId: TX_ID.describe("Transaction id, e.g. tx-cc34ee59"),
+      },
+    },
+    async ({ txId }) => {
+      try {
+        const tx = await fetchStatus(txId);
+        if (!tx) return fail(`Transaction ${txId} not found.`);
+        return ok(tx);
+      } catch (err) {
+        return failFrom(err);
+      }
+    },
+  );
+}

--- a/mcp/tsconfig.json
+++ b/mcp/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,25 @@ importers:
         specifier: ^5
         version: 5.9.3
 
+  mcp:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@3.25.76)
+      zod:
+        specifier: ^3.25.0
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^20
+        version: 20.19.37
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5
+        version: 5.9.3
+
   server:
     dependencies:
       '@pancakeswap/sdk':
@@ -493,6 +512,12 @@ packages:
     resolution: {integrity: sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==}
     peerDependencies:
       react: '>= 16 || ^19.0.0-rc'
+
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
 
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
@@ -961,6 +986,16 @@ packages:
 
   '@mintlify/validation@0.1.641':
     resolution: {integrity: sha512-BXKJOiU0vsmlKAKLCLbqKgK/mrO7vEJDqjCRpXvuG6sdo7IFEv4OZDkNRsFxAZWr4gDVCFs0D2HGlJOH2NNqCQ==}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@msgpack/msgpack@3.1.2':
     resolution: {integrity: sha512-JEW4DEtBzfe8HvUYecLU9e6+XJnKDlUAIve8FvPzF3Kzs6Xo/KuZkZJsDH0wJXl/qEZbeeE7edxDNY3kMs39hQ==}
@@ -3045,6 +3080,10 @@ packages:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -3422,6 +3461,10 @@ packages:
     resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
   borsh@0.7.0:
     resolution: {integrity: sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==}
 
@@ -3709,9 +3752,17 @@ packages:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
     engines: {node: '>= 0.6'}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
 
   convert-to-spaces@2.0.1:
     resolution: {integrity: sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==}
@@ -3725,6 +3776,10 @@ packages:
 
   cookie-signature@1.0.7:
     resolution: {integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
 
   cookie@0.4.2:
     resolution: {integrity: sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==}
@@ -4411,6 +4466,20 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
+  express-rate-limit@8.5.2:
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
   express@4.18.2:
     resolution: {integrity: sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==}
     engines: {node: '>= 0.10.0'}
@@ -4418,6 +4487,10 @@ packages:
   express@4.22.1:
     resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
     engines: {node: '>= 0.10.0'}
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -4543,6 +4616,10 @@ packages:
     resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
     engines: {node: '>= 0.8'}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
@@ -4612,6 +4689,10 @@ packages:
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   front-matter@4.0.2:
     resolution: {integrity: sha512-I8ZuJ/qG92NWX8i5x1Y8qyj3vizhXS31OxjKDu3LKP+7/qBgfIKValiZIEwoVoJKUHlhWtYrktkxV1XsX+pPlg==}
@@ -5009,6 +5090,10 @@ packages:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
     engines: {node: '>= 12'}
 
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
+
   ip-regex@4.3.0:
     resolution: {integrity: sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==}
     engines: {node: '>=8'}
@@ -5153,6 +5238,9 @@ packages:
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
@@ -5307,6 +5395,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -5623,11 +5714,19 @@ packages:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
   merge-descriptors@1.0.1:
     resolution: {integrity: sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==}
 
   merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -5759,9 +5858,17 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mime@1.6.0:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
@@ -5888,6 +5995,10 @@ packages:
 
   negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
   neotraverse@0.6.18:
@@ -6244,6 +6355,9 @@ packages:
   path-to-regexp@0.1.7:
     resolution: {integrity: sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==}
 
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
@@ -6320,6 +6434,10 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pm2-axon-rpc@0.7.1:
     resolution: {integrity: sha512-FbLvW60w+vEyvMjP/xom2UPhUN/2bVpdtLfKJeYM3gwzYhoTEEChCOICfFzxkxuoEleOlnpjie+n1nue91bDQw==}
@@ -6603,6 +6721,10 @@ packages:
     resolution: {integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==}
     engines: {node: '>= 0.8'}
 
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
+
   react-device-detect@2.2.3:
     resolution: {integrity: sha512-buYY3qrCnQVlIFHrC5UcUoAj7iANs/+srdkwsnNjI7anr3Tt7UY6MqNxtMLlr0tMBied0O49UZVK8XKs3ZIiPw==}
     peerDependencies:
@@ -6883,6 +7005,10 @@ packages:
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   rpc-websockets@9.3.6:
     resolution: {integrity: sha512-RzuOQDGd+EtR/cBYQAH/0jjaBzhyvXXGROhxigGJPf+q3XKyvtelZCucylzxiq5MaGlfBx1075djTsxFsFDgrA==}
 
@@ -6970,6 +7096,10 @@ packages:
     resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
     engines: {node: '>= 0.8.0'}
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
   serialize-error@13.0.1:
     resolution: {integrity: sha512-bBZaRwLH9PN5HbLCjPId4dP5bNGEtumcErgOX952IsvOhVPrm3/AeK1y0UHA/QaPG701eg0yEnOKsCOC6X/kaA==}
     engines: {node: '>=20'}
@@ -6981,6 +7111,10 @@ packages:
   serve-static@1.16.3:
     resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
     engines: {node: '>= 0.8.0'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
 
   serwist@9.5.7:
     resolution: {integrity: sha512-4R3kezBK0YAwkU6kIKbJc1I7QmbDV+wauV6Rf2+PdEHN5tBFK+3S92JPgj+XAa1ZCtg55qJGyyzAQ+d0G5AjDg==}
@@ -7504,6 +7638,10 @@ packages:
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
+
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
 
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
@@ -8074,6 +8212,11 @@ packages:
     peerDependencies:
       zod: ^3.20.0
 
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
   zod@3.21.4:
     resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
 
@@ -8533,6 +8676,10 @@ snapshots:
   '@heroicons/react@2.2.0(react@18.3.1)':
     dependencies:
       react: 18.3.1
+
+  '@hono/node-server@1.19.14(hono@4.12.9)':
+    dependencies:
+      hono: 4.12.9
 
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
@@ -9456,6 +9603,28 @@ snapshots:
       - react-dom
       - supports-color
       - typescript
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.9)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.9
+      jose: 6.2.2
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
 
   '@msgpack/msgpack@3.1.2': {}
 
@@ -13599,6 +13768,11 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn-jsx@5.3.2(acorn@8.11.2):
     dependencies:
       acorn: 8.11.2
@@ -13984,6 +14158,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.14.2
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   borsh@0.7.0:
     dependencies:
       bn.js: 5.2.3
@@ -14270,7 +14458,11 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  content-disposition@1.1.0: {}
+
   content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
 
   convert-to-spaces@2.0.1: {}
 
@@ -14279,6 +14471,8 @@ snapshots:
   cookie-signature@1.0.6: {}
 
   cookie-signature@1.0.7: {}
+
+  cookie-signature@1.2.2: {}
 
   cookie@0.4.2: {}
 
@@ -14849,7 +15043,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1)
@@ -14879,7 +15073,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -14894,7 +15088,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -15129,6 +15323,17 @@ snapshots:
 
   events@3.3.0: {}
 
+  eventsource-parser@3.1.0: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.0
+
+  express-rate-limit@8.5.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.2.0
+
   express@4.18.2:
     dependencies:
       accepts: 1.3.8
@@ -15197,6 +15402,39 @@ snapshots:
       statuses: 2.0.2
       type-is: 1.6.18
       utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.14.2
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
@@ -15332,6 +15570,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-up@4.1.0:
     dependencies:
       locate-path: 5.0.0
@@ -15396,6 +15645,8 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
 
   fresh@0.5.2: {}
+
+  fresh@2.0.0: {}
 
   front-matter@4.0.2:
     dependencies:
@@ -15966,6 +16217,8 @@ snapshots:
 
   ip-address@10.1.0: {}
 
+  ip-address@10.2.0: {}
+
   ip-regex@4.3.0: {}
 
   ipaddr.js@1.9.1: {}
@@ -16097,6 +16350,8 @@ snapshots:
   is-path-inside@3.0.3: {}
 
   is-plain-obj@4.1.0: {}
+
+  is-promise@4.0.0: {}
 
   is-regex@1.2.1:
     dependencies:
@@ -16280,6 +16535,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -16729,9 +16986,13 @@ snapshots:
 
   media-typer@0.3.0: {}
 
+  media-typer@1.1.0: {}
+
   merge-descriptors@1.0.1: {}
 
   merge-descriptors@1.0.3: {}
+
+  merge-descriptors@2.0.0: {}
 
   merge2@1.4.1: {}
 
@@ -17028,9 +17289,15 @@ snapshots:
 
   mime-db@1.52.0: {}
 
+  mime-db@1.54.0: {}
+
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   mime@1.6.0: {}
 
@@ -17146,6 +17413,8 @@ snapshots:
       - supports-color
 
   negotiator@0.6.3: {}
+
+  negotiator@1.0.0: {}
 
   neotraverse@0.6.18: {}
 
@@ -17644,6 +17913,8 @@ snapshots:
 
   path-to-regexp@0.1.7: {}
 
+  path-to-regexp@8.4.2: {}
+
   pend@1.2.0: {}
 
   performance-now@2.1.0:
@@ -17746,6 +18017,8 @@ snapshots:
       thread-stream: 0.15.2
 
   pirates@4.0.7: {}
+
+  pkce-challenge@5.0.1: {}
 
   pm2-axon-rpc@0.7.1:
     dependencies:
@@ -18083,6 +18356,13 @@ snapshots:
       bytes: 3.1.2
       http-errors: 2.0.1
       iconv-lite: 0.4.24
+      unpipe: 1.0.0
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
       unpipe: 1.0.0
 
   react-device-detect@2.2.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
@@ -18490,6 +18770,16 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   rpc-websockets@9.3.6:
     dependencies:
       '@swc/helpers': 0.5.19
@@ -18602,6 +18892,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   serialize-error@13.0.1:
     dependencies:
       non-error: 0.1.0
@@ -18622,6 +18928,15 @@ snapshots:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.19.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
     transitivePeerDependencies:
       - supports-color
 
@@ -19303,6 +19618,12 @@ snapshots:
     dependencies:
       media-typer: 0.3.0
       mime-types: 2.1.35
+
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -20125,6 +20446,10 @@ snapshots:
   zod-to-json-schema@3.20.4(zod@3.24.0):
     dependencies:
       zod: 3.24.0
+
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
 
   zod@3.21.4: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,4 @@ packages:
   - client
   - server
   - agent
+  - mcp


### PR DESCRIPTION
Implements phase 1 of #46. Follow-up transport work tracked in #47.

## Why
Three field incidents with the curl-based agent skill, all structural properties of "LLM composes shell commands":
1. A **reject command routed to `/execute`** — funds moved on a misread.
2. **Silent timeouts** — nanobot's 60s exec limit killed `/execute` mid-inclusion; the agent went quiet while the tx completed server-side.
3. **`AGENT_SECRET` leaked into Telegram** — the model read `.env` to "debug" a 401 and printed the bearer token.

Typed MCP tools eliminate all three classes: the model picks from a labeled tool list (no URL composition), inputs are zod-validated before any HTTP, and the secret lives in the MCP server's process env where the model cannot see it.

## Hard constraint honored
**Zero changes to existing endpoints.** `mcp/` is a pure client of the API as it exists today. The markdown skill's curls keep working in parallel; rollback = remove the `mcpServers` config block.

## What's in the package
New workspace package `mcp/` (`zhentan-mcp`), stdio transport, 8 tools:

| Tool | Wraps |
|---|---|
| `execute_transaction` | `POST /execute` — 150s budget; on timeout auto-polls `GET /transactions/:id` and never resubmits |
| `reject_transaction` / `review_transaction` | `PATCH /transactions/{id\|latest}` |
| `check_transaction_status` | `GET /transactions/:id` |
| `queue_request` / `list_requests` / `update_request_status` | `/requests` |
| `update_screening_settings` | `PATCH /status` |

`buildServer()` (src/server.ts) is transport-agnostic — streamable HTTP (#47) adds a branch in `index.ts` + auth middleware, zero tool changes. Legacy SSE intentionally skipped (deprecated by the MCP spec).

## Verification (all passing locally)
- `pnpm --filter zhentan-mcp build` — clean.
- JSON-RPC handshake over stdio → `initialize` + `tools/list` returns all 8 tools with schemas.
- Negative: `reject_transaction` with `{}` → friendly tool error before HTTP; with `txId:"DROP TABLE;--"` → schema rejection at the protocol layer.
- Live: `check_transaction_status` for a bogus id against the local server → clean "Transaction not found" through real auth.

## Rollout (after merge)
1. `pnpm install && pnpm --filter zhentan-mcp build`
2. Add the `tools.mcpServers.zhentan` block from `mcp/README.md` to `~/.nanobot/config.json` (**`toolTimeout: 200` required**), restart the gateway.
3. Field-test approve/reject/queue via Telegram.
4. **Phase 2 (separate PR):** slim `agent/SKILL.md` + `AGENTS.md` cheat-sheet to reference tool names instead of embedding curls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)