### PR TITLE
Commit Claude Design sync inputs (.design-sync)

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -1,0 +1,25 @@
+# Zhentan Design System — sync notes
+
+## Shape & pipeline
+- Repo is a **Next.js app**, not a packaged component library. No `dist/`, no Storybook.
+- Components are **pre-bundled** by `.ds-sync/prebuild.mjs` (esbuild) from raw `.tsx`:
+  entry `.design-sync/ds-entry.tsx` (re-exports only the scoped brand/UI set) →
+  `client/.ds-dist/ds.mjs`. The converter then runs with `--entry client/.ds-dist/ds.mjs`
+  (so `PKG_DIR` resolves to `client/`).
+- Prebuild MUST: jsx=automatic; alias react/react-dom/jsx-runtime → `.design-sync/shims/*.cjs`
+  (window.React) and bundle them in (NO external react — a stray CJS `require("react/jsx-runtime")`
+  becomes a "Dynamic require not supported" throw in the converter's IIFE → bundle fails to load →
+  every card shows "⚠ no PascalCase exports"); `define` + `banner` for `process` (next/link, pulled
+  in via BrandMark.tsx, references `process.env.__NEXT_*`).
+- CSS is a **statically compiled Tailwind v4** stylesheet: `client/.ds-styles.css` =
+  Google-Fonts @import + font var defs + `@tailwindcss/cli -i client/src/app/globals.css`.
+  Regenerate it on re-sync (utilities are otherwise generated on-demand and won't ship).
+- Fonts (Manrope/JetBrains) load via remote @import; `runtimeFontPrefixes` suppresses [FONT_MISSING].
+
+## Verification
+- User declined the playwright/chromium download. Render-checked instead with the system
+  `google-chrome --headless --dump-dom` against a local `python3 -m http.server -d ds-bundle`.
+
+## Re-sync risks
+- Rebuild order: `node .ds-sync/prebuild.mjs` → recompile `client/.ds-styles.css` → converter.
+- If the brand/UI component APIs change, update `dtsPropsFor` in config (hand-written, no dist .d.ts).

--- a/.design-sync/build-inputs.sh
+++ b/.design-sync/build-inputs.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Rebuilds the two converter inputs for the Zhentan design-system sync:
+#   1. client/.ds-dist/ds.mjs  — the pre-bundled scoped components (esbuild)
+#   2. client/.ds-styles.css   — statically compiled Tailwind v4 + fonts
+# Run from the repo root, after the converter deps are staged in .ds-sync/.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+NODE_PATH="$ROOT/.ds-sync/node_modules" node .design-sync/prebuild.mjs
+( cd client && "$ROOT/.ds-sync/node_modules/.bin/tailwindcss" -i src/app/globals.css -o "$ROOT/.design-sync/dist/tw.css" )
+{
+  echo "@import url('https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap');"
+  echo ":root{--font-manrope:'Manrope',ui-sans-serif,system-ui,sans-serif;--font-jetbrains:'JetBrains Mono',ui-monospace,'SF Mono',Menlo,monospace;}"
+  cat .design-sync/dist/tw.css
+} > client/.ds-styles.css
+echo "OK: client/.ds-dist/ds.mjs + client/.ds-styles.css"

--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -1,0 +1,49 @@
+{
+  "projectId": "ef5a195d-69a0-4a18-b060-cb4c8f672c24",
+  "shape": "package",
+  "pkg": "zhentan-client",
+  "globalName": "ZhentanUI",
+  "entry": "client/.ds-dist/ds.mjs",
+  "tsconfig": "tsconfig.json",
+  "cssEntry": ".ds-styles.css",
+  "readmeHeader": ".design-sync/conventions.md",
+  "runtimeFontPrefixes": [
+    "Manrope",
+    "JetBrains"
+  ],
+  "overrides": {
+    "Dialog": {
+      "cardMode": "single",
+      "viewport": "460x560"
+    }
+  },
+  "componentSrcMap": {
+    "Button": "src/components/ui/Button.tsx",
+    "Card": "src/components/ui/Card.tsx",
+    "Input": "src/components/ui/Input.tsx",
+    "Skeleton": "src/components/ui/Skeleton.tsx",
+    "Spinner": "src/components/ui/Spinner.tsx",
+    "Dialog": "src/components/ui/Dialog.tsx",
+    "StatusBadge": "src/components/StatusBadge.tsx",
+    "TwinTick": "src/components/BrandMark.tsx",
+    "BrandMarkSprite": "src/components/BrandMark.tsx",
+    "ExecutedAnimation": "src/components/animations/StatusAnimation.tsx",
+    "ReviewAnimation": "src/components/animations/StatusAnimation.tsx",
+    "RejectedAnimation": "src/components/animations/StatusAnimation.tsx"
+  },
+  "dtsPropsFor": {
+    "Button": "variant?: \"primary\" | \"secondary\" | \"ghost\"; loading?: boolean; children?: React.ReactNode; className?: string; disabled?: boolean; type?: \"button\" | \"submit\" | \"reset\"; onClick?: React.MouseEventHandler<HTMLButtonElement>;",
+    "Card": "children: React.ReactNode; className?: string;",
+    "Input": "label?: string; suffix?: React.ReactNode; className?: string; placeholder?: string; value?: string; defaultValue?: string; type?: string; disabled?: boolean; onChange?: React.ChangeEventHandler<HTMLInputElement>;",
+    "Skeleton": "className?: string;",
+    "Spinner": "className?: string; size?: number;",
+    "Dialog": "open: boolean; onClose: () => void; title?: string; children: React.ReactNode; className?: string; sheetOnMobile?: boolean;",
+    "StatusBadge": "status: \"pending\" | \"in_review\" | \"executed\" | \"rejected\";",
+    "TwinTick": "size?: number; halo?: string; className?: string; style?: React.CSSProperties;",
+    "BrandMarkSprite": "",
+    "ExecutedAnimation": "size?: number; loop?: boolean;",
+    "ReviewAnimation": "size?: number;",
+    "RejectedAnimation": "size?: number; loop?: boolean;"
+  },
+  "buildCmd": "bash .design-sync/build-inputs.sh"
+}

--- a/.design-sync/conventions.md
+++ b/.design-sync/conventions.md
@@ -1,0 +1,41 @@
+# Zhentan UI — how to build with it
+
+Zhentan is a **dark-canonical, gold + ink** design system. Styling is **Tailwind utility classes backed by CSS variables** — there are no CSS-module class maps and no style props; you compose layout with the utility classes below and the components carry their own look.
+
+## Setup (required)
+- **Wrap your app/screen root in `className="dark"`.** The components read ink + gold tokens from the `.dark` scope; the bare `:root` is a light parchment fallback, so without `dark` everything renders washed out. No React provider/context is needed.
+- Put `bg-background` + `text-foreground` on that root for the canonical ink canvas.
+- Render `<BrandMarkSprite />` once near the root if you use `<TwinTick />` — it injects the gold gradient the mark fills with.
+
+## The styling idiom (real class vocabulary)
+- **Surfaces:** `bg-background` (ink-900 canvas), `bg-card` (ink-800 panel), subtle overlays `bg-foreground/[0.04]` … `bg-foreground/8`.
+- **Text:** `text-foreground`, `text-muted-foreground` (secondary), `text-foreground/80` (dim).
+- **Brand accent — gold, use sparingly:** `text-gold`, `bg-gold`, `border-gold/25`, and `gradient-text` (gold gradient, for hero numbers/wordmark). Gold = brand only.
+- **Transaction state — NOT brand:** `text-safe`/`bg-safe` (green = pass/executed), `text-watch`/`bg-watch` (amber = review/pending), `text-danger`/`bg-danger` (red = block/rejected).
+- **Borders:** `border-border` (faint neutral hairline), `border-gold/25` for an accent edge.
+- **Radii:** `rounded-md` (14, buttons/inputs/cards) · `rounded-lg` (22, big panels) · `rounded-pill` (badges, dots, avatars).
+- **Type:** `font-sans` = Manrope (default UI), `font-mono` = JetBrains Mono (addresses, hashes, amounts, status labels — pair with `tabular-nums`). `eyebrow` = a mono, uppercase, letter-spaced section label.
+
+## Components
+- **Controls:** `Button` (`variant="primary|secondary|ghost"`, `loading`), `Input` (`label`, `suffix`), `Dialog` (`open`, `onClose`, `title`; bottom-sheet on mobile).
+- **Surfaces / feedback:** `Card`, `Skeleton`, `Spinner`, `StatusBadge` (`status="pending|in_review|executed|rejected"`).
+- **Brand / motion:** `TwinTick` (+ `BrandMarkSprite`), and the transaction-state animations `ExecutedAnimation`, `ReviewAnimation`, `RejectedAnimation` (`size`, `loop`).
+
+## Where the truth lives
+The bound stylesheet (`styles.css` and its `@import`s) defines every token and utility; read it before inventing class names. Per-component API + usage is in each `components/<group>/<Name>/<Name>.prompt.md`.
+
+## One idiomatic snippet
+```tsx
+import { Card, Button, StatusBadge } from "zhentan-client";
+
+<div className="dark bg-background p-6 font-sans">
+  <Card className="p-5">
+    <p className="eyebrow text-muted-foreground">Payment</p>
+    <p className="mt-2 text-3xl font-mono font-semibold gradient-text tabular-nums">$120.00</p>
+    <div className="mt-4 flex items-center justify-between gap-3">
+      <StatusBadge status="in_review" />
+      <Button variant="primary">Approve</Button>
+    </div>
+  </Card>
+</div>
+```

--- a/.design-sync/ds-entry.tsx
+++ b/.design-sync/ds-entry.tsx
@@ -1,0 +1,16 @@
+// Design-system entry: re-exports only the brand/UI components in scope.
+// BrandMark (the next/link wordmark wrapper) is intentionally omitted — the
+// brand mark ships as the pure-SVG TwinTick (+ BrandMarkSprite for its gradient).
+export { Button } from "@/components/ui/Button";
+export { Card } from "@/components/ui/Card";
+export { Input } from "@/components/ui/Input";
+export { Skeleton } from "@/components/ui/Skeleton";
+export { Spinner } from "@/components/ui/Spinner";
+export { Dialog } from "@/components/ui/Dialog";
+export { StatusBadge } from "@/components/StatusBadge";
+export { TwinTick, BrandMarkSprite } from "@/components/BrandMark";
+export {
+  ExecutedAnimation,
+  ReviewAnimation,
+  RejectedAnimation,
+} from "@/components/animations/StatusAnimation";

--- a/.design-sync/prebuild.mjs
+++ b/.design-sync/prebuild.mjs
@@ -1,0 +1,38 @@
+// Pre-bundle the scoped components from raw .tsx with JSX=automatic and the
+// @/ path alias. React / react-dom / jsx-runtime are aliased to tiny
+// window.React shims and bundled in — so the output has ZERO external imports
+// (no bare `react/jsx-runtime` import or require for the converter's IIFE pass
+// to choke on). The converter then just wraps this plain JS into the
+// window.ZhentanUI IIFE.
+import { build } from "esbuild";
+import { resolve } from "node:path";
+
+const CLIENT = resolve("client");
+const shim = (p) => resolve(".design-sync/shims", p);
+
+await build({
+  entryPoints: [resolve(".design-sync/ds-entry.tsx")],
+  bundle: true,
+  format: "esm",
+  platform: "browser",
+  target: "es2020",
+  outfile: resolve("client/.ds-dist/ds.mjs"),
+  alias: {
+    react: shim("react.cjs"),
+    "react/jsx-runtime": shim("jsx-runtime.cjs"),
+    "react/jsx-dev-runtime": shim("jsx-runtime.cjs"),
+    "react-dom": shim("react-dom.cjs"),
+    "react-dom/client": shim("react-dom.cjs"),
+  },
+  jsx: "automatic",
+  jsxImportSource: "react",
+  define: { "process.env.NODE_ENV": '"development"' },
+  banner: { js: "var process=(typeof globalThis!=='undefined'&&globalThis.process)||{env:{NODE_ENV:'development'}};" },
+  loader: { ".svg": "dataurl", ".png": "dataurl" },
+  absWorkingDir: CLIENT,
+  tsconfigRaw: JSON.stringify({
+    compilerOptions: { jsx: "react-jsx", baseUrl: ".", paths: { "@/*": ["./src/*"] } },
+  }),
+  logLevel: "info",
+});
+console.log("OK -> client/.ds-dist/ds.mjs");

--- a/.design-sync/previews/BrandMarkSprite.tsx
+++ b/.design-sync/previews/BrandMarkSprite.tsx
@@ -1,0 +1,28 @@
+import { BrandMarkSprite, TwinTick } from "zhentan-client";
+
+// BrandMarkSprite renders no visible UI — it injects the shared gold gradient
+// (#ztgb) that every TwinTick fills with. Render it once near the document root.
+function Frame({ children }: { children: React.ReactNode }) {
+  if (typeof document !== "undefined") {
+    document.documentElement.classList.add("dark");
+    document.body.style.background = "#0a0d0e";
+    document.body.style.margin = "0";
+  }
+  return (
+    <div style={{ background: "#0a0d0e", padding: 32, fontFamily: "var(--font-manrope)", color: "var(--ink-0)" }}>
+      {children}
+    </div>
+  );
+}
+
+export function GradientSource() {
+  return (
+    <Frame>
+      <BrandMarkSprite />
+      <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+        <p className="eyebrow text-muted-foreground">Renders no UI · powers the gold gradient</p>
+        <TwinTick size={48} halo="#0a0d0e" />
+      </div>
+    </Frame>
+  );
+}

--- a/.design-sync/previews/Button.tsx
+++ b/.design-sync/previews/Button.tsx
@@ -1,0 +1,45 @@
+import { Button } from "zhentan-client";
+
+function Frame({ children, pad = 28 }: { children: React.ReactNode; pad?: number }) {
+  if (typeof document !== "undefined") {
+    document.documentElement.classList.add("dark");
+    document.body.style.background = "#0a0d0e";
+    document.body.style.margin = "0";
+  }
+  return (
+    <div style={{ background: "#0a0d0e", padding: pad, fontFamily: "var(--font-manrope)", color: "var(--ink-0)" }}>
+      {children}
+    </div>
+  );
+}
+
+export function Variants() {
+  return (
+    <Frame>
+      <div style={{ display: "flex", gap: 12, flexWrap: "wrap", alignItems: "center" }}>
+        <Button variant="primary">Send</Button>
+        <Button variant="secondary">Receive</Button>
+        <Button variant="ghost">Cancel</Button>
+      </div>
+    </Frame>
+  );
+}
+
+export function Loading() {
+  return (
+    <Frame>
+      <Button variant="primary" loading>Confirming…</Button>
+    </Frame>
+  );
+}
+
+export function Disabled() {
+  return (
+    <Frame>
+      <div style={{ display: "flex", gap: 12 }}>
+        <Button variant="primary" disabled>Unavailable</Button>
+        <Button variant="secondary" disabled>Disabled</Button>
+      </div>
+    </Frame>
+  );
+}

--- a/.design-sync/previews/Card.tsx
+++ b/.design-sync/previews/Card.tsx
@@ -1,0 +1,39 @@
+import { Card } from "zhentan-client";
+
+function Frame({ children, pad = 28 }: { children: React.ReactNode; pad?: number }) {
+  if (typeof document !== "undefined") {
+    document.documentElement.classList.add("dark");
+    document.body.style.background = "#0a0d0e";
+    document.body.style.margin = "0";
+  }
+  return (
+    <div style={{ background: "#0a0d0e", padding: pad, fontFamily: "var(--font-manrope)", color: "var(--ink-0)" }}>
+      {children}
+    </div>
+  );
+}
+
+export function BalanceCard() {
+  return (
+    <Frame>
+      <Card className="p-5" >
+        <p className="eyebrow text-muted-foreground">Portfolio</p>
+        <p className="mt-2 text-3xl font-mono font-semibold gradient-text tracking-tight tabular-nums">$12,480.55</p>
+        <p className="mt-1 text-xs text-muted-foreground">Across 4 assets on BNB Chain</p>
+      </Card>
+    </Frame>
+  );
+}
+
+export function Plain() {
+  return (
+    <Frame>
+      <Card className="p-5">
+        <h3 className="text-sm font-semibold text-foreground">Screening active</h3>
+        <p className="mt-1 text-xs text-muted-foreground">
+          The agent reviews each signature against your patterns before co-signing.
+        </p>
+      </Card>
+    </Frame>
+  );
+}

--- a/.design-sync/previews/Dialog.tsx
+++ b/.design-sync/previews/Dialog.tsx
@@ -1,0 +1,29 @@
+import { Dialog, Button } from "zhentan-client";
+
+// Dialog portals into document.body, so push the dark scope to <html> (not just
+// a wrapper) — otherwise the portaled panel renders with light tokens.
+function ensureDark() {
+  if (typeof document !== "undefined") {
+    document.documentElement.classList.add("dark");
+    document.body.style.background = "#0a0d0e";
+    document.body.style.margin = "0";
+  }
+}
+
+export function SendDialog() {
+  ensureDark();
+  return (
+    <Dialog open onClose={() => {}} title="Send crypto">
+      <div className="space-y-4" style={{ fontFamily: "var(--font-manrope)" }}>
+        <p className="text-sm text-muted-foreground">
+          Confirm this transfer. The agent screens it before co-signing.
+        </p>
+        <div className="flex items-center justify-between rounded-md bg-foreground/6 p-4">
+          <span className="text-base font-semibold text-foreground">120.00 USDC</span>
+          <span className="font-mono text-xs text-muted-foreground">to 0x9f…3a21</span>
+        </div>
+        <Button variant="primary" className="w-full">Confirm</Button>
+      </div>
+    </Dialog>
+  );
+}

--- a/.design-sync/previews/ExecutedAnimation.tsx
+++ b/.design-sync/previews/ExecutedAnimation.tsx
@@ -1,0 +1,23 @@
+import { ExecutedAnimation } from "zhentan-client";
+
+function Frame({ children }: { children: React.ReactNode }) {
+  if (typeof document !== "undefined") {
+    document.documentElement.classList.add("dark");
+    document.body.style.background = "#0a0d0e";
+    document.body.style.margin = "0";
+  }
+  return (
+    <div style={{ background: "#0a0d0e", padding: 32, display: "flex", flexDirection: "column", alignItems: "center", gap: 14, fontFamily: "var(--font-manrope)", color: "var(--ink-0)" }}>
+      {children}
+    </div>
+  );
+}
+
+export function Executed() {
+  return (
+    <Frame>
+      <ExecutedAnimation size={96} loop />
+      <span className="text-sm font-semibold text-safe">Executed</span>
+    </Frame>
+  );
+}

--- a/.design-sync/previews/Input.tsx
+++ b/.design-sync/previews/Input.tsx
@@ -1,0 +1,38 @@
+import { Input } from "zhentan-client";
+
+function Frame({ children }: { children: React.ReactNode }) {
+  if (typeof document !== "undefined") {
+    document.documentElement.classList.add("dark");
+    document.body.style.background = "#0a0d0e";
+    document.body.style.margin = "0";
+  }
+  return (
+    <div style={{ background: "#0a0d0e", padding: 28, fontFamily: "var(--font-manrope)", color: "var(--ink-0)", maxWidth: 360 }}>
+      {children}
+    </div>
+  );
+}
+
+export function WithLabel() {
+  return (
+    <Frame>
+      <Input label="Recipient" placeholder="0x… or name.bnb" />
+    </Frame>
+  );
+}
+
+export function WithSuffix() {
+  return (
+    <Frame>
+      <Input label="Amount" placeholder="0.00" suffix={<span className="font-mono">USDC</span>} />
+    </Frame>
+  );
+}
+
+export function Plain() {
+  return (
+    <Frame>
+      <Input placeholder="Search assets" />
+    </Frame>
+  );
+}

--- a/.design-sync/previews/RejectedAnimation.tsx
+++ b/.design-sync/previews/RejectedAnimation.tsx
@@ -1,0 +1,23 @@
+import { RejectedAnimation } from "zhentan-client";
+
+function Frame({ children }: { children: React.ReactNode }) {
+  if (typeof document !== "undefined") {
+    document.documentElement.classList.add("dark");
+    document.body.style.background = "#0a0d0e";
+    document.body.style.margin = "0";
+  }
+  return (
+    <div style={{ background: "#0a0d0e", padding: 32, display: "flex", flexDirection: "column", alignItems: "center", gap: 14, fontFamily: "var(--font-manrope)", color: "var(--ink-0)" }}>
+      {children}
+    </div>
+  );
+}
+
+export function Rejected() {
+  return (
+    <Frame>
+      <RejectedAnimation size={96} loop />
+      <span className="text-sm font-semibold text-danger">Rejected</span>
+    </Frame>
+  );
+}

--- a/.design-sync/previews/ReviewAnimation.tsx
+++ b/.design-sync/previews/ReviewAnimation.tsx
@@ -1,0 +1,23 @@
+import { ReviewAnimation } from "zhentan-client";
+
+function Frame({ children }: { children: React.ReactNode }) {
+  if (typeof document !== "undefined") {
+    document.documentElement.classList.add("dark");
+    document.body.style.background = "#0a0d0e";
+    document.body.style.margin = "0";
+  }
+  return (
+    <div style={{ background: "#0a0d0e", padding: 32, display: "flex", flexDirection: "column", alignItems: "center", gap: 14, fontFamily: "var(--font-manrope)", color: "var(--ink-0)" }}>
+      {children}
+    </div>
+  );
+}
+
+export function InReview() {
+  return (
+    <Frame>
+      <ReviewAnimation size={96} />
+      <span className="text-sm font-semibold text-watch">In review</span>
+    </Frame>
+  );
+}

--- a/.design-sync/previews/Skeleton.tsx
+++ b/.design-sync/previews/Skeleton.tsx
@@ -1,0 +1,41 @@
+import { Skeleton } from "zhentan-client";
+
+function Frame({ children }: { children: React.ReactNode }) {
+  if (typeof document !== "undefined") {
+    document.documentElement.classList.add("dark");
+    document.body.style.background = "#0a0d0e";
+    document.body.style.margin = "0";
+  }
+  return (
+    <div style={{ background: "#0a0d0e", padding: 28, fontFamily: "var(--font-manrope)", color: "var(--ink-0)", maxWidth: 360 }}>
+      {children}
+    </div>
+  );
+}
+
+export function Lines() {
+  return (
+    <Frame>
+      <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+        <Skeleton className="h-5 w-40" />
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-2/3" />
+      </div>
+    </Frame>
+  );
+}
+
+export function TokenRow() {
+  return (
+    <Frame>
+      <div style={{ display: "flex", alignItems: "center", gap: 14 }}>
+        <Skeleton className="h-10 w-10 rounded-pill" />
+        <div style={{ display: "flex", flexDirection: "column", gap: 8, flex: 1 }}>
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-3 w-32" />
+        </div>
+        <Skeleton className="h-5 w-16" />
+      </div>
+    </Frame>
+  );
+}

--- a/.design-sync/previews/Spinner.tsx
+++ b/.design-sync/previews/Spinner.tsx
@@ -1,0 +1,34 @@
+import { Spinner } from "zhentan-client";
+
+function Frame({ children }: { children: React.ReactNode }) {
+  if (typeof document !== "undefined") {
+    document.documentElement.classList.add("dark");
+    document.body.style.background = "#0a0d0e";
+    document.body.style.margin = "0";
+  }
+  return (
+    <div style={{ background: "#0a0d0e", padding: 28, fontFamily: "var(--font-manrope)", color: "var(--ink-0)" }}>
+      {children}
+    </div>
+  );
+}
+
+export function Default() {
+  return (
+    <Frame>
+      <Spinner />
+    </Frame>
+  );
+}
+
+export function Sizes() {
+  return (
+    <Frame>
+      <div style={{ display: "flex", gap: 20, alignItems: "center" }}>
+        <Spinner size={16} />
+        <Spinner size={24} />
+        <Spinner size={40} />
+      </div>
+    </Frame>
+  );
+}

--- a/.design-sync/previews/StatusBadge.tsx
+++ b/.design-sync/previews/StatusBadge.tsx
@@ -1,0 +1,27 @@
+import { StatusBadge } from "zhentan-client";
+
+function Frame({ children }: { children: React.ReactNode }) {
+  if (typeof document !== "undefined") {
+    document.documentElement.classList.add("dark");
+    document.body.style.background = "#0a0d0e";
+    document.body.style.margin = "0";
+  }
+  return (
+    <div style={{ background: "#0a0d0e", padding: 28, fontFamily: "var(--font-manrope)", color: "var(--ink-0)" }}>
+      {children}
+    </div>
+  );
+}
+
+export function AllStates() {
+  return (
+    <Frame>
+      <div style={{ display: "flex", gap: 10, flexWrap: "wrap", alignItems: "center" }}>
+        <StatusBadge status="pending" />
+        <StatusBadge status="in_review" />
+        <StatusBadge status="executed" />
+        <StatusBadge status="rejected" />
+      </div>
+    </Frame>
+  );
+}

--- a/.design-sync/previews/TwinTick.tsx
+++ b/.design-sync/previews/TwinTick.tsx
@@ -1,0 +1,39 @@
+import { TwinTick, BrandMarkSprite } from "zhentan-client";
+
+function Frame({ children }: { children: React.ReactNode }) {
+  if (typeof document !== "undefined") {
+    document.documentElement.classList.add("dark");
+    document.body.style.background = "#0a0d0e";
+    document.body.style.margin = "0";
+  }
+  return (
+    <div style={{ background: "#0a0d0e", padding: 32, fontFamily: "var(--font-manrope)", color: "var(--ink-0)" }}>
+      {/* sprite defines the gold gradient the mark fills with */}
+      <BrandMarkSprite />
+      {children}
+    </div>
+  );
+}
+
+export function Mark() {
+  return (
+    <Frame>
+      <div style={{ display: "flex", alignItems: "center", gap: 14 }}>
+        <TwinTick size={56} halo="#0a0d0e" />
+        <span style={{ fontWeight: 700, fontSize: 24, letterSpacing: "-0.01em" }}>Zhentan</span>
+      </div>
+    </Frame>
+  );
+}
+
+export function Sizes() {
+  return (
+    <Frame>
+      <div style={{ display: "flex", alignItems: "flex-end", gap: 18 }}>
+        <TwinTick size={24} halo="#0a0d0e" />
+        <TwinTick size={40} halo="#0a0d0e" />
+        <TwinTick size={64} halo="#0a0d0e" />
+      </div>
+    </Frame>
+  );
+}

--- a/.design-sync/shims/jsx-runtime.cjs
+++ b/.design-sync/shims/jsx-runtime.cjs
@@ -1,0 +1,5 @@
+var R = (typeof window !== "undefined" && window.React) || {};
+function jsx(type, props, key) {
+  return R.createElement(type, key === void 0 ? props : Object.assign({ key: key }, props));
+}
+module.exports = { jsx: jsx, jsxs: jsx, jsxDEV: jsx, Fragment: R.Fragment };

--- a/.design-sync/shims/react-dom.cjs
+++ b/.design-sync/shims/react-dom.cjs
@@ -1,0 +1,1 @@
+module.exports = (typeof window !== "undefined" && window.ReactDOM) || {};

--- a/.design-sync/shims/react.cjs
+++ b/.design-sync/shims/react.cjs
@@ -1,0 +1,2 @@
+// Resolves react to the page's window.React (the vendored copy the cards load).
+module.exports = (typeof window !== "undefined" && window.React) || {};

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,12 @@ client/public/sw.js.map
 client/public/swe-worker-*.js
 client/public/workbox-*.js
 client/public/workbox-*.js.map
+
+.ds-sync/
+ds-bundle/
+.design-sync/.cache/
+.design-sync/learnings/
+.design-sync/node_modules
+client/.ds-styles.css
+.design-sync/dist/
+client/.ds-dist/


### PR DESCRIPTION
Commits the durable inputs used to sync the Zhentan brand/UI component set to **claude.ai/design** (project *Zhentan Design System*). These are **sync inputs, not app code** — committing them means future re-syncs reuse the authored previews, conventions header, and build setup instead of rediscovering them.

## What's here
- **`config.json`** — package shape, scoped `componentSrcMap` (12 components), hand-written `dtsPropsFor`, compiled `cssEntry`, `readmeHeader`, and `buildCmd`.
- **`conventions.md`** — the header inlined into the design agent's prompt: dark scope, the gold+ink Tailwind class vocabulary, and the gold=brand / green-amber-red=state rule.
- **`previews/`** — authored preview compositions for all 12 components (Button, Card, Input, Skeleton, Spinner, Dialog, StatusBadge, TwinTick, BrandMarkSprite, Executed/Review/Rejected animations).
- **`shims/`, `ds-entry.tsx`, `prebuild.mjs`, `build-inputs.sh`** — the input build. Since this is a Next.js app (no packaged lib), components are pre-bundled with esbuild (react aliased to `window.React`, `process` shimmed for `next/link`) and Tailwind v4 is compiled to a static stylesheet.
- **`NOTES.md`** — shape/pipeline, the bundle-load fixes, and re-sync risks.
- **`.gitignore`** — ignores generated outputs (`ds-bundle/`, `client/.ds-dist`, compiled css, staged scripts).

## Not included
Generated/regenerated artifacts (the compiled bundle, vendored React, screenshots, caches) stay gitignored. `config.json` carries the Claude Design `projectId` (a UUID, not a secret) so re-syncs find the project.

Separate from the brand-redesign UI work in #50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)