### PR TITLE
Brand redesign: live data updates, request UX parity, and request risk scoring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What is Zhentan
 
-Zhentan is a personalized wallet assistant with AI-powered transaction screening. It uses a Safe multisig (2-of-2) on BNB Chain where the user is one signer and an OpenClaw AI agent is the other. The agent analyzes transactions against learned behavioral patterns and either auto-approves, sends for review (via Telegram/WhatsApp), or blocks suspicious activity.
+Zhentan is a personalized wallet assistant with AI-powered transaction screening. It uses a Safe multisig (2-of-2) on BNB Chain where the user is one signer and an NanoBot/Hermes AI agent is the other. The agent analyzes transactions against learned behavioral patterns and either auto-approves, sends for review (via Telegram/WhatsApp), or blocks suspicious activity.
 
 ## Architecture
 
@@ -12,7 +12,7 @@ Three components work together:
 
 - **`client/`** — Next.js 14 frontend. Privy authentication (Google OAuth + embedded wallets), Safe smart account creation, transaction proposal (owner signs 1 of 2). Has its own API routes for local dev; in production calls the Express server.
 - **`server/`** — Express API for queue management and execution. Required when client deploys to read-only filesystems (Vercel). Routes: `/queue`, `/execute`, `/transactions`, `/invoices`, `/health`. Reads/writes JSON queue files.
-- **`agent/`** — OpenClaw skill pack (`zhentan-agent`). Agent runs on a cron (every 10s), picks up pending transactions, scores risk, and decides: APPROVE (risk < 40), REVIEW (40-70), or BLOCK (> 70). Skills: `check-pending`, `analyze-risk`, `sign-and-execute`, `mark-review`, `reject-tx`, `record-pattern`, `toggle-screening`, `queue-invoice`, `get-status`.
+- **`agent/`** — NanoBot/Hermes skill pack (`zhentan-agent`). Agent runs on a cron (every 10s), picks up pending transactions, scores risk, and decides: APPROVE (risk < 40), REVIEW (40-70), or BLOCK (> 70). Skills: `check-pending`, `analyze-risk`, `sign-and-execute`, `mark-review`, `reject-tx`, `record-pattern`, `toggle-screening`, `queue-invoice`, `get-status`.
 
 Transaction flow: User signs in client → queued to `pending-queue.json` → agent analyzes → agent co-signs (2 of 2) → submitted to Pimlico bundler → gasless execution on BNB Chain via ERC-4337.
 
@@ -60,7 +60,7 @@ pnpm agent-sign      # agent-sign.js — agent co-signs and executes
 - **Auth**: Privy (embedded wallets + Google OAuth)
 - **Blockchain libs**: viem, permissionless.js
 - **Backend**: Express, tsx (dev), PM2 (production)
-- **AI Agent**: OpenClaw with Qwen3-235B / Claude Sonnet 4.5 via OpenRouter
+- **AI Agent**: NanoBot/Hermes with Qwen3-235B / Claude Sonnet 4.5 via OpenRouter
 
 ## Key Configuration
 
@@ -85,5 +85,5 @@ See `scripts/.env.example` and `server/.env.example` for templates.
 ## Known Issues
 
 - **USDC decimals discrepancy**: `client/src/lib/constants.ts` declares `USDC_DECIMALS = 18`, but scripts use 6 decimals. BSC mainnet USDC uses 18 decimals; other chains may differ.
-- **Queue file paths**: Scripts default to `~/.openclaw/workspace/skills/zhentan/pending-queue.json`. Override with `QUEUE_PATH` env var.
-- **Live demo** at zhentan.me runs without the OpenClaw agent (no screening). Full AI screening requires local setup with agent.
+- **Queue file paths**: Scripts default to `~/.nanobot/workspace/skills/zhentan/pending-queue.json`. Override with `QUEUE_PATH` env var.
+- **Live demo** at zhentan.me runs without the NanoBot/Hermes agent (no screening). Full AI screening requires local setup with agent.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Your personalized onchain detective agent and assistant that learns and guards y
 
 - Node.js 18+
 - pnpm 10+
-- OpenClaw CLI
+- NanoBot/Hermes CLI
 
 ## Setup
 
@@ -52,7 +52,7 @@ pnpm dev:docs        # http://localhost:3002
 ```
 client/    Next.js 14 app
 server/    Express API
-agent/     OpenClaw skill pack
+agent/     NanoBot/Hermes skill pack
 scripts/   CLI tools
 docs/      Mintlify docs
 ```
@@ -60,7 +60,7 @@ docs/      Mintlify docs
 ## Agent
 
 ```bash
-mkdir -p ~/.openclaw/workspace/skills
-ln -sf "$(pwd)/agent" ~/.openclaw/workspace/skills/zhentan
-openclaw gateway restart
+mkdir -p ~/.nanobot/workspace/skills
+ln -sf "$(pwd)/agent" ~/.nanobot/workspace/skills/zhentan
+nanobot gateway restart
 ```

--- a/agent/README.md
+++ b/agent/README.md
@@ -1,6 +1,6 @@
 # Zhentan Skills
 
-OpenClaw skill pack for **Zhentan** — a treasury monitor agent that watches pending multisig transactions, analyzes risk, auto-signs safe ones, flags risky ones for review, and handles invoices.
+NanoBot/Hermes skill pack for **Zhentan** — a treasury monitor agent that watches pending multisig transactions, analyzes risk, auto-signs safe ones, flags risky ones for review, and handles invoices.
 
 ---
 
@@ -8,57 +8,57 @@ OpenClaw skill pack for **Zhentan** — a treasury monitor agent that watches pe
 
 | Requirement | Details |
 |---|---|
-| **OpenClaw** | Installed and configured — [OpenClaw setup guide](https://github.com/anthropics/openclaw) |
+| **NanoBot/Hermes** | Installed and configured — [NanoBot/Hermes setup guide](https://nanobot.wiki/) |
 | **Node.js** | v18 or higher |
-| **Environment variables** | `AGENT_SECRET` (required — authenticates skill calls to the server). `ZHENTAN_API_URL` (optional — server base URL; defaults to `https://api.zhentan.me`, set `http://localhost:3001` for local dev). Plus server config per the [Zhentan server](../server/README.md): `AGENT_PRIVATE_KEY`, `PIMLICO_API_KEY`, etc. All must be set in the environment where OpenClaw runs. |
+| **Environment variables** | `AGENT_SECRET` (required — authenticates skill calls to the server). `ZHENTAN_API_URL` (optional — server base URL; defaults to `https://api.zhentan.me`, set `http://localhost:3001` for local dev). Plus server config per the [Zhentan server](../server/README.md): `AGENT_PRIVATE_KEY`, `PIMLICO_API_KEY`, etc. All must be set in the environment where NanoBot/Hermes runs. |
 
 ---
 
 ## Quick Start
 
-### 1. Link the skill into OpenClaw
+### 1. Link the skill into NanoBot/Hermes
 
 From the Zhentan repo root:
 
 ```bash
-mkdir -p ~/.openclaw/workspace/skills
-ln -sf "$(pwd)/zhentan-skills" ~/.openclaw/workspace/skills/zhentan
+mkdir -p ~/.nanobot/workspace/skills
+ln -sf "$(pwd)/zhentan-skills" ~/.nanobot/workspace/skills/zhentan
 ```
 
-### 2. Restart OpenClaw
+### 2. Restart NanoBot/Hermes
 
 ```bash
-openclaw gateway restart
+nanobot gateway restart
 ```
 
 Confirm that the zhentan skill is detected.
 
 ```bash
-openclaw skills check
+nanobot skills check
 ```
 
-OpenClaw will load the skill from `SKILL.md` and begin responding to commands via Telegram.
+NanoBot/Hermes will load the skill from `SKILL.md` and begin responding to commands via Telegram.
 
 ---
 
 ## Alternative Skill Install Methods
 
-### Copy into OpenClaw's skill directory
+### Copy into NanoBot/Hermes's skill directory
 
 ```bash
-mkdir -p ~/.openclaw/skills
-cp -r /path/to/zhentan/zhentan-skills ~/.openclaw/skills/zhentan
+mkdir -p ~/.nanobot/skills
+cp -r /path/to/zhentan/zhentan-skills ~/.nanobot/skills/zhentan
 ```
 
 > If you copy, remember to re-copy after editing the skill source.
 
 ### Project-local skills
 
-Create a symlink at the repo root so OpenClaw discovers it locally:
+Create a symlink at the repo root so NanoBot/Hermes discovers it locally:
 
 ```bash
-mkdir -p .openclaw/skills
-ln -sf "$(pwd)/zhentan-skills" .openclaw/skills/zhentan
+mkdir -p .nanobot/skills
+ln -sf "$(pwd)/zhentan-skills" .nanobot/skills/zhentan
 ```
 
 

--- a/agent/SKILL.md
+++ b/agent/SKILL.md
@@ -82,9 +82,15 @@ owner to approve** — queueing never moves funds.
    - transfers: `description` — the instruction in one sentence
    - invoices: `invoiceNumber`, `issueDate`, `dueDate`, `billedFrom`/`billedTo`,
      `services` `[{description, qty, rate, total}]`
-   - `riskScore` (0–100, your assessment: known vs unknown recipient via
-     `get_screening_status` patterns, amount vs history, urgency) and `riskNotes`
-3. `queue_request(...)` → confirm: "Request for [amount] [token] queued — approve it
+3. **Always score the request before queueing — `riskScore` (0–100) and `riskNotes`
+   are required on every `queue_request`, for both transfers and invoices.** Unlike
+   live transactions (which the server scores automatically), a request is scored by
+   **you**: call `get_screening_status(safe, includePatterns: true)` and apply the
+   **Risk scoring reference** below — unknown vs known recipient, amount vs the
+   recipient's history, hour-of-day, and any single-tx / daily / custom limits. Set
+   `riskNotes` to one line justifying the score (e.g. "Unknown recipient, amount 4×
+   their average"). Never queue a request without a score.
+4. `queue_request(...)` → confirm: "Request for [amount] [token] queued — approve it
    in your Zhentan dashboard."
 
 ## Risk scoring reference

--- a/agent/package.json
+++ b/agent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zhentan-agent",
   "version": "0.1.0",
-  "description": "OpenClaw agent skills for Zhentan transaction screening",
+  "description": "NanoBot/Hermes agent skills for Zhentan transaction screening",
   "type": "module",
   "scripts": {
     "sign-and-execute": "node sign-and-execute.js"

--- a/bsc.address
+++ b/bsc.address
@@ -29,5 +29,5 @@
   ],
   "frontendUrl": "https://zhentan.me",
   "backendApi": "https://api.zhentan.me",
-  "notes": "User Safe smart account addresses are computed on first login but deployed on first transaction. Each is a Safe 1.4.1 proxy with the user's Privy embedded wallet as owner (signer 1) and the Zhentan agent as co-signer (signer 2), threshold 2-of-2. To find a specific user's Safe address, check the client dashboard or query Safe Proxy Factory events on BscScan. The live deployment at zhentan.me runs without the OpenClaw agent; full AI screening requires running client + server + OpenClaw skills locally."
+  "notes": "User Safe smart account addresses are computed on first login but deployed on first transaction. Each is a Safe 1.4.1 proxy with the user's Privy embedded wallet as owner (signer 1) and the Zhentan agent as co-signer (signer 2), threshold 2-of-2. To find a specific user's Safe address, check the client dashboard or query Safe Proxy Factory events on BscScan. The live deployment at zhentan.me runs without the NanoBot/Hermes agent; full AI screening requires running client + server + NanoBot/Hermes skills locally."
 }

--- a/client/.env.example
+++ b/client/.env.example
@@ -3,10 +3,10 @@
 # Get your Pimlico bundler and paymaster API key from https://dashboard.pimlico.io
 NEXT_PUBLIC_PIMLICO_API_KEY=
 
-# Use your own OpenClaw agent address or use our public agent address: https://api.zhentan.me.i.e: 0xcA1d93272E4fb317744cA4925bf0D8E9AA5Fb733
+# Use your own NanoBot/Hermes agent address or use our public agent address: https://api.zhentan.me.i.e: 0xcA1d93272E4fb317744cA4925bf0D8E9AA5Fb733
 NEXT_PUBLIC_AGENT_ADDRESS=0xcA1d93272E4fb317744cA4925bf0D8E9AA5Fb733
 
-# Run local backend with local OpenClaw agent or use our remote backend with public OpenClaw agent: https://api.zhentan.me
+# Run local backend with local NanoBot/Hermes agent or use our remote backend with public NanoBot/Hermes agent: https://api.zhentan.me
 NEXT_PUBLIC_BACKEND_URL=http://localhost:3001
 
 # Privy (Google sign-in + embedded wallet) Get your app ID from https://dashboard.privy.io and enable Google sign-in in the dashboard.

--- a/client/README.md
+++ b/client/README.md
@@ -37,7 +37,7 @@ Next.js frontend for the Zhentan wallet: dashboard, send/receive USDC, activity,
    Edit `.env.local` and set at least:
 
    - `NEXT_PUBLIC_PIMLICO_API_KEY` (Pimlico bundler/paymaster API key)
-   - `NEXT_PUBLIC_AGENT_ADDRESS` (OpenClaw agent wallet address)
+   - `NEXT_PUBLIC_AGENT_ADDRESS` (NanoBot/Hermes agent wallet address)
    - `NEXT_PUBLIC_BACKEND_URL` (local: `http://localhost:3001` or your deployed API URL)
    - `NEXT_PUBLIC_PRIVY_APP_ID` (Privy app ID)
    - `NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID` (WalletConnect project ID, for mobile app support)

--- a/client/public/SKILL.md
+++ b/client/public/SKILL.md
@@ -2,7 +2,7 @@
 name: zhentan
 description: Zhentan is your personal onchain security agent and co-signer. It monitors pending multisig transactions, screens them against behavioral patterns and security risk data, and auto-signs safe ones — blocking or flagging suspicious activity before it executes. Use when the user wants to review pending transactions, approve or reject a transaction, check risk scores, toggle screening mode, view transaction history, or queue and process an invoice.
 metadata:
-  openclaw:
+  nanobot:
     requires:
       bins: ["curl"]
       env: ["AGENT_SECRET"]

--- a/client/src/app/(app)/home/page.tsx
+++ b/client/src/app/(app)/home/page.tsx
@@ -17,6 +17,7 @@ import { ThemeLoader } from "@/components/ThemeLoader";
 import { ClaimBanner } from "@/components/ClaimBanner";
 import { useAuth } from "@/app/context/AuthContext";
 import { useApiClient } from "@/lib/api/client";
+import { useAutoRefresh } from "@/hooks/useAutoRefresh";
 import { padTokensWithFallbacks } from "@/lib/tokenFallbacks";
 import type { TransactionWithStatus, StatusResponse, TokenPosition, PortfolioResponse } from "@/types";
 
@@ -81,6 +82,16 @@ function Dashboard() {
     fetchStatus();
     api.users.get(safeAddress).then((d) => setUsername(d?.username ?? null)).catch(() => {});
   }, [safeAddress, fetchPortfolio, fetchTransactions, fetchStatus, api]);
+
+  // Keep the dashboard live. Portfolio + status refresh on a calm cadence; the
+  // activity list speeds up while a tx is mid-flight so a pending send flips to
+  // executed/rejected within seconds. A focused tab refetches immediately.
+  const hasPendingTx = transactions.some(
+    (t) => t.status === "pending" || t.status === "in_review"
+  );
+  useAutoRefresh(fetchPortfolio, 30_000);
+  useAutoRefresh(fetchStatus, 30_000);
+  useAutoRefresh(fetchTransactions, hasPendingTx ? 8_000 : 30_000);
 
   const handleSendSuccess = () => {
     setSendOpen(false);

--- a/client/src/app/(app)/settings/page.tsx
+++ b/client/src/app/(app)/settings/page.tsx
@@ -352,7 +352,7 @@ function SettingsPageContent() {
                       Claude Sonnet 4.5
                     </span>
                     <p className="text-[11px] text-muted-foreground/80 mt-2.5 leading-relaxed">
-                      Dedicated OpenClaw instance with advanced AI model
+                      Dedicated NanoBot/Hermes instance with advanced AI model
                     </p>
                   </div>
 
@@ -370,11 +370,11 @@ function SettingsPageContent() {
                       </span>
                     </div>
                     <p className="text-[11px] text-muted-foreground/80 leading-relaxed">
-                      Run your own OpenClaw agent
+                      Run your own NanoBot/Hermes agent
                     </p>
                     <div className="flex items-center gap-1 mt-2.5 text-[11px] font-mono text-muted-foreground/80">
                       <ExternalLink className="h-3 w-3" />
-                      docs.openclaw.ai
+                      docs.zhentan.me 
                     </div>
                   </div>
                 </div>
@@ -386,16 +386,6 @@ function SettingsPageContent() {
                   <span className="eyebrow text-muted-foreground/60">App</span>
                 </div>
                 <div className="mt-1">
-                  <div className="flex items-center justify-between gap-6 py-4 border-b border-dashed border-border">
-                    <div className="min-w-0">
-                      <p className="eyebrow text-muted-foreground">Network</p>
-                      <p className="text-xs text-muted-foreground/60 mt-1">Chain the agent co-signs on</p>
-                    </div>
-                    <span className="inline-flex items-center gap-2 text-[13px] font-medium text-foreground shrink-0">
-                      <span className="h-1.5 w-1.5 rounded-pill bg-safe signal-dot" />
-                      BNB Chain · Mainnet
-                    </span>
-                  </div>
                   <div className="flex items-center justify-between gap-6 py-4">
                     <div className="min-w-0">
                       <p className="eyebrow text-muted-foreground">Block explorer</p>

--- a/client/src/app/context/ActivityDataContext.tsx
+++ b/client/src/app/context/ActivityDataContext.tsx
@@ -10,6 +10,7 @@ import {
   type ReactNode,
 } from "react";
 import { useApiClient } from "@/lib/api/client";
+import { useAutoRefresh } from "@/hooks/useAutoRefresh";
 import { useAuth } from "./AuthContext";
 import type { QueuedRequest, TransactionWithStatus } from "@/types";
 
@@ -22,11 +23,18 @@ import type { QueuedRequest, TransactionWithStatus } from "@/types";
  * slow Zerion-merged `/transactions` endpoint. This provider fetches both
  * sources once, in parallel, off the cheap `/transactions/db` endpoint, and
  * hands the result to every consumer.
+ *
+ * Updates are poll-driven but adaptive: polling speeds up while anything is
+ * awaiting resolution (a queued request or an in-review tx) so the pending →
+ * executed/rejected transition lands within seconds, and backs off to a slow
+ * cadence when idle. A focused tab also refetches immediately (see
+ * {@link useAutoRefresh}). New proposals can be inserted optimistically so they
+ * appear instantly, then reconcile against the server record by id.
  */
 interface ActivityDataContextType {
   /** All queued/processed requests (invoices, payment asks). */
   requests: QueuedRequest[];
-  /** Zhentan DB transaction records (no Zerion enrichment). */
+  /** Zhentan DB transaction records (no Zerion enrichment), newest first. */
   transactions: TransactionWithStatus[];
   /** Requests still awaiting the user (status === "queued"). */
   queuedCount: number;
@@ -34,25 +42,37 @@ interface ActivityDataContextType {
   loading: boolean;
   /** Force an immediate refetch (e.g. after approve/reject). */
   refresh: () => Promise<void>;
+  /**
+   * Insert a just-proposed tx so it shows immediately, before the next poll.
+   * Dropped automatically once the server returns a record with the same id.
+   */
+  addOptimisticTransaction: (tx: TransactionWithStatus) => void;
 }
 
 const ActivityDataContext = createContext<ActivityDataContextType | null>(null);
 
+/** Idle cadence — nothing awaiting resolution. */
 const POLL_MS = 30_000;
+/** Active cadence — a request or tx is mid-flight; resolve the transition fast. */
+const FAST_POLL_MS = 8_000;
+
+function isActiveTx(t: TransactionWithStatus): boolean {
+  return t.status === "pending" || t.status === "in_review";
+}
 
 export function ActivityDataProvider({ children }: { children: ReactNode }) {
   const api = useApiClient();
   const { safeAddress } = useAuth();
   const [requests, setRequests] = useState<QueuedRequest[]>([]);
-  const [transactions, setTransactions] = useState<TransactionWithStatus[]>([]);
+  const [serverTxns, setServerTxns] = useState<TransactionWithStatus[]>([]);
+  const [optimistic, setOptimistic] = useState<TransactionWithStatus[]>([]);
   const [loading, setLoading] = useState(true);
 
+  // Background-safe refetch — never toggles `loading`, so polls don't flash skeletons.
   const refresh = useCallback(async () => {
-    // Both sources require an authenticated Safe; skip on public pages.
     if (!safeAddress) {
       setRequests([]);
-      setTransactions([]);
-      setLoading(false);
+      setServerTxns([]);
       return;
     }
     const [reqResult, txResult] = await Promise.allSettled([
@@ -63,17 +83,50 @@ export function ActivityDataProvider({ children }: { children: ReactNode }) {
       setRequests(reqResult.value.requests || []);
     }
     if (txResult.status === "fulfilled") {
-      setTransactions(txResult.value.transactions || []);
+      setServerTxns(txResult.value.transactions || []);
     }
-    setLoading(false);
   }, [api, safeAddress]);
 
+  // Initial load (and reload on Safe change) — this is the only path that shows loading.
   useEffect(() => {
     setLoading(true);
-    refresh();
-    const interval = setInterval(refresh, POLL_MS);
-    return () => clearInterval(interval);
+    refresh().finally(() => setLoading(false));
   }, [refresh]);
+
+  // Merge optimistic proposals ahead of server records; the server copy wins by id.
+  const transactions = useMemo(() => {
+    const serverIds = new Set(serverTxns.map((t) => t.id));
+    const extras = optimistic.filter((o) => !serverIds.has(o.id));
+    return [...extras, ...serverTxns].sort(
+      (a, b) => new Date(b.proposedAt).getTime() - new Date(a.proposedAt).getTime()
+    );
+  }, [serverTxns, optimistic]);
+
+  // Once the server knows about an optimistic tx, drop the local copy.
+  useEffect(() => {
+    if (optimistic.length === 0) return;
+    const serverIds = new Set(serverTxns.map((t) => t.id));
+    if (optimistic.some((o) => serverIds.has(o.id))) {
+      setOptimistic((prev) => prev.filter((o) => !serverIds.has(o.id)));
+    }
+  }, [serverTxns, optimistic]);
+
+  const addOptimisticTransaction = useCallback(
+    (tx: TransactionWithStatus) => {
+      setOptimistic((prev) => [tx, ...prev.filter((p) => p.id !== tx.id)]);
+      refresh(); // kick a fetch so the real record arrives ASAP
+    },
+    [refresh]
+  );
+
+  // Speed up while anything awaits resolution; idle otherwise.
+  const hasActive = useMemo(
+    () =>
+      transactions.some(isActiveTx) ||
+      requests.some((r) => r.status === "queued"),
+    [transactions, requests]
+  );
+  useAutoRefresh(refresh, hasActive ? FAST_POLL_MS : POLL_MS);
 
   const queuedCount = useMemo(
     () => requests.filter((r) => r.status === "queued").length,
@@ -81,8 +134,15 @@ export function ActivityDataProvider({ children }: { children: ReactNode }) {
   );
 
   const value = useMemo(
-    () => ({ requests, transactions, queuedCount, loading, refresh }),
-    [requests, transactions, queuedCount, loading, refresh]
+    () => ({
+      requests,
+      transactions,
+      queuedCount,
+      loading,
+      refresh,
+      addOptimisticTransaction,
+    }),
+    [requests, transactions, queuedCount, loading, refresh, addOptimisticTransaction]
   );
 
   return (

--- a/client/src/app/context/ScreeningStatusContext.tsx
+++ b/client/src/app/context/ScreeningStatusContext.tsx
@@ -10,6 +10,7 @@ import {
   type ReactNode,
 } from "react";
 import { useApiClient } from "@/lib/api/client";
+import { useAutoRefresh } from "@/hooks/useAutoRefresh";
 import { useAuth } from "./AuthContext";
 
 interface ScreeningStatusContextType {
@@ -54,9 +55,9 @@ export function ScreeningStatusProvider({ children }: { children: ReactNode }) {
     if (!safeAddress) return;
     setLoading(true);
     refresh().finally(() => setLoading(false));
-    const interval = setInterval(refresh, 30_000);
-    return () => clearInterval(interval);
   }, [safeAddress, refresh]);
+
+  useAutoRefresh(refresh, 30_000);
 
   const fullyActivated = telegramLinked && botConnected;
   const isScreeningActive = screeningMode && fullyActivated;

--- a/client/src/app/deck/page.tsx
+++ b/client/src/app/deck/page.tsx
@@ -244,7 +244,7 @@ function SlideHowItWorks() {
 
       <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 0.65 }}
         className="flex flex-wrap justify-center gap-2">
-        {["GoPlus", "Honeypot.is", "De.fi", "OpenClaw Agent", "Pimlico Bundler"].map((tag) => (
+        {["GoPlus", "Honeypot.is", "De.fi", "NanoBot/Hermes Agent", "Pimlico Bundler"].map((tag) => (
           <Tag key={tag}>{tag}</Tag>
         ))}
       </motion.div>
@@ -260,7 +260,7 @@ function SlideProduct() {
     { name: "ERC-4337",       note: "Account abstraction · 40M+ smart accounts", color: "rgba(99,102,241,0.10)", border: "rgba(99,102,241,0.28)" },
     { name: "ERC-7579",       note: "Module extensibility standard",           color: "rgba(168,85,247,0.10)", border: "rgba(168,85,247,0.28)" },
     { name: "ERC-8004",       note: "Agent identity on-chain",                 color: "rgba(196,148,40,0.10)", border: "rgba(196,148,40,0.28)" },
-    { name: "OpenClaw",       note: "Qwen3-235B + Claude Sonnet agent",        color: "rgba(196,148,40,0.15)", border: "rgba(196,148,40,0.30)" },
+    { name: "NanoBot/Hermes",       note: "Qwen3-235B + Claude Sonnet agent",        color: "rgba(196,148,40,0.15)", border: "rgba(196,148,40,0.30)" },
     { name: "Pimlico",        note: "Gasless bundler + paymaster",             color: "rgba(168,85,247,0.10)", border: "rgba(168,85,247,0.25)" },
   ];
 

--- a/client/src/app/login/page.tsx
+++ b/client/src/app/login/page.tsx
@@ -1,559 +1,17 @@
 "use client";
 
-import { useRef, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { motion, useInView } from "framer-motion";
+import { motion } from "framer-motion";
 import { Loader2 } from "lucide-react";
-import { Button } from "@/components/ui/Button";
-import { BrandMark } from "@/components/BrandMark";
+import { TwinTick } from "@/components/BrandMark";
+import { GuardianCard } from "@/components/GuardianCard";
 import { ThemeLoader } from "@/components/ThemeLoader";
 import { useAuth } from "@/app/context/AuthContext";
 import { useOnboarding } from "@/lib/useOnboarding";
 import { useLoginWithOAuth } from "@privy-io/react-auth";
 
-/* ─── Helpers ─────────────────────────────────────────────────────── */
-
-function Section({
-  children,
-  className = "",
-}: {
-  children: React.ReactNode;
-  className?: string;
-}) {
-  const ref = useRef(null);
-  const inView = useInView(ref, { once: true, margin: "-80px" });
-  return (
-    <motion.section
-      ref={ref}
-      initial={{ opacity: 0, y: 40 }}
-      animate={inView ? { opacity: 1, y: 0 } : {}}
-      transition={{ duration: 0.6, type: "spring", bounce: 0.18 }}
-      className={className}
-    >
-      {children}
-    </motion.section>
-  );
-}
-
-/* ─── Animated Risk Gauge ─────────────────────────────────────────── */
-
-function RiskGauge() {
-  const ref = useRef(null);
-  const inView = useInView(ref, { once: true });
-  const [score, setScore] = useState(0);
-  const TARGET = 65; // REVIEW zone — most interesting to demonstrate
-
-  useEffect(() => {
-    if (!inView) return;
-    let raf: number;
-    const duration = 1800;
-    const startTime = Date.now();
-    const tick = () => {
-      const elapsed = Date.now() - startTime;
-      const t = Math.min(elapsed / duration, 1);
-      const eased = 1 - Math.pow(1 - t, 3); // ease-out cubic
-      setScore(Math.round(eased * TARGET));
-      if (t < 1) raf = requestAnimationFrame(tick);
-    };
-    const delay = setTimeout(() => {
-      raf = requestAnimationFrame(tick);
-    }, 500);
-    return () => {
-      clearTimeout(delay);
-      cancelAnimationFrame(raf);
-    };
-  }, [inView]);
-
-  const R = 70;
-  const cx = 90;
-  const cy = 90;
-
-  const arcPath = (fromDeg: number, toDeg: number) => {
-    const toRad = (d: number) => (d * Math.PI) / 180;
-    const fx = cx + R * Math.cos(toRad(fromDeg));
-    const fy = cy + R * Math.sin(toRad(fromDeg));
-    const tx = cx + R * Math.cos(toRad(toDeg));
-    const ty = cy + R * Math.sin(toRad(toDeg));
-    const large = toDeg - fromDeg > 180 ? 1 : 0;
-    return `M ${fx.toFixed(2)} ${fy.toFixed(2)} A ${R} ${R} 0 ${large} 1 ${tx.toFixed(2)} ${ty.toFixed(2)}`;
-  };
-
-  // Gauge: 135° → 405° (= 45°), 270° total sweep, clockwise
-  const progressEndDeg = 135 + (score / 100) * 270;
-  const toRad = (d: number) => (d * Math.PI) / 180;
-  const nx = cx + R * Math.cos(toRad(progressEndDeg));
-  const ny = cy + R * Math.sin(toRad(progressEndDeg));
-
-  const color = score < 40 ? "#10b981" : score < 70 ? "#f59e0b" : "#e5524f";
-  const label = score < 40 ? "SAFE" : score < 70 ? "REVIEW" : "BLOCK";
-  const labelColor =
-    score < 40 ? "text-safe" : score < 70 ? "text-watch" : "text-danger";
-
-  return (
-    <div ref={ref} className="flex flex-col items-center gap-2">
-      <svg
-        width="180"
-        height="150"
-        viewBox="0 0 180 150"
-        className="overflow-visible"
-      >
-        <defs>
-          <filter id="glow-gauge" x="-50%" y="-50%" width="200%" height="200%">
-            <feGaussianBlur stdDeviation="4" result="blur" />
-            <feMerge>
-              <feMergeNode in="blur" />
-              <feMergeNode in="SourceGraphic" />
-            </feMerge>
-          </filter>
-        </defs>
-        {/* Background track */}
-        <path
-          d={arcPath(135, 405)}
-          fill="none"
-          stroke="rgba(255,255,255,0.07)"
-          strokeWidth="12"
-          strokeLinecap="round"
-        />
-        {/* Zone shading */}
-        <path
-          d={arcPath(135, 243)}
-          fill="none"
-          stroke="rgba(16,185,129,0.2)"
-          strokeWidth="12"
-          strokeLinecap="butt"
-        />
-        <path
-          d={arcPath(243, 324)}
-          fill="none"
-          stroke="rgba(245,158,11,0.2)"
-          strokeWidth="12"
-          strokeLinecap="butt"
-        />
-        <path
-          d={arcPath(324, 405)}
-          fill="none"
-          stroke="rgba(239,68,68,0.2)"
-          strokeWidth="12"
-          strokeLinecap="butt"
-        />
-        {/* Animated progress arc */}
-        {score > 0 && (
-          <path
-            d={arcPath(135, Math.min(progressEndDeg, 405))}
-            fill="none"
-            stroke={color}
-            strokeWidth="12"
-            strokeLinecap="round"
-            filter="url(#glow-gauge)"
-          />
-        )}
-        {/* Needle dot */}
-        <circle
-          cx={nx}
-          cy={ny}
-          r="7"
-          fill={color}
-          filter="url(#glow-gauge)"
-        />
-        {/* Score display */}
-        <text
-          x={cx}
-          y={cy - 4}
-          textAnchor="middle"
-          dominantBaseline="middle"
-          fill="white"
-          fontSize="30"
-          fontWeight="bold"
-        >
-          {score}
-        </text>
-        <text
-          x={cx}
-          y={cy + 18}
-          textAnchor="middle"
-          fill="rgba(255,255,255,0.3)"
-          fontSize="9"
-          letterSpacing="2"
-        >
-          RISK SCORE
-        </text>
-      </svg>
-      {/* Zone labels */}
-      <div className="flex justify-between w-[170px] -mt-3 text-[8px] font-bold uppercase tracking-widest">
-        <span className="text-safe/60">Safe</span>
-        <span className="text-watch/60">Review</span>
-        <span className="text-danger/60">Block</span>
-      </div>
-      {/* Current verdict */}
-      <motion.span
-        key={label}
-        initial={{ opacity: 0, scale: 0.8 }}
-        animate={{ opacity: 1, scale: 1 }}
-        transition={{ type: "spring", bounce: 0.4 }}
-        className={`text-[10px] font-black tracking-[0.2em] uppercase mt-1 ${labelColor}`}
-      >
-        ● {label}
-      </motion.span>
-    </div>
-  );
-}
-
-/* ─── Architecture Diagram ────────────────────────────────────────── */
-
-function ArchitectureDiagram() {
-  const ref = useRef(null);
-  const inView = useInView(ref, { once: true, margin: "-60px" });
-  const SF = "system-ui, -apple-system, sans-serif";
-
-  // Layout (viewBox 720×640):
-  // Layer 0 y=15  — User Wallet (center x=117) + DApp (center x=602)
-  // Layer 1 y=135 — Safe Multisig (center x=360)
-  // Layer 2 y=300 — Zhentan Agent circle (center 360,300) ← hero node
-  // Layer 3 y=450 — APPROVE / REVIEW / BLOCK
-  // Layer 4 y=572 — BNB Chain / Telegram / Blocked
-
-  const PATHS = [
-    { id: "ap1", d: "M 117,80 C 117,112 360,110 360,135",        color: "rgba(196,148,40,0.45)", dur: "2.4s", begin: "0.3s", delay: 0.40 },
-    { id: "ap2", d: "M 602,105 C 602,122 360,122 360,135",       color: "rgba(196,148,40,0.45)", dur: "2.4s", begin: "1.1s", delay: 0.55 },
-    { id: "ap3", d: "M 360,203 L 360,232",                       color: "rgba(196,148,40,0.45)", dur: "2.0s", begin: "0.8s", delay: 0.78 },
-    { id: "ap4", d: "M 288,300 C 200,358 117,390 117,450",       color: "rgba(16,185,129,0.60)", dur: "2.0s", begin: "0.6s", delay: 1.05 },
-    { id: "ap5", d: "M 360,368 L 360,450",                       color: "rgba(245,158,11,0.60)", dur: "1.8s", begin: "0.2s", delay: 1.00 },
-    { id: "ap6", d: "M 432,300 C 520,358 602,390 602,450",       color: "rgba(239,68,68,0.60)",  dur: "2.0s", begin: "1.4s", delay: 1.10 },
-    { id: "ap7", d: "M 117,525 L 117,572",                       color: "rgba(16,185,129,0.40)", dur: "1.4s", begin: "0.9s", delay: 1.50 },
-    { id: "ap8", d: "M 360,525 L 360,572",                       color: "rgba(245,158,11,0.40)", dur: "1.4s", begin: "0.4s", delay: 1.60 },
-    { id: "ap9", d: "M 602,525 L 602,572",                       color: "rgba(239,68,68,0.40)",  dur: "1.4s", begin: "1.2s", delay: 1.70 },
-  ];
-
-  const n = (delay: number) => ({
-    initial: { opacity: 0, scale: 0.92 },
-    animate: inView ? { opacity: 1, scale: 1 } : { opacity: 0, scale: 0.92 },
-    transition: { delay, type: "spring" as const, bounce: 0.22 },
-  });
-
-  return (
-    <div ref={ref} className="w-full max-w-4xl mx-auto">
-      <svg viewBox="0 0 720 640" className="w-full" style={{ maxHeight: 600 }}>
-        <defs>
-          {PATHS.map((p) => (
-            <path key={`def-${p.id}`} id={p.id} d={p.d} fill="none" />
-          ))}
-
-          {/* Horizontal gradient top-edge accents (objectBoundingBox = per element) */}
-          <linearGradient id="g-gold" x1="0" y1="0" x2="1" y2="0">
-            <stop offset="0%"   stopColor="#F0B90B" stopOpacity={0} />
-            <stop offset="50%"  stopColor="#F0B90B" stopOpacity={0.7} />
-            <stop offset="100%" stopColor="#F0B90B" stopOpacity={0} />
-          </linearGradient>
-          <linearGradient id="g-green" x1="0" y1="0" x2="1" y2="0">
-            <stop offset="0%"   stopColor="#10b981" stopOpacity={0} />
-            <stop offset="50%"  stopColor="#10b981" stopOpacity={0.7} />
-            <stop offset="100%" stopColor="#10b981" stopOpacity={0} />
-          </linearGradient>
-          <linearGradient id="g-amber" x1="0" y1="0" x2="1" y2="0">
-            <stop offset="0%"   stopColor="#f59e0b" stopOpacity={0} />
-            <stop offset="50%"  stopColor="#f59e0b" stopOpacity={0.7} />
-            <stop offset="100%" stopColor="#f59e0b" stopOpacity={0} />
-          </linearGradient>
-          <linearGradient id="g-red" x1="0" y1="0" x2="1" y2="0">
-            <stop offset="0%"   stopColor="#e5524f" stopOpacity={0} />
-            <stop offset="50%"  stopColor="#e5524f" stopOpacity={0.7} />
-            <stop offset="100%" stopColor="#e5524f" stopOpacity={0} />
-          </linearGradient>
-          {/* Vertical glass fill — top lighter, bottom darker */}
-          <linearGradient id="g-glass" x1="0" y1="0" x2="0" y2="1">
-            <stop offset="0%"   stopColor="white" stopOpacity={0.07} />
-            <stop offset="100%" stopColor="white" stopOpacity={0.02} />
-          </linearGradient>
-
-          {/* dapp logos strip: 16px padding each side → x=521,y=46 w=163,h=48 */}
-          <clipPath id="clip-dapps"><rect x="521" y="46" width="163" height="48" rx="6" /></clipPath>
-          <clipPath id="clip-agent-c"><circle cx="360" cy="300" r="54" /></clipPath>
-          <clipPath id="clip-safe-c"><circle cx="256" cy="169" r="24" /></clipPath>
-          {/* bnb logo center: x=30+20=50, y=582+20=602 */}
-          <clipPath id="clip-bnb-c"><circle cx="50" cy="602" r="20" /></clipPath>
-          {/* telegram logo left-aligned: x=272+20=292, y=582+20=602 */}
-          <clipPath id="clip-tg-c"><circle cx="292" cy="602" r="20" /></clipPath>
-        </defs>
-
-        {/* ── Connector lines ───────────────────────────────────────── */}
-        {PATHS.map((p) => (
-          <motion.path key={p.id} d={p.d} fill="none" stroke={p.color}
-            strokeWidth="1.5" strokeLinecap="round"
-            initial={{ pathLength: 0, opacity: 0 }}
-            animate={inView ? { pathLength: 1, opacity: 1 } : {}}
-            transition={{ duration: 1.1, delay: p.delay, ease: "easeInOut" }}
-          />
-        ))}
-
-        {/* ── Flowing data-packet dots ──────────────────────────────── */}
-        {inView && PATHS.map((p) => (
-          <circle key={`dot-${p.id}`} r="3.5" fill={p.color} opacity="0.9">
-            <animateMotion dur={p.dur} repeatCount="indefinite" begin={p.begin}>
-              <mpath href={`#${p.id}`} />
-            </animateMotion>
-          </circle>
-        ))}
-
-        {/* ══════════════════════════════════════════════════════════ */}
-
-        {/* ── User Wallet ─────────────────────────────────────────── */}
-        <motion.g {...n(0.10)}>
-          <rect x="20" y="15" width="195" height="65" rx="12"
-            fill="url(#g-glass)" stroke="rgba(255,255,255,0.10)" strokeWidth="1" />
-          <rect x="20" y="15" width="195" height="1.5" rx="1" fill="url(#g-gold)" />
-          <text x="117" y="43" textAnchor="middle" fill="rgba(255,255,255,0.90)" fontSize="12" fontWeight="600" fontFamily={SF}>User Wallet</text>
-          <text x="117" y="59" textAnchor="middle" fill="rgba(196,148,40,0.65)" fontSize="8.5" fontFamily={SF}>1 of 2 signers · Privy</text>
-        </motion.g>
-
-        {/* ── WalletConnect DApp ───────────────────────────────────── */}
-        {/* box bottom y=105 to match ap2 path start */}
-        <motion.g {...n(0.20)}>
-          <rect x="505" y="15" width="195" height="90" rx="12"
-            fill="url(#g-glass)" stroke="rgba(255,255,255,0.10)" strokeWidth="1" />
-          <rect x="505" y="15" width="195" height="1.5" rx="1" fill="url(#g-gold)" />
-          <text x="602" y="33" textAnchor="middle" fill="rgba(255,255,255,0.90)" fontSize="12" fontWeight="600" fontFamily={SF}>WalletConnect DApp</text>
-          {/* DApp logo strip — arch-dapps.png 684×200 (ratio 3.42:1), display 163×48 ≈ same ratio, 16px padding */}
-          <image href="/arch-dapps.png" x="521" y="46" width="163" height="48"
-            clipPath="url(#clip-dapps)" preserveAspectRatio="xMidYMid slice" />
-        </motion.g>
-
-        {/* ── Safe Multisig (logo + one line) ─────────────────────── */}
-        <motion.g {...n(0.38)}>
-          <rect x="222" y="135" width="276" height="68" rx="12"
-            fill="url(#g-glass)" stroke="rgba(255,255,255,0.10)" strokeWidth="1" />
-          <rect x="222" y="135" width="276" height="1.5" rx="1" fill="url(#g-gold)" />
-          {/* Safe logo — scaled down inside circle so edges aren't cut (padding) */}
-          <image href="/arch-safe.png" x="236" y="149" width="40" height="40"
-            clipPath="url(#clip-safe-c)" preserveAspectRatio="xMidYMid meet" />
-          <circle cx="256" cy="169" r="25" fill="none" stroke="rgba(196,148,40,0.18)" strokeWidth="1" />
-          {/* Text centered in remaining space: logo right ≈ 281, box right = 498 → center = 389 */}
-          <text x="389" y="162" textAnchor="middle" fill="white" fontSize="11.5" fontWeight="700" fontFamily={SF}>Safe Multisig — 2 of 2</text>
-          <text x="389" y="178" textAnchor="middle" fill="rgba(255,255,255,0.45)" fontSize="9" fontFamily={SF}>User + OpenClaw agent both must sign</text>
-        </motion.g>
-
-        {/* ── Zhentan Agent — HERO CIRCLE NODE ────────────────────── */}
-        <motion.g {...n(0.62)}>
-          {/* ── Float wrapper: whole agent bobs up/down (OpenClaw-style "float") */}
-          <motion.g
-            animate={inView ? { y: [0, -7, 0] } : {}}
-            transition={{ repeat: Infinity, duration: 4, ease: "easeInOut" }}
-          >
-            {/* Outermost pulse ring */}
-            <motion.circle cx="360" cy="300" r="82"
-              fill="none" stroke="rgba(196,148,40,0.10)" strokeWidth="1"
-              animate={inView ? { opacity: [0.2, 0.8, 0.2], r: [78, 86, 78] } : {}}
-              transition={{ repeat: Infinity, duration: 3.5, ease: "easeInOut" }}
-            />
-            {/* Middle breathing ring */}
-            <motion.circle cx="360" cy="300" r="70"
-              fill="rgba(196,148,40,0.04)" stroke="rgba(196,148,40,0.22)" strokeWidth="1"
-              animate={inView ? { opacity: [0.8, 0.3, 0.8] } : {}}
-              transition={{ repeat: Infinity, duration: 2.8, ease: "easeInOut", delay: 0.4 }}
-            />
-            {/* Inner glow ring */}
-            <motion.circle cx="360" cy="300" r="60"
-              fill="rgba(196,148,40,0.08)"
-              stroke="rgba(196,148,40,0.50)" strokeWidth="1.8"
-              style={{ filter: "drop-shadow(0 0 12px rgba(196,148,40,0.45))" }}
-              animate={inView ? { opacity: [1, 0.5, 1] } : {}}
-              transition={{ repeat: Infinity, duration: 2.2, ease: "easeInOut", delay: 0.9 }}
-            />
-
-            {/* ── Agent image: glow-pulse + snap jolt layers ────────── */}
-            {/* Glow layer: drop-shadow breathes in/out (OpenClaw eye blink / logo-glow) */}
-            <motion.g
-              animate={inView ? {
-                filter: [
-                  "drop-shadow(0 0 4px rgba(196,148,40,0.15))",
-                  "drop-shadow(0 0 22px rgba(196,148,40,0.80))",
-                  "drop-shadow(0 0 4px rgba(196,148,40,0.15))",
-                ],
-              } : {}}
-              transition={{ repeat: Infinity, duration: 2.5, ease: "easeInOut", delay: 0.3 }}
-            >
-              {/* Snap layer: stays still for 70% of cycle then briefly pops (OpenClaw clawSnap) */}
-              <motion.g
-                style={{ transformBox: "fill-box", transformOrigin: "center" }}
-                animate={inView ? {
-                  scale: [1, 1, 1, 1, 1, 1, 1, 1.08, 1.02, 1],
-                } : {}}
-                transition={{
-                  repeat: Infinity,
-                  duration: 5,
-                  ease: "easeInOut",
-                  delay: 1.5,
-                  times: [0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.68, 0.80, 0.90, 1],
-                }}
-              >
-                <image href="/arch-agent.png" x="306" y="246" width="108" height="108"
-                  clipPath="url(#clip-agent-c)" preserveAspectRatio="xMidYMid slice" />
-              </motion.g>
-            </motion.g>
-
-            {/* Labels */}
-            <text x="360" y="382" textAnchor="middle" fill="#F0B90B" fontSize="14" fontWeight="700" fontFamily={SF}>Zhentan Agent</text>
-            <text x="360" y="397" textAnchor="middle" fill="rgba(255,255,255,0.40)" fontSize="9" fontFamily={SF}>powered by OpenClaw</text>
-            <text x="360" y="414" textAnchor="middle" fill="rgba(255,255,255,0.55)" fontSize="8.5" fontFamily={SF}>Assesses risks · learns behaviour · communicates with user</text>
-          </motion.g>
-        </motion.g>
-
-        {/* ── APPROVE ─────────────────────────────────────────────── */}
-        <motion.g {...n(1.00)}>
-          <motion.rect x="20" y="450" width="195" height="75" rx="12"
-            fill="rgba(16,185,129,0.07)" stroke="rgba(16,185,129,0.30)" strokeWidth="1"
-            animate={inView ? { opacity: [0.7, 1, 0.7] } : {}}
-            transition={{ repeat: Infinity, duration: 3, ease: "easeInOut", delay: 2 }}
-          />
-          <rect x="20" y="450" width="195" height="1.5" rx="1" fill="url(#g-green)" />
-          <text x="117" y="482" textAnchor="middle" fill="#10b981" fontSize="13" fontWeight="700" fontFamily={SF}>APPROVE</text>
-          <text x="117" y="498" textAnchor="middle" fill="rgba(255,255,255,0.42)" fontSize="9" fontFamily={SF}>Score &lt; 40</text>
-          <text x="117" y="513" textAnchor="middle" fill="rgba(16,185,129,0.65)" fontSize="8" fontFamily={SF}>Auto-execute · gasless</text>
-        </motion.g>
-
-        {/* ── REVIEW ──────────────────────────────────────────────── */}
-        <motion.g {...n(1.12)}>
-          <motion.rect x="262" y="450" width="196" height="75" rx="12"
-            fill="rgba(245,158,11,0.07)" stroke="rgba(245,158,11,0.30)" strokeWidth="1"
-            animate={inView ? { opacity: [1, 0.6, 1] } : {}}
-            transition={{ repeat: Infinity, duration: 2.5, ease: "easeInOut", delay: 2.3 }}
-          />
-          <rect x="262" y="450" width="196" height="1.5" rx="1" fill="url(#g-amber)" />
-          <text x="360" y="482" textAnchor="middle" fill="#f59e0b" fontSize="13" fontWeight="700" fontFamily={SF}>REVIEW</text>
-          <text x="360" y="498" textAnchor="middle" fill="rgba(255,255,255,0.42)" fontSize="9" fontFamily={SF}>Score 40–70</text>
-          <text x="360" y="513" textAnchor="middle" fill="rgba(245,158,11,0.65)" fontSize="8" fontFamily={SF}>Telegram notified</text>
-        </motion.g>
-
-        {/* ── BLOCK ───────────────────────────────────────────────── */}
-        <motion.g {...n(1.24)}>
-          <motion.rect x="505" y="450" width="195" height="75" rx="12"
-            fill="rgba(239,68,68,0.07)" stroke="rgba(239,68,68,0.30)" strokeWidth="1"
-            animate={inView ? { opacity: [0.7, 1, 0.7] } : {}}
-            transition={{ repeat: Infinity, duration: 3.2, ease: "easeInOut", delay: 2.6 }}
-          />
-          <rect x="505" y="450" width="195" height="1.5" rx="1" fill="url(#g-red)" />
-          <text x="602" y="482" textAnchor="middle" fill="#e5524f" fontSize="13" fontWeight="700" fontFamily={SF}>BLOCK</text>
-          <text x="602" y="498" textAnchor="middle" fill="rgba(255,255,255,0.42)" fontSize="9" fontFamily={SF}>Score &gt; 70</text>
-          <text x="602" y="513" textAnchor="middle" fill="rgba(239,68,68,0.65)" fontSize="8" fontFamily={SF}>Denied · user alerted</text>
-        </motion.g>
-
-        {/* ── BNB Chain (logo left, text centered in remaining space) ── */}
-        <motion.g {...n(1.42)}>
-          <rect x="20" y="572" width="195" height="58" rx="12"
-            fill="url(#g-glass)" stroke="rgba(255,255,255,0.09)" strokeWidth="1" />
-          <rect x="20" y="572" width="195" height="1.5" rx="1" fill="url(#g-gold)" />
-          {/* Logo center at (50, 602) — 10px left padding */}
-          <image href="/arch-bnb.png" x="30" y="582" width="40" height="40"
-            clipPath="url(#clip-bnb-c)" preserveAspectRatio="xMidYMid slice" />
-          <circle cx="50" cy="602" r="21" fill="none" stroke="rgba(196,148,40,0.20)" strokeWidth="1" />
-          {/* Text centered from logo right (71) to box right (215): center = 143 */}
-          <text x="143" y="597" textAnchor="middle" fill="rgba(255,255,255,0.88)" fontSize="11" fontWeight="600" fontFamily={SF}>BNB Chain</text>
-          <text x="143" y="613" textAnchor="middle" fill="rgba(196,148,40,0.55)" fontSize="8.5" fontFamily={SF}>Gasless · ERC-4337 · Pimlico</text>
-        </motion.g>
-
-        {/* ── Telegram (logo left, text centered in remaining space) ─── */}
-        <motion.g {...n(1.55)}>
-          <rect x="262" y="572" width="196" height="58" rx="12"
-            fill="url(#g-glass)" stroke="rgba(255,255,255,0.09)" strokeWidth="1" />
-          <rect x="262" y="572" width="196" height="1.5" rx="1" fill="url(#g-amber)" />
-          {/* Logo center at (292, 602) — 10px left padding */}
-          <image href="/arch-telegram.png" x="272" y="582" width="40" height="40"
-            clipPath="url(#clip-tg-c)" preserveAspectRatio="xMidYMid slice" />
-          <circle cx="292" cy="602" r="21" fill="none" stroke="rgba(245,158,11,0.20)" strokeWidth="1" />
-          {/* Text centered from logo right (313) to box right (458): center = 385 */}
-          <text x="385" y="597" textAnchor="middle" fill="rgba(255,255,255,0.88)" fontSize="11" fontWeight="600" fontFamily={SF}>Telegram</text>
-          <text x="385" y="613" textAnchor="middle" fill="rgba(245,158,11,0.55)" fontSize="8.5" fontFamily={SF}>Interactive approve / reject</text>
-        </motion.g>
-
-        {/* ── Blocked ─────────────────────────────────────────────── */}
-        <motion.g {...n(1.68)}>
-          <rect x="505" y="572" width="195" height="58" rx="12"
-            fill="url(#g-glass)" stroke="rgba(255,255,255,0.09)" strokeWidth="1" />
-          <rect x="505" y="572" width="195" height="1.5" rx="1" fill="url(#g-red)" />
-          <text x="602" y="597" textAnchor="middle" fill="rgba(255,255,255,0.85)" fontSize="12" fontWeight="600" fontFamily={SF}>Blocked</text>
-          <text x="602" y="613" textAnchor="middle" fill="rgba(239,68,68,0.55)" fontSize="8.5" fontFamily={SF}>Rejected · alert dispatched</text>
-        </motion.g>
-      </svg>
-    </div>
-  );
-}
-
-/* ─── Data ────────────────────────────────────────────────────────── */
-
-const verdicts = [
-  {
-    range: "< 40",
-    label: "APPROVE",
-    desc: "Auto-signed and executed immediately. Pattern recorded asynchronously for future learning.",
-    border: "rgba(16,185,129,0.28)",
-    accent: "rgba(16,185,129,0.70)",
-    bg: "rgba(16,185,129,0.07)",
-    text: "text-safe",
-  },
-  {
-    range: "40 – 70",
-    label: "REVIEW",
-    desc: "Telegram notification sent with interactive [Approve] [Reject] buttons for user review.",
-    border: "rgba(245,158,11,0.28)",
-    accent: "rgba(245,158,11,0.70)",
-    bg: "rgba(245,158,11,0.07)",
-    text: "text-watch",
-  },
-  {
-    range: "> 70",
-    label: "BLOCK",
-    desc: "Transaction blocked outright. Telegram alert dispatched with full risk breakdown.",
-    border: "rgba(239,68,68,0.28)",
-    accent: "rgba(239,68,68,0.70)",
-    bg: "rgba(239,68,68,0.07)",
-    text: "text-danger",
-  },
-];
-
-// const features = [
-//   {
-//     icon: Bot,
-//     title: "Agentic AI Co-Signer",
-//     desc: "OpenClaw agent (Qwen3-235B) acts as the second signer on your Safe multisig, making autonomous decisions on every transaction.",
-//   },
-//   {
-//     icon: TrendingUp,
-//     title: "Behavioral Pattern Learning",
-//     desc: "Builds a profile of your onchain habits — typical recipients, amounts, timing, daily limits — and flags deviations instantly.",
-//   },
-//   {
-//     icon: Lock,
-//     title: "2-of-2 Safe Multisig",
-//     desc: "Your embedded wallet holds one key; the OpenClaw agent holds the other. Both signatures required — no single point of compromise, ever.",
-//   },
-//   {
-//     icon: Search,
-//     title: "Deep Security Scan",
-//     desc: "On-demand GoPlus + Honeypot.is checks for address reputation, scam detection, and token security analysis via Telegram.",
-//   },
-//   {
-//     icon: Zap,
-//     title: "Gasless via ERC-4337",
-//     desc: "Account abstraction with Pimlico bundler means zero gas fees for every transaction. Sponsored automatically.",
-//   },
-//   {
-//     icon: Bell,
-//     title: "Telegram Reviews",
-//     desc: "Borderline transactions trigger interactive Telegram messages. Approve or reject from anywhere on your phone.",
-//   },
-// ];
-
-const techStack = [
-  "OpenClaw Agent",
-  "Safe Multisig",
-  "ERC-4337",
-  "BNB Chain",
-  "Privy Auth",
-  "OpenRouter",
-];
-
-/* ─── Page ────────────────────────────────────────────────────────── */
-
-export default function LandingPage() {
+export default function LoginPage() {
   const { user, wallet, loading, safeAddress, safeLoading, telegramUserId } = useAuth();
   const { initOAuth, loading: oauthLoading } = useLoginWithOAuth();
   const [signingInGoogle, setSigningInGoogle] = useState(false);
@@ -565,7 +23,9 @@ export default function LandingPage() {
     telegramUserId
   );
 
-  useEffect(() => { setMounted(true); }, []);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   useEffect(() => {
     if (loading || !user || !wallet || safeLoading || onboardingLoading) return;
@@ -582,11 +42,11 @@ export default function LandingPage() {
     }
   };
 
-  // As soon as Privy reports an authenticated session we stay on the loader —
-  // otherwise the login UI flashes during the window where user/wallet are
-  // populated but safeAddress / onboarding status are still resolving.
+  // Stay on the loader through the window where the session is authenticated but
+  // safeAddress / onboarding status are still resolving — avoids a login flash.
   const hasSession = !!user && !!wallet;
   const routeReady = hasSession && !safeLoading && !onboardingLoading;
+  const busy = signingInGoogle || oauthLoading;
 
   if (!mounted || loading || hasSession) {
     return (
@@ -599,243 +59,85 @@ export default function LandingPage() {
   }
 
   return (
-    <div className="min-h-screen hero-gradient text-foreground overflow-x-hidden">
-      {/* ── Hero ──────────────────────────────────────────────────── */}
-      <section className="min-h-screen flex flex-col items-center justify-center px-4 relative">
+    <div className="relative min-h-screen w-full overflow-hidden bg-background text-foreground flex items-center justify-center">
+      {/* Ambient gold glow */}
+      <div
+        className="absolute inset-[-10%] pointer-events-none"
+        style={{
+          background:
+            "radial-gradient(ellipse at 50% 38%, rgba(196,148,40,0.16), transparent 55%), radial-gradient(ellipse at 18% 92%, rgba(196,148,40,0.05), transparent 55%)",
+        }}
+      />
+      <div className="absolute inset-0 grid-pattern opacity-30 pointer-events-none" />
 
-        {/* Background grid */}
-        <div className="absolute inset-0 grid-pattern opacity-40 pointer-events-none" />
-
-        {/* Logo */}
+      <div className="relative z-10 w-full max-w-[1180px] px-6 py-14 sm:px-12 grid items-center gap-12 lg:grid-cols-[1.05fr_1fr] lg:gap-16">
+        {/* ── Left: copy + CTA ── */}
         <motion.div
-          initial={{ opacity: 0, scale: 0.92, y: 8 }}
-          animate={{ opacity: 1, scale: 1, y: 0 }}
-          transition={{ delay: 0.1, type: "spring", bounce: 0.3 }}
-          className="mb-10"
-        >
-          <BrandMark size="hero" className="gap-4" glow priority />
-        </motion.div>
-
-        {/* Card — contains headline, subtext, and button */}
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
+          initial={{ opacity: 0, y: 18 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.25, type: "spring", bounce: 0.15 }}
-          className="w-full max-w-sm glass-card p-8 flex flex-col items-center"
+          transition={{ duration: 0.55, type: "spring", bounce: 0.15 }}
         >
-          <h2 className="text-2xl font-bold text-center mb-2">Your Onchain Behaviour, Guarded</h2>
-          <p className="text-sm text-muted-foreground text-center mb-8 max-w-xs">
-            Sign in to access your onchain detective wallet.
+          {/* Agent-id badge */}
+          <span className="inline-flex items-center gap-3 px-3.5 py-2 rounded-pill bg-gold/[0.06] border border-gold/20 font-mono text-[11px] tracking-[0.14em] uppercase text-gold-300">
+            <span className="w-[18px] h-[18px] rounded-pill bg-gold/15 flex items-center justify-center p-0.5">
+              <TwinTick size={13} halo="none" />
+            </span>
+            Agent · online
+            <span className="w-1.5 h-1.5 rounded-pill bg-gold-400 animate-signal-pulse" />
+          </span>
+
+          <h1 className="mt-6 font-bold text-[40px] sm:text-5xl lg:text-6xl leading-[1.02] tracking-[-0.04em] max-w-[15ch] text-foreground">
+            Welcome back.
+            <br />
+            <em className="not-italic font-medium text-gold-300">Zhentan</em> has been watching.
+          </h1>
+
+          <p className="mt-5 text-base sm:text-lg leading-relaxed text-muted-foreground max-w-[44ch]">
+            Your wallet is under guard. Sign in to see what Zhentan has been
+            screening while you were away.
           </p>
 
-          <div className="w-full space-y-4">
-            <Button
-              onClick={handleGoogleLogin}
-              disabled={signingInGoogle || oauthLoading}
-              className="w-full"
-            >
-              {signingInGoogle || oauthLoading ? (
-                <><Loader2 className="h-4 w-4 animate-spin" />Signing in...</>
-              ) : (
-                <>
-                  <svg className="h-4 w-4 shrink-0" viewBox="0 0 24 24">
-                    <path fill="currentColor" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
-                    <path fill="currentColor" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
-                    <path fill="currentColor" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
-                    <path fill="currentColor" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
-                  </svg>
-                  Continue with Google
-                </>
-              )}
-            </Button>
+          <button
+            type="button"
+            onClick={handleGoogleLogin}
+            disabled={busy}
+            className="mt-8 inline-flex items-center gap-3 px-6 py-3.5 rounded-pill bg-gradient-to-br from-gold-light to-gold-500 text-ink-900 font-semibold text-[15px] shadow-[0_14px_40px_-18px_rgba(196,148,40,0.8)] hover:brightness-[1.05] active:translate-y-px transition disabled:opacity-60 disabled:cursor-default cursor-pointer"
+          >
+            {busy ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Signing in…
+              </>
+            ) : (
+              <>
+                <svg className="h-[18px] w-[18px] shrink-0" viewBox="0 0 24 24" aria-hidden>
+                  <path fill="#1a1205" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" />
+                  <path fill="#1a1205" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" />
+                  <path fill="#1a1205" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" />
+                  <path fill="#1a1205" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" />
+                </svg>
+                Continue with Google
+              </>
+            )}
+          </button>
 
-            <p className="text-[11px] text-muted-foreground/50 text-center">
-              Secured by Safe · Powered by OpenClaw on BNB Chain
-            </p>
+          <div className="mt-7 flex items-center gap-3 font-mono text-[11px] tracking-[0.12em] uppercase text-muted-foreground/70">
+            <span>Secured by Safe</span>
+            <span aria-hidden>·</span>
+            <span>OpenClaw on BNB Chain</span>
           </div>
         </motion.div>
 
-      </section>
-
-      {/* ── Architecture / How It Works ───────────────────────────── */}
-      {/* <Section className="py-20 sm:py-28 px-4">
-        <h2 className="text-2xl sm:text-3xl font-bold text-center mb-3">
-          How It <span className="gradient-text">Works</span>
-        </h2>
-        <p className="text-muted-foreground text-center max-w-lg mx-auto mb-12 text-sm">
-          Each transaction goes from your wallet after you sign to the AI agent (OpenClaw), which can-sign and auto-execute, send for review, or block it based on transaction risk.
-        </p>
-        <ArchitectureDiagram />
-      </Section> */}
-
-      {/* ── Dynamic Risk Assessment ───────────────────────────────── */}
-      {/* <Section className="py-20 sm:py-28 px-4">
-        <h2 className="text-2xl sm:text-3xl font-bold text-center mb-3">
-          Dynamic <span className="gradient-text">Risk Assessment</span>
-        </h2>
-        <p className="text-muted-foreground text-center max-w-md mx-auto mb-12 text-sm">
-          Every transaction receives a real-time 0–100 risk score computed
-          against your learned behavioral patterns and dynamic assessment via GoPlus and Honeypot.is. The agent acts instantly —
-          no delays, no manual steps.
-        </p>
-
-        <div className="max-w-4xl mx-auto flex flex-col items-center gap-10">
-          <RiskGauge />
-
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 w-full">
-            {verdicts.map((v, i) => (
-              <motion.div
-                key={v.label}
-                initial={{ opacity: 0, y: 24 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                viewport={{ once: true, margin: "-40px" }}
-                transition={{ delay: i * 0.12, type: "spring", bounce: 0.18 }}
-                whileHover={{ scale: 1.02 }}
-                className="relative rounded-2xl p-5 overflow-hidden"
-                style={{
-                  background: `linear-gradient(to bottom, rgba(255,255,255,0.05), transparent), ${v.bg}`,
-                  border: `1px solid ${v.border}`,
-                }}
-              >
-                <div
-                  className="absolute top-0 left-0 right-0"
-                  style={{
-                    height: "1.5px",
-                    background: `linear-gradient(90deg, transparent, ${v.accent}, transparent)`,
-                  }}
-                />
-                <div className="flex items-baseline gap-2 mb-2">
-                  <span className={`text-base font-black ${v.text}`}>
-                    {v.label}
-                  </span>
-                  <span className="text-[10px] text-muted-foreground/80 font-mono">
-                    {v.range}
-                  </span>
-                </div>
-                <p className="text-muted-foreground text-xs leading-relaxed">
-                  {v.desc}
-                </p>
-              </motion.div>
-            ))}
-          </div>
-        </div>
-      </Section> */}
-
-      {/* ── Features ──────────────────────────────────────────────── */}
-      {/* <Section className="py-20 sm:py-28 px-4">
-        <h2 className="text-2xl sm:text-3xl font-bold text-center mb-3">
-          Built with <span className="gradient-text">Agentic Security</span>
-        </h2>
-        <p className="text-muted-foreground text-center max-w-md mx-auto mb-12 text-sm">
-          Full-stack AI protection — from behavioral modeling to on-chain
-          execution.
-        </p>
-        <div className="max-w-4xl mx-auto grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {features.map((feat, i) => {
-            const Icon = feat.icon;
-            return (
-              <motion.div
-                key={feat.title}
-                initial={{ opacity: 0, y: 28 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                viewport={{ once: true, margin: "-60px" }}
-                transition={{ delay: i * 0.08, type: "spring", bounce: 0.18 }}
-                whileHover={{ scale: 1.02, y: -4 }}
-                className="relative rounded-2xl overflow-hidden bg-foreground/[0.05] border border-foreground/[0.07] hover:border-claw/20 transition-colors p-5"
-              >
-                <div
-                  className="absolute top-0 left-0 right-0 h-px"
-                  style={{
-                    background:
-                      "linear-gradient(90deg, transparent, rgba(196,148,40,0.3), transparent)",
-                  }}
-                />
-                <div className="w-10 h-10 rounded-xl bg-claw/10 shadow-[0_0_10px_rgba(196,148,40,0.08)] flex items-center justify-center mb-3">
-                  <Icon className="w-5 h-5 text-claw" />
-                </div>
-                <h3 className="text-sm font-semibold mb-1.5">{feat.title}</h3>
-                <p className="text-muted-foreground/80 text-xs leading-relaxed">
-                  {feat.desc}
-                </p>
-              </motion.div>
-            );
-          })}
-        </div>
-      </Section> */}
-
-      {/* ── Tech Stack ────────────────────────────────────────────── */}
-      {/* <Section className="py-12 px-4">
-        <p className="text-center text-[10px] text-muted-foreground/60 uppercase tracking-[0.25em] mb-5">
-          Powered by
-        </p>
-        <div className="flex flex-wrap justify-center gap-2 max-w-2xl mx-auto">
-          {techStack.map((tech, i) => (
-            <motion.span
-              key={tech}
-              initial={{ opacity: 0, scale: 0.85 }}
-              whileInView={{ opacity: 1, scale: 1 }}
-              viewport={{ once: true }}
-              transition={{ delay: i * 0.04, type: "spring" }}
-              whileHover={{ scale: 1.06 }}
-              className="px-3 py-1.5 rounded-full border border-foreground/8 bg-foreground/[0.03] text-xs text-muted-foreground font-medium cursor-default"
-            >
-              {tech}
-            </motion.span>
-          ))}
-        </div>
-      </Section> */}
-
-      {/* ── Final CTA ─────────────────────────────────────────────── */}
-      {/* <Section className="py-20 sm:py-28 px-4 text-center relative">
-        <div className="absolute inset-0 pointer-events-none overflow-hidden">
-          <motion.div
-            initial={{ opacity: 0 }}
-            whileInView={{ opacity: 1 }}
-            viewport={{ once: true }}
-            className="absolute bottom-0 left-1/2 -translate-x-1/2 w-[500px] h-[300px]"
-            style={{
-              background:
-                "radial-gradient(ellipse, rgba(196,148,40,0.07) 0%, transparent 70%)",
-            }}
-          />
-        </div>
-        <h2 className="text-2xl sm:text-4xl font-bold mb-4">
-          Ready to guard your{" "}
-          <span className="gradient-text">assets</span>?
-        </h2>
-        <p className="text-muted-foreground mb-8 max-w-md mx-auto text-sm">
-          Set up your AI-secured wallet in seconds. No gas fees, no
-          friction - just intelligent protection on BNB Chain.
-        </p>
-        <Button onClick={handleGoogleLogin} disabled={isLoading} className="text-lg px-8 py-4">
-          {isLoading ? (
-            <><Loader2 className="h-4 w-4 mr-2 animate-spin" />Signing in...</>
-          ) : (
-            "Login with Google"
-          )}
-        </Button>
-      </Section> */}
-
-      {/* ── Footer ────────────────────────────────────────────────── */}
-      {/* <footer className="py-8 px-4 border-t border-foreground/[0.04]">
-        <div className="max-w-4xl mx-auto flex flex-col items-center gap-4 text-center">
-          <motion.div
-            initial={{ opacity: 0, y: 8 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true }}
-            className="inline-flex items-center gap-2 px-5 py-2 rounded-full border border-claw/20 bg-claw/5"
-          >
-            <motion.span
-              animate={{ opacity: [1, 0.5, 1] }}
-              transition={{ repeat: Infinity, duration: 3 }}
-              className="w-1.5 h-1.5 rounded-full bg-claw shrink-0"
-            />
-            <span className="text-[11px] text-claw/60 font-medium">
-              Built for DoraHacks Good Vibes Only: OpenClaw Edition | BNBChain
-            </span>
-          </motion.div>
-        </div>
-      </footer> */}
+        {/* ── Right: live readout guardian card (landing hero) ── */}
+        <motion.div
+          className="flex justify-center lg:justify-end"
+          initial={{ opacity: 0, y: 24, scale: 0.98 }}
+          animate={{ opacity: 1, y: 0, scale: 1 }}
+          transition={{ delay: 0.15, duration: 0.6, type: "spring", bounce: 0.12 }}
+        >
+          <GuardianCard />
+        </motion.div>
+      </div>
     </div>
   );
 }

--- a/client/src/app/login/page.tsx
+++ b/client/src/app/login/page.tsx
@@ -124,7 +124,7 @@ export default function LoginPage() {
           <div className="mt-7 flex items-center gap-3 font-mono text-[11px] tracking-[0.12em] uppercase text-muted-foreground/70">
             <span>Secured by Safe</span>
             <span aria-hidden>·</span>
-            <span>OpenClaw on BNB Chain</span>
+            <span>NanoBot/Hermes on BNB Chain</span>
           </div>
         </motion.div>
 

--- a/client/src/components/GuardianCard.module.css
+++ b/client/src/components/GuardianCard.module.css
@@ -1,0 +1,371 @@
+/* ── Card shell ── */
+.card {
+  background: linear-gradient(160deg, #161208 0%, #1c1606 100%);
+  border: 1px solid rgba(245, 208, 96, 0.18);
+  border-radius: 22px;
+  padding: 22px 24px;
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.4), inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-height: 340px;
+  width: 100%;
+  max-width: 480px;
+}
+
+.card::before {
+  content: '';
+  position: absolute;
+  inset: -1px;
+  border-radius: 23px;
+  background: linear-gradient(180deg, rgba(245, 208, 96, 0.28), transparent 30%);
+  z-index: -1;
+  filter: blur(14px);
+  opacity: 0.5;
+}
+
+.fading {
+  animation: cardFade 0.55s 2.3s ease forwards;
+}
+
+@keyframes cardFade {
+  to { opacity: 0; }
+}
+
+/* ── Header ── */
+.head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-bottom: 14px;
+  border-bottom: 1px dashed rgba(255, 255, 255, 0.08);
+  margin-bottom: 2px;
+}
+
+.headTitle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ink-200);
+}
+
+.statusBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  color: var(--gold-400);
+  transition: color 0.35s ease;
+}
+
+.statusDanger { color: #E5524F; }
+
+.statusDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  animation: statusPulse 2.2s ease-out infinite;
+}
+
+@keyframes statusPulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50%       { opacity: 0.55; transform: scale(0.8); }
+}
+
+/* ── Sonar idle slot ── */
+.sonarSlot {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+  opacity: 1;
+  transition: opacity 0.35s ease;
+  pointer-events: auto;
+  z-index: 2;
+}
+
+.sonarSlotHidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.sonarWrap {
+  position: relative;
+  width: 72px;
+  height: 72px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.sonarRing {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  border: 1.5px solid rgba(245, 208, 96, 0.7);
+  animation: sonarExpand 2.4s ease-out infinite;
+}
+
+.sonarCenter {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: rgba(245, 208, 96, 0.1);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  animation: sonarBreath 2.4s ease-in-out infinite;
+  position: relative;
+  z-index: 1;
+}
+
+.sonarLabel {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: rgba(245, 208, 96, 0.5);
+  letter-spacing: 0.12em;
+  margin: 0;
+}
+
+@keyframes sonarExpand {
+  0%   { transform: scale(1);   opacity: 0.9; }
+  100% { transform: scale(2.2); opacity: 0;   }
+}
+
+@keyframes sonarBreath {
+  0%, 100% { transform: scale(1);    }
+  50%       { transform: scale(1.06); }
+}
+
+/* ── Transaction card ── */
+.txCard {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  padding: 0 14px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  overflow: hidden;
+  max-height: 0;
+  opacity: 0;
+  transition: max-height 0.4s ease, opacity 0.4s ease, padding 0.4s ease;
+}
+
+.txCardIn {
+  max-height: 70px;
+  opacity: 1;
+  padding: 12px 14px;
+}
+
+.txLeft {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.txIcon {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.06);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.txIcon img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.txWho {
+  font-family: var(--font-sans);
+  font-weight: 600;
+  font-size: 13px;
+  color: var(--ink-0);
+}
+
+.txAddr {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--ink-300);
+  margin-top: 2px;
+}
+
+.txRight { text-align: right; flex-shrink: 0; }
+
+.txAmount {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  font-size: 13px;
+  color: var(--ink-0);
+  white-space: nowrap;
+}
+
+.txSub {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--ink-300);
+  margin-top: 2px;
+}
+
+/* ── Check rows ── */
+.checkRow {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 7px 10px;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.02);
+  opacity: 0;
+  transform: translateY(5px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.checkRowIn {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.iconSlot {
+  position: relative;
+  width: 15px;
+  height: 15px;
+  flex-shrink: 0;
+}
+
+.iconFace {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: opacity 0.22s ease, transform 0.22s ease;
+}
+
+.iconGone {
+  opacity: 0;
+  transform: scale(0.5);
+}
+
+.checkLabel {
+  flex: 1;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: rgba(200, 203, 190, 0.75);
+  letter-spacing: 0.03em;
+}
+
+/* ── Result badges ── */
+.badge {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  padding: 3px 8px;
+  border-radius: 999px;
+  opacity: 0;
+  transform: scale(0.6);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  flex-shrink: 0;
+}
+
+.badgeIn {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.pass { background: rgba(63, 190, 118, 0.12); color: #3FBE76; }
+.warn { background: rgba(240, 179, 60,  0.12); color: #F0B33C; }
+.fail { background: rgba(229, 82,  79,  0.12); color: #E5524F; }
+
+/* ── Verdict bar ── */
+.verdict {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 13px;
+  border-radius: 10px;
+  opacity: 0;
+  transform: translateY(5px);
+  transition: opacity 0.4s ease, transform 0.4s ease;
+  margin-top: 2px;
+}
+
+.verdictIn {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.verdictSafe   { background: rgba(63, 190, 118, 0.07); border: 1px solid rgba(63, 190, 118, 0.22); }
+.verdictDanger { background: rgba(229,  82,  79, 0.07); border: 1px solid rgba(229,  82,  79, 0.22); }
+
+.verdictDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  flex-shrink: 0;
+  box-shadow: 0 0 6px currentColor;
+}
+
+.verdictLabel {
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+}
+
+.verdictSafe   .verdictLabel, .verdictSafe   .verdictDot { color: #3FBE76; }
+.verdictDanger .verdictLabel, .verdictDanger .verdictDot { color: #E5524F; }
+
+.verdictMsg {
+  flex: 1;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  color: var(--ink-300);
+  letter-spacing: 0.04em;
+}
+
+/* ── Execute row ── */
+.exec {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  font-size: 12px;
+  letter-spacing: 0.1em;
+  text-align: right;
+  padding: 6px 4px 2px;
+  opacity: 0;
+  transform: translateY(4px);
+  transition: opacity 0.35s ease, transform 0.35s ease;
+}
+
+.execIn     { opacity: 1; transform: translateY(0); }
+.execSafe   { color: #3FBE76; }
+.execDanger { color: #E5524F; }
+
+/* ── Spinner ── */
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.spinSvg  { display: block; animation: spin 1s linear infinite; }
+.checkSvg { display: block; }

--- a/client/src/components/GuardianCard.tsx
+++ b/client/src/components/GuardianCard.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import { ReactNode, useEffect, useState } from "react";
+import { TwinTick } from "@/components/BrandMark";
+import s from "./GuardianCard.module.css";
+
+function SwapIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#f5d060" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M17 3l4 4-4 4" />
+      <path d="M21 7H7" />
+      <path d="M7 21l-4-4 4-4" />
+      <path d="M3 17h14" />
+    </svg>
+  );
+}
+
+function ContractIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#E5524F" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M14 3H7a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V8z" />
+      <path d="M14 3v5h5" />
+      <path d="M9 13h6M9 17h6M9 9h2" />
+    </svg>
+  );
+}
+
+// ── Phase state machine ──────────────────────────────────────────────────────
+const PHASES = [
+  "idle", "tx",
+  "c1", "c1d",
+  "c2", "c2d",
+  "c3", "c3d",
+  "verdict", "exec", "done",
+] as const;
+type Phase = (typeof PHASES)[number];
+
+const pi = (p: Phase) => PHASES.indexOf(p);
+const gte = (curr: Phase, target: Phase) => pi(curr) >= pi(target);
+
+const DURATIONS: Record<Phase, number> = {
+  idle:    1800,
+  tx:       900,
+  c1:      1300, c1d: 380,
+  c2:      1100, c2d: 380,
+  c3:      1500, c3d: 600,
+  verdict: 1000,
+  exec:    1800,
+  done:    2900,
+};
+
+// ── Scenarios ────────────────────────────────────────────────────────────────
+interface Scenario {
+  tx: { who: string; addr: string; amount: string; sub: string; icon?: ReactNode };
+  checks: Array<{ label: string; result: "pass" | "warn" | "fail" }>;
+  verdict: "safe" | "danger";
+  action: string;
+}
+
+const SCENARIOS: Scenario[] = [
+  {
+    tx: { who: "PancakeSwap Router", addr: "0x10ED…A2c8", amount: "−0.42 BNB", sub: "BNB → USDC swap", icon: <SwapIcon /> },
+    checks: [
+      { label: "Checking onchain behaviour",  result: "pass" },
+      { label: "Scanning contract & tokens",  result: "pass" },
+      { label: "Simulating transaction",      result: "pass" },
+    ],
+    verdict: "safe",
+    action: "SIGNED · 14ms",
+  },
+  {
+    tx: { who: "Unknown contract", addr: "0xDRA1…nrZk", amount: "−ALL BNB", sub: "drain attempt", icon: <ContractIcon /> },
+    checks: [
+      { label: "Checking onchain behaviour",  result: "pass" },
+      { label: "Scanning contract & tokens",  result: "warn" },
+      { label: "Simulating transaction",      result: "fail" },
+    ],
+    verdict: "danger",
+    action: "BLOCKED",
+  },
+];
+
+// ── SVG helpers ──────────────────────────────────────────────────────────────
+function Spinner() {
+  return (
+    <svg className={s.spinSvg} width="15" height="15" viewBox="0 0 15 15" fill="none">
+      <circle cx="7.5" cy="7.5" r="5.5" stroke="rgba(245,208,96,0.15)" strokeWidth="2" />
+      <circle cx="7.5" cy="7.5" r="5.5" stroke="#f5d060" strokeWidth="2"
+        strokeDasharray="8 26" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function Check({ result }: { result: "pass" | "warn" | "fail" }) {
+  const c = result === "pass" ? "#3FBE76" : result === "warn" ? "#F0B33C" : "#E5524F";
+  const f = result === "pass" ? "rgba(63,190,118,0.12)" : result === "warn" ? "rgba(240,179,60,0.12)" : "rgba(229,82,79,0.12)";
+  return (
+    <svg className={s.checkSvg} width="15" height="15" viewBox="0 0 15 15" fill="none">
+      <circle cx="7.5" cy="7.5" r="6.5" fill={f} stroke={c} strokeWidth="1.4" />
+      {result === "pass" && <path d="M4.5 7.5l2 2 4-4" stroke={c} strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />}
+      {result === "warn" && <path d="M7.5 4.5v3.5M7.5 10.5v.3" stroke={c} strokeWidth="1.5" strokeLinecap="round" />}
+      {result === "fail" && <path d="M5 5l5 5M10 5l-5 5" stroke={c} strokeWidth="1.4" strokeLinecap="round" />}
+    </svg>
+  );
+}
+
+// ── Component ────────────────────────────────────────────────────────────────
+export function GuardianCard() {
+  const [idx, setIdx] = useState(0);
+  const [phase, setPhase] = useState<Phase>("idle");
+
+  useEffect(() => {
+    const t = setTimeout(() => {
+      const next = pi(phase) + 1;
+      if (next < PHASES.length) {
+        setPhase(PHASES[next]);
+      } else {
+        setIdx((i) => (i + 1) % SCENARIOS.length);
+        setPhase("idle");
+      }
+    }, DURATIONS[phase]);
+    return () => clearTimeout(t);
+  }, [phase]);
+
+  const sc = SCENARIOS[idx];
+  const txVisible = gte(phase, "tx");
+
+  const status = gte(phase, "verdict")
+    ? sc.verdict === "safe" ? "VERIFIED" : "BLOCKED"
+    : txVisible ? "WATCHING" : "LISTENING";
+
+  const CHECK_SPIN: Phase[] = ["c1", "c2", "c3"];
+  const CHECK_DONE: Phase[] = ["c1d", "c2d", "c3d"];
+
+  return (
+    <aside className={`${s.card} ${phase === "done" ? s.fading : ""}`}>
+      {/* ── Header ── */}
+      <div className={s.head}>
+        <span className={s.headTitle}>
+          <TwinTick size={18} halo="none" />
+          Zhentan · live readout
+        </span>
+        <span className={`${s.statusBadge} ${gte(phase, "verdict") && sc.verdict === "danger" ? s.statusDanger : ""}`}>
+          <span className={s.statusDot} />
+          {status}
+        </span>
+      </div>
+
+      {/* ── Idle: sonar animation centered ── */}
+      <div className={`${s.sonarSlot} ${txVisible ? s.sonarSlotHidden : ""}`}>
+        <div className={s.sonarWrap}>
+          {[0, 1, 2].map((i) => (
+            <span key={i} className={s.sonarRing} style={{ animationDelay: `${i * 0.8}s` }} />
+          ))}
+          <div className={s.sonarCenter}>
+            <TwinTick size={22} halo="none" style={{ opacity: 0.85 }} />
+          </div>
+        </div>
+        <p className={s.sonarLabel}>Zhentan is monitoring</p>
+      </div>
+
+      {/* ── Transaction card ── */}
+      <div className={`${s.txCard} ${txVisible ? s.txCardIn : ""}`}>
+        <div className={s.txLeft}>
+          {sc.tx.icon && <span className={s.txIcon}>{sc.tx.icon}</span>}
+          <div>
+            <div className={s.txWho}>{sc.tx.who}</div>
+            <div className={s.txAddr}>{sc.tx.addr}</div>
+          </div>
+        </div>
+        <div className={s.txRight}>
+          <div className={s.txAmount}>{sc.tx.amount}</div>
+          <div className={s.txSub}>{sc.tx.sub}</div>
+        </div>
+      </div>
+
+      {/* ── Checks ── */}
+      {sc.checks.map((check, i) => {
+        const spinning = gte(phase, CHECK_SPIN[i]);
+        const done     = gte(phase, CHECK_DONE[i]);
+        const resClass = check.result === "pass" ? s.pass : check.result === "warn" ? s.warn : s.fail;
+
+        return (
+          <div key={i} className={`${s.checkRow} ${spinning ? s.checkRowIn : ""}`}>
+            <span className={s.iconSlot}>
+              <span className={`${s.iconFace} ${done ? s.iconGone : ""}`}><Spinner /></span>
+              <span className={`${s.iconFace} ${done ? "" : s.iconGone}`}><Check result={check.result} /></span>
+            </span>
+            <span className={s.checkLabel}>{check.label}</span>
+            <span className={`${s.badge} ${resClass} ${done ? s.badgeIn : ""}`}>
+              {check.result === "pass" ? "PASS" : check.result === "warn" ? "WARN" : "FAIL"}
+            </span>
+          </div>
+        );
+      })}
+
+      {/* ── Verdict ── */}
+      <div className={`${s.verdict} ${gte(phase, "verdict") ? s.verdictIn : ""} ${sc.verdict === "safe" ? s.verdictSafe : s.verdictDanger}`}>
+        <span className={s.verdictDot} />
+        <span className={s.verdictLabel}>{sc.verdict === "safe" ? "SAFE" : "THREAT DETECTED"}</span>
+        <span className={s.verdictMsg}>{sc.verdict === "safe" ? "All checks passed" : "Drainer fingerprint matched"}</span>
+      </div>
+
+      {/* ── Execute ── */}
+      <div className={`${s.exec} ${gte(phase, "exec") ? s.execIn : ""} ${sc.verdict === "safe" ? s.execSafe : s.execDanger}`}>
+        ◆ {sc.action}
+      </div>
+    </aside>
+  );
+}

--- a/client/src/components/RequestDetailDialog.tsx
+++ b/client/src/components/RequestDetailDialog.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useRef, useState } from "react";
-import { motion } from "framer-motion";
+import { motion, AnimatePresence } from "framer-motion";
+import Image from "next/image";
 import type { QueuedRequest } from "@/types";
 import { truncateAddress, formatDate } from "@/lib/format";
 import { useApiClient } from "@/lib/api/client";
@@ -12,11 +13,11 @@ import { UsdcIcon } from "./icons/UsdcIcon";
 import {
   FileText,
   ArrowUpRight,
-  CheckCircle2,
-  XCircle,
-  Clock,
   Send,
   ShieldCheck,
+  ShieldAlert,
+  ChevronDown,
+  ChevronUp,
   ExternalLink,
 } from "lucide-react";
 import { clsx } from "clsx";
@@ -42,94 +43,126 @@ type ScreeningPhase =
   | "rejected"
   | "error";
 
+/** Polished status visuals shared with the activity (transaction) dialog. */
 function StatusAnimation({ status }: { status: QueuedRequest["status"] }) {
-  const common = "rounded-2xl flex items-center justify-center";
-  const size = "w-20 h-20";
-
   switch (status) {
     case "queued":
-      return (
-        <motion.div
-          className={`${size} ${common} bg-watch/15 text-watch`}
-          initial={{ scale: 0.8, opacity: 0 }}
-          animate={{
-            scale: 1,
-            opacity: 1,
-            rotate: [0, 5, -5, 0],
-          }}
-          transition={{
-            opacity: { duration: 0.3 },
-            scale: { type: "spring", bounce: 0.4 },
-            rotate: { repeat: Infinity, duration: 2, ease: "easeInOut" },
-          }}
-        >
-          <Clock className="h-10 w-10" />
-        </motion.div>
-      );
     case "approved":
-      return (
-        <motion.div
-          className={`${size} ${common} bg-gold/15 text-gold`}
-          initial={{ scale: 0.8, opacity: 0 }}
-          animate={{ scale: [1, 1.05, 1], opacity: 1 }}
-          transition={{
-            opacity: { duration: 0.3 },
-            scale: { repeat: Infinity, duration: 1.5, ease: "easeInOut" },
-          }}
-        >
-          <Send className="h-10 w-10" />
-        </motion.div>
-      );
+      return <ReviewAnimation size={80} />;
     case "executed":
-      return (
-        <motion.div
-          className={`${size} ${common} bg-gold/20 text-gold`}
-          initial={{ scale: 0, opacity: 0 }}
-          animate={{ scale: [0, 1.2, 1], opacity: 1 }}
-          transition={{
-            duration: 0.5,
-            scale: { times: [0, 0.6, 1], duration: 0.5 },
-          }}
-        >
-          <CheckCircle2 className="h-10 w-10" />
-        </motion.div>
-      );
+      return <ExecutedAnimation size={80} />;
     case "rejected":
-      return (
-        <motion.div
-          className={`${size} ${common} bg-danger/15 text-danger`}
-          initial={{ scale: 0.8, opacity: 0 }}
-          animate={{ scale: 1, opacity: 1, x: [0, -6, 6, -4, 4, 0] }}
-          transition={{
-            opacity: { duration: 0.3 },
-            scale: { type: "spring", bounce: 0.3 },
-            x: { duration: 0.4 },
-          }}
-        >
-          <XCircle className="h-10 w-10" />
-        </motion.div>
-      );
+      return <RejectedAnimation size={80} />;
   }
 }
 
-function RiskBadge({ score }: { score: number }) {
-  const color =
-    score < 40
-      ? "bg-gold/15 text-gold"
-      : score <= 70
-        ? "bg-watch/15 text-watch"
-        : "bg-danger/15 text-danger";
-  const label = score < 40 ? "Low" : score <= 70 ? "Medium" : "High";
+/** Severity bucket → tailwind text/bg classes (mirrors TransactionDetailDialog). */
+function severity(score: number): { tone: "safe" | "watch" | "danger"; text: string; bg: string; label: string } {
+  if (score >= 70) return { tone: "danger", text: "text-danger", bg: "bg-danger", label: "High" };
+  if (score >= 40) return { tone: "watch", text: "text-watch", bg: "bg-watch", label: "Medium" };
+  return { tone: "safe", text: "text-safe", bg: "bg-safe", label: "Low" };
+}
+
+/**
+ * Expandable "View analysis" panel — same treatment as the activity dialog,
+ * adapted to request fields (riskScore + free-text riskNotes, plus the
+ * rejection reason for blocked requests).
+ */
+function RequestAnalysisSection({
+  riskScore,
+  riskNotes,
+  rejectReason,
+}: {
+  riskScore?: number;
+  riskNotes?: string;
+  rejectReason?: string;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const sev = riskScore != null ? severity(riskScore) : null;
 
   return (
-    <span
-      className={clsx(
-        "inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium",
-        color
-      )}
-    >
-      {label} ({score})
-    </span>
+    <div className="rounded-2xl bg-foreground/6 overflow-hidden">
+      <button
+        type="button"
+        onClick={() => setExpanded((e) => !e)}
+        aria-expanded={expanded}
+        className="w-full flex items-center gap-2 px-4 py-3 text-left hover:bg-foreground/6 transition-colors cursor-pointer"
+      >
+        <ShieldAlert className="h-4 w-4 text-watch/90 shrink-0" />
+        <span className="text-sm font-medium text-foreground flex-1">View analysis</span>
+        {sev && (
+          <span className={`font-mono text-xs font-semibold ${sev.text}`}>
+            {riskScore}
+            <span className="text-muted-foreground/60">/100</span>
+          </span>
+        )}
+        {expanded ? (
+          <ChevronUp className="h-4 w-4 text-muted-foreground/80 shrink-0" />
+        ) : (
+          <ChevronDown className="h-4 w-4 text-muted-foreground/80 shrink-0" />
+        )}
+      </button>
+      <AnimatePresence initial={false}>
+        {expanded && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            className="border-t border-foreground/10"
+          >
+            <div className="px-4 py-3.5 space-y-3.5 text-sm">
+              {/* Risk score + bar */}
+              {riskScore != null && sev && (
+                <div>
+                  <div className="flex items-center justify-between mb-1.5">
+                    <span className="text-muted-foreground/80">Risk score</span>
+                    <span className={`font-mono font-semibold ${sev.text}`}>
+                      {riskScore}
+                      <span className="text-muted-foreground/60">/100</span>
+                    </span>
+                  </div>
+                  <div className="h-1.5 rounded-pill bg-foreground/10 overflow-hidden">
+                    <motion.span
+                      className={`block h-full rounded-pill ${sev.bg}`}
+                      initial={{ width: 0 }}
+                      animate={{ width: `${Math.min(100, Math.max(0, riskScore))}%` }}
+                      transition={{ duration: 0.5, ease: "easeOut" }}
+                    />
+                  </div>
+                </div>
+              )}
+
+              {/* Verdict / level */}
+              {sev && (
+                <div className="flex items-center justify-between">
+                  <span className="text-muted-foreground/80">Verdict</span>
+                  <span className={`font-mono uppercase tracking-wide text-xs font-semibold ${sev.text}`}>
+                    {sev.label}
+                  </span>
+                </div>
+              )}
+
+              {/* Agent notes */}
+              {riskNotes && (
+                <div>
+                  <span className="text-muted-foreground/80 block mb-1">Message</span>
+                  <p className="text-foreground/85 leading-relaxed">{riskNotes}</p>
+                </div>
+              )}
+
+              {/* Rejection reason */}
+              {rejectReason && (
+                <div>
+                  <span className="text-muted-foreground/80 block mb-1">Rejection reason</span>
+                  <p className="text-danger leading-relaxed">{rejectReason}</p>
+                </div>
+              )}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
   );
 }
 
@@ -275,32 +308,45 @@ export function RequestDetailDialog({
       className="max-w-md"
     >
       <div className="space-y-6">
-        {/* Status animation */}
-        <div className="flex flex-col items-center gap-3">
-          <StatusAnimation status={request.status} />
-          <span
-            className={clsx(
-              "text-sm font-semibold",
-              request.status === "executed" || request.status === "approved"
-                ? "text-gold"
-                : request.status === "rejected"
-                  ? "text-danger"
-                  : "text-watch"
-            )}
+        {/* Status animation — morphs in place when the status changes */}
+        <AnimatePresence mode="wait">
+          <motion.div
+            key={request.status}
+            className="flex flex-col items-center gap-3"
+            initial={{ opacity: 0, scale: 0.92 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.92 }}
+            transition={{ duration: 0.28, ease: "easeOut" }}
           >
-            {statusLabels[request.status]}
-          </span>
-        </div>
+            <StatusAnimation status={request.status} />
+            <span
+              className={clsx(
+                "text-sm font-semibold",
+                request.status === "executed" || request.status === "approved"
+                  ? "text-gold"
+                  : request.status === "rejected"
+                    ? "text-danger"
+                    : "text-watch"
+              )}
+            >
+              {statusLabels[request.status]}
+            </span>
+          </motion.div>
+        </AnimatePresence>
 
-        {/* Amount row */}
-        <div className="flex items-center gap-3 rounded-2xl bg-foreground/6 p-4">
-          <div className="w-10 h-10 rounded-2xl bg-foreground/8 flex items-center justify-center text-gold">
+        {/* Hero amount — op icon + token avatar + amount (mirrors activity dialog) */}
+        <div className="rounded-2xl bg-foreground/6 p-4 flex items-center gap-3">
+          <div className="w-10 h-10 rounded-2xl bg-foreground/[0.08] flex items-center justify-center shrink-0 text-gold">
             {isInvoice ? <FileText className="h-5 w-5" /> : <ArrowUpRight className="h-5 w-5" />}
           </div>
-          <UsdcIcon size={24} className="shrink-0 opacity-90" />
-          <span className="text-lg font-semibold text-foreground">
-            {request.amount} {request.token}
-          </span>
+          <div className="w-9 h-9 rounded-full bg-foreground/8 flex items-center justify-center shrink-0 overflow-hidden">
+            <UsdcIcon size={22} className="opacity-90" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <p className="text-base font-semibold text-foreground">
+              {request.amount} {request.token}
+            </p>
+          </div>
         </div>
 
         {/* Instruction from the agent (transfer requests) */}
@@ -336,13 +382,24 @@ export function RequestDetailDialog({
             <dt className="text-muted-foreground/80">Queued</dt>
             <dd className="text-foreground/80">{formatDate(request.queuedAt)}</dd>
           </div>
-          <div className="flex justify-between gap-4">
-            <dt className="text-muted-foreground/80">To</dt>
-            <dd
-              className="font-mono text-foreground truncate min-w-0 max-w-[50%] sm:max-w-[200px]"
-              title={request.to}
-            >
-              {truncateAddress(request.to)}
+          {request.executedAt && (
+            <div className="flex justify-between gap-4">
+              <dt className="text-muted-foreground/80">Executed</dt>
+              <dd className="text-foreground/80 truncate min-w-0">{formatDate(request.executedAt)}</dd>
+            </div>
+          )}
+          <div className="flex justify-between gap-2 sm:gap-4">
+            <dt className="text-muted-foreground/80 shrink-0">{isInvoice ? "Pay to" : "To"}</dt>
+            <dd className="min-w-0 max-w-[50%] sm:max-w-[200px] truncate" title={request.to}>
+              <a
+                href={`${BSC_EXPLORER_URL}/address/${request.to}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="group inline-flex items-center gap-2 font-mono text-foreground hover:text-foreground transition-colors underline-offset-4 hover:underline truncate"
+              >
+                <ExternalLink className="h-3.5 w-3.5 shrink-0 text-muted-foreground/80 group-hover:text-foreground" />
+                <span className="truncate">{truncateAddress(request.to, 10)}</span>
+              </a>
             </dd>
           </div>
         </dl>
@@ -387,25 +444,33 @@ export function RequestDetailDialog({
           </div>
         )}
 
-        {/* Risk assessment */}
-        {request.riskScore != null && (
-          <div className="rounded-2xl bg-foreground/4 p-3">
-            <div className="flex items-center justify-between mb-1">
-              <p className="text-xs text-muted-foreground/80">Risk Assessment</p>
-              <RiskBadge score={request.riskScore} />
-            </div>
-            {request.riskNotes && (
-              <p className="text-xs text-muted-foreground">{request.riskNotes}</p>
-            )}
-          </div>
+        {/* Agent analysis — expandable: score, verdict, notes, rejection reason */}
+        {(request.riskScore != null ||
+          request.riskNotes ||
+          (request.status === "rejected" && request.rejectReason)) && (
+          <RequestAnalysisSection
+            riskScore={request.riskScore}
+            riskNotes={request.riskNotes}
+            rejectReason={request.status === "rejected" ? request.rejectReason : undefined}
+          />
         )}
 
-        {/* Rejection info */}
-        {request.status === "rejected" && request.rejectReason && (
-          <div className="rounded-2xl bg-danger/10 p-3">
-            <p className="text-xs text-danger/70 mb-1">Rejection Reason</p>
-            <p className="text-sm text-danger">{request.rejectReason}</p>
-          </div>
+        {/* BSCScan explorer link — executed requests */}
+        {request.txHash && (
+          <motion.a
+            href={`${BSC_EXPLORER_URL}/tx/${request.txHash}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center justify-center gap-2 w-full rounded-2xl py-3 bg-foreground/8 text-foreground/80 hover:text-foreground hover:bg-foreground/12 transition-colors text-sm font-medium"
+            whileHover={{ scale: 1.02 }}
+            whileTap={{ scale: 0.98 }}
+          >
+            <span className="relative w-[18px] h-[18px] shrink-0">
+              <Image src="/bscscan.png" alt="" fill className="object-contain rounded" sizes="18px" />
+            </span>
+            View on BSC Explorer
+            <ExternalLink className="h-3.5 w-3.5 opacity-50" />
+          </motion.a>
         )}
 
         {/* Action buttons (only for queued requests) */}

--- a/client/src/components/RequestList.tsx
+++ b/client/src/components/RequestList.tsx
@@ -5,29 +5,14 @@ import { motion } from "framer-motion";
 import type { QueuedRequest } from "@/types";
 import { RequestRow } from "./RequestRow";
 import { RequestDetailDialog } from "./RequestDetailDialog";
-import { Card } from "./ui/Card";
 import { Skeleton } from "./ui/Skeleton";
-import { Bell } from "lucide-react";
 
 const containerVariants = {
   hidden: { opacity: 0 },
   visible: {
     opacity: 1,
     transition: {
-      staggerChildren: 0.1,
-    },
-  },
-};
-
-const headerVariants = {
-  hidden: { opacity: 0, y: 20 },
-  visible: {
-    opacity: 1,
-    y: 0,
-    transition: {
-      duration: 0.5,
-      type: "spring" as const,
-      bounce: 0.18,
+      staggerChildren: 0.06,
     },
   },
 };
@@ -53,26 +38,11 @@ export function RequestList({
   if (!loading && requests.length === 0) return null;
 
   return (
-    <Card className="p-6">
-      <motion.div
-        className="flex items-center gap-2 mb-4"
-        initial="hidden"
-        animate="visible"
-        variants={headerVariants}
-      >
-        <Bell className="h-4 w-4 text-gold" />
-        <h2 className="text-sm font-semibold text-foreground tracking-wide">
-          <span className="text-gold">&rsaquo;</span> Requests
-        </h2>
-      </motion.div>
-
+    <>
       {loading ? (
-        <div className="space-y-1">
+        <div className="divide-y divide-border/60">
           {[1, 2, 3].map((i) => (
-            <div
-              key={i}
-              className="flex items-center gap-4 px-4 py-3 rounded-2xl"
-            >
+            <div key={i} className="flex items-center gap-4 px-2 sm:px-3 py-3.5">
               <Skeleton className="h-10 w-10 rounded-2xl shrink-0" />
               <div className="flex-1 min-w-0 space-y-2">
                 <div className="flex items-center gap-2">
@@ -88,7 +58,7 @@ export function RequestList({
         </div>
       ) : (
         <motion.div
-          className="space-y-1"
+          className="divide-y divide-border/60"
           initial="hidden"
           animate="visible"
           variants={containerVariants}
@@ -112,6 +82,6 @@ export function RequestList({
         onReject={onReject}
         onRefresh={onRefresh}
       />
-    </Card>
+    </>
   );
 }

--- a/client/src/components/RequestRow.tsx
+++ b/client/src/components/RequestRow.tsx
@@ -70,19 +70,19 @@ export function RequestRow({ request, index = 0, onClick }: RequestRowProps) {
       onClick={onClick}
       onKeyDown={onClick ? (e) => e.key === "Enter" && onClick() : undefined}
       className={clsx(
-        "flex items-center gap-3 sm:gap-4 px-3 sm:px-4 py-3 hover:bg-foreground/6 rounded-2xl transition-all min-h-[3.5rem] touch-manipulation",
+        "group flex items-center gap-3 sm:gap-4 px-1 py-3.5 hover:bg-foreground/[0.035] transition-colors min-h-[3.5rem] touch-manipulation",
         onClick && "cursor-pointer"
       )}
-      initial={{ opacity: 0, y: 30, scale: 0.98 }}
-      animate={{ opacity: 1, y: 0, scale: 1 }}
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
       transition={{
-        delay: index * 0.1,
-        duration: 0.5,
+        delay: Math.min(index, 8) * 0.05,
+        duration: 0.4,
         type: "spring",
         bounce: 0.15,
       }}
     >
-      <div className="w-10 h-10 rounded-2xl bg-foreground/8 flex items-center justify-center shrink-0 text-gold">
+      <div className="w-10 h-10 rounded-xl bg-foreground/8 flex items-center justify-center shrink-0 text-gold transition-colors group-hover:bg-foreground/[0.12]">
         {isInvoice ? <FileText className="h-5 w-5" /> : <ArrowUpRight className="h-5 w-5" />}
       </div>
 

--- a/client/src/components/RightRail.tsx
+++ b/client/src/components/RightRail.tsx
@@ -17,6 +17,10 @@ import { useScreeningStatus } from "@/app/context/ScreeningStatusContext";
 import { useActivityData } from "@/app/context/ActivityDataContext";
 import { truncateAddress, timeAgo, formatTokenAmount } from "@/lib/format";
 import { TwinTick } from "@/components/BrandMark";
+import { TransactionDetailDialog } from "@/components/TransactionDetailDialog";
+import { RequestDetailDialog } from "@/components/RequestDetailDialog";
+import { useRequestActions } from "@/hooks/useRequestActions";
+import type { TransactionWithStatus, QueuedRequest } from "@/types";
 
 /* ── Rolling agent readout — rotating idle messages ─────────────── */
 
@@ -85,7 +89,11 @@ function RollingReadout({ isActive }: { isActive: boolean }) {
 function LiveReadout({ isActive }: { isActive: boolean }) {
   return (
     <div className="p-3 pt-4 flex-1 flex min-h-0">
-      <div className="relative flex-1 overflow-hidden rounded-xl bg-foreground/[0.03] border border-border">
+      <Link
+        href="/settings"
+        aria-label="Agent screening settings"
+        className="group relative flex-1 overflow-hidden rounded-xl bg-foreground/[0.03] border border-border transition-colors hover:bg-foreground/[0.05] hover:border-gold/25"
+      >
         {/* Gold top-edge accent */}
         <div
           className="absolute top-0 left-0 right-0 h-px"
@@ -120,7 +128,7 @@ function LiveReadout({ isActive }: { isActive: boolean }) {
           {/* Rolling agent text */}
           <RollingReadout isActive={isActive} />
         </div>
-      </div>
+      </Link>
     </div>
   );
 }
@@ -136,6 +144,7 @@ function PendingCard({
   meta,
   note,
   risk,
+  onClick,
 }: {
   kind: "queued" | "review";
   amount: string;
@@ -145,6 +154,8 @@ function PendingCard({
   meta?: string;
   note: string;
   risk?: number | null;
+  /** When set, the whole card is clickable (opens the detail dialog) and no CTA is shown. */
+  onClick?: () => void;
 }) {
   const isQueued = kind === "queued";
   const accentRgba = isQueued
@@ -157,7 +168,15 @@ function PendingCard({
       initial={{ opacity: 0, y: 6 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.28 }}
-      className="relative overflow-hidden rounded-xl bg-foreground/[0.04] border border-border"
+      role={onClick ? "button" : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      onClick={onClick}
+      onKeyDown={onClick ? (e) => e.key === "Enter" && onClick() : undefined}
+      className={clsx(
+        "relative overflow-hidden rounded-xl bg-foreground/[0.04] border border-border",
+        onClick &&
+          "cursor-pointer transition-colors hover:bg-foreground/[0.06] hover:border-gold/25"
+      )}
     >
       {/* Top accent gradient line */}
       <div
@@ -212,19 +231,19 @@ function PendingCard({
           </span>
         </div>
 
-        {/* CTA */}
-        <Link
-          href="/requests"
-          className={clsx(
-            "mt-3 w-full inline-flex items-center justify-center gap-1.5 py-2.5 rounded-lg text-xs font-semibold transition-colors",
-            isQueued
-              ? "bg-watch/[0.13] text-watch hover:bg-watch/20"
-              : "bg-gold/[0.13] text-gold-light hover:bg-gold/20"
-          )}
-        >
-          {isQueued ? "Screen & accept" : "Approve & send"}
-          <ArrowRight className="h-3.5 w-3.5" />
-        </Link>
+        {/* CTA → full queue. Agent-proposed only; the user-proposed card just
+            opens the detail dialog. The card itself opens a dialog (onClick), so
+            stop propagation here to let the button navigate instead. */}
+        {isQueued && (
+          <Link
+            href="/requests"
+            onClick={(e) => e.stopPropagation()}
+            className="mt-3 w-full inline-flex items-center justify-center gap-1.5 py-2.5 rounded-lg text-xs font-semibold transition-colors bg-watch/[0.13] text-watch hover:bg-watch/20"
+          >
+            Screen &amp; accept
+            <ArrowRight className="h-3.5 w-3.5" />
+          </Link>
+        )}
       </div>
     </motion.div>
   );
@@ -235,6 +254,9 @@ function PendingCard({
 export function RightRail() {
   const { isScreeningActive } = useScreeningStatus();
   const { requests, transactions } = useActivityData();
+  const { handleApprove, handleReject, refresh } = useRequestActions();
+  const [selectedTx, setSelectedTx] = useState<TransactionWithStatus | null>(null);
+  const [selectedRequest, setSelectedRequest] = useState<QueuedRequest | null>(null);
 
   // Most recent agent-proposed request (queued)
   const lastQueued = useMemo(() => {
@@ -277,8 +299,12 @@ export function RightRail() {
           "radial-gradient(90% 55% at 50% 42%, rgba(196,148,40,0.10) 0%, rgba(196,148,40,0.03) 30%, transparent 62%), var(--ink-950)",
       }}
     >
-      {/* Agent status header */}
-      <div className="px-5 pt-[18px] pb-4 border-b border-border shrink-0">
+      {/* Agent status header — opens screening settings */}
+      <Link
+        href="/settings"
+        aria-label="Agent screening settings"
+        className="block px-5 pt-[18px] pb-4 border-b border-border shrink-0 transition-colors hover:bg-foreground/[0.03]"
+      >
         <div className="flex items-center gap-3">
           <div className="relative w-10 h-10 shrink-0 flex items-center justify-center">
             {isScreeningActive && (
@@ -325,14 +351,31 @@ export function RightRail() {
             {isScreeningActive ? "Live" : "Off"}
           </span>
         </div>
-      </div>
+      </Link>
 
       {/* Pending section */}
-      <div className={clsx(!hasPending && "flex-1 min-h-0 flex flex-col")}>
+      <div className={clsx("flex flex-col min-h-0", !hasPending && "flex-1")}>
+        <AnimatePresence mode="wait">
         {!hasPending ? (
-          <LiveReadout isActive={isScreeningActive} />
+          <motion.div
+            key="rail-empty"
+            className="flex-1 flex min-h-0"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.25 }}
+          >
+            <LiveReadout isActive={isScreeningActive} />
+          </motion.div>
         ) : (
-          <div className="px-3 pt-4 pb-2 flex flex-col gap-3">
+          <motion.div
+            key="rail-pending"
+            className="px-3 pt-4 pb-2 flex flex-col gap-3"
+            initial={{ opacity: 0, y: 6 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.25 }}
+          >
             {lastQueued && (
               <PendingCard
                 kind="queued"
@@ -355,6 +398,7 @@ export function RightRail() {
                     : "Agent prepared this — review before you sign.")
                 }
                 risk={lastQueued.riskScore}
+                onClick={() => setSelectedRequest(lastQueued)}
               />
             )}
             {lastReview && (
@@ -370,6 +414,7 @@ export function RightRail() {
                   `Agent screened${lastReview.riskScore != null ? ` · risk ${lastReview.riskScore}` : ""} — needs your approval.`
                 }
                 risk={lastReview.riskScore}
+                onClick={() => setSelectedTx(lastReview)}
               />
             )}
             <Link
@@ -379,8 +424,9 @@ export function RightRail() {
               Open full queue
               <ArrowRight className="h-3 w-3" />
             </Link>
-          </div>
+          </motion.div>
         )}
+        </AnimatePresence>
       </div>
 
       {/* Agent decisions stream */}
@@ -401,13 +447,15 @@ export function RightRail() {
             {decisions.map((tx, i) => {
               const rejected = tx.status === "rejected";
               return (
-                <motion.div
+                <motion.button
                   key={`${tx.id}-${i}`}
+                  type="button"
+                  onClick={() => setSelectedTx(tx)}
                   initial={{ opacity: 0, y: 8 }}
                   animate={{ opacity: 1, y: 0 }}
                   transition={{ delay: i * 0.05, duration: 0.3 }}
                   className={clsx(
-                    "flex items-center gap-3 px-3 py-2.5 rounded-md hover:bg-foreground/[0.03] transition-colors",
+                    "w-full text-left flex items-center gap-3 px-3 py-2.5 rounded-md hover:bg-foreground/[0.04] transition-colors cursor-pointer",
                     rejected && "opacity-55"
                   )}
                 >
@@ -432,14 +480,29 @@ export function RightRail() {
                       rejected ? "text-danger" : "text-safe"
                     )}
                   >
-                    {rejected ? "Blocked" : "Auto-signed"}
+                    {rejected ? "Blocked" : "Approved"}
                   </span>
-                </motion.div>
+                </motion.button>
               );
             })}
           </div>
         </>
       )}
+
+      <TransactionDetailDialog
+        tx={selectedTx}
+        open={selectedTx !== null}
+        onClose={() => setSelectedTx(null)}
+      />
+
+      <RequestDetailDialog
+        request={selectedRequest}
+        open={selectedRequest !== null}
+        onClose={() => setSelectedRequest(null)}
+        onApprove={handleApprove}
+        onReject={handleReject}
+        onRefresh={refresh}
+      />
     </aside>
   );
 }

--- a/client/src/components/SendPanel.tsx
+++ b/client/src/components/SendPanel.tsx
@@ -7,9 +7,11 @@ import { motion } from "framer-motion";
 import { Button } from "./ui/Button";
 import { proposeTransaction } from "@/lib/propose";
 import { useAuth } from "@/app/context/AuthContext";
+import { useActivityData } from "@/app/context/ActivityDataContext";
+import { useLiveTransaction } from "@/hooks/useLiveTransaction";
 import { UsdcIcon } from "./icons/UsdcIcon";
 import { ThemeLoaderSpinner } from "./ThemeLoader";
-import { ExecutedAnimation, ReviewAnimation } from "./animations/StatusAnimation";
+import { ExecutedAnimation, ReviewAnimation, RejectedAnimation } from "./animations/StatusAnimation";
 import { ChevronDown, ArrowUpRight, CheckCircle2, ExternalLink, Clock, Coins, MessageCircle, X, UserRound } from "lucide-react";
 import { truncateAddress, formatDate, statusLabel, formatTokenAmount } from "@/lib/format";
 import { BSC_EXPLORER_URL } from "@/lib/constants";
@@ -31,6 +33,7 @@ interface SendPanelProps {
 export function SendPanel({ onSuccess, onClose, onRefreshActivities, tokens, screeningMode = true }: SendPanelProps) {
   const { user, wallet, getOwnerAccount, telegramUserId, identityToken } = useAuth();
   const api = useApiClient();
+  const { addOptimisticTransaction } = useActivityData();
   const router = useRouter();
   const [showTgRequiredModal, setShowTgRequiredModal] = useState(false);
   const [recipient, setRecipient] = useState("");
@@ -42,7 +45,7 @@ export function SendPanel({ onSuccess, onClose, onRefreshActivities, tokens, scr
   const [resolveError, setResolveError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [sendPhase, setSendPhase] = useState<"form" | "proposing" | "proposed" | "sending" | "success">("form");
+  const [sendPhase, setSendPhase] = useState<"form" | "proposing" | "proposed" | "sending" | "success" | "rejected">("form");
   const [proposedTx, setProposedTx] = useState<TransactionWithStatus | null>(null);
   const [executedResult, setExecutedResult] = useState<{
     to: string;
@@ -82,6 +85,32 @@ export function SendPanel({ onSuccess, onClose, onRefreshActivities, tokens, scr
   const insufficientFunds = amountNum > 0 && amountNum > balanceNum;
 
   useEffect(() => { resetAmount(); }, [selectedToken?.id]);
+
+  // Live-track the proposed tx so the "Proposed" screen transitions in place when
+  // the agent (or the owner via Telegram) resolves it — no waiting on a refresh.
+  const liveProposed = useLiveTransaction(
+    sendPhase === "proposed" && proposedTx ? proposedTx.id : null
+  );
+  useEffect(() => {
+    if (!liveProposed) return;
+    if (liveProposed.status === "executed") {
+      setExecutedResult({
+        to: liveProposed.to,
+        amount: liveProposed.amount,
+        token: liveProposed.token,
+        txHash: liveProposed.txHash ?? "",
+        executedAt: liveProposed.executedAt ?? new Date().toISOString(),
+        tokenIconUrl: liveProposed.tokenIconUrl ?? undefined,
+      });
+      setSendPhase("success");
+    } else if (liveProposed.status === "rejected") {
+      setProposedTx((prev) => (prev ? { ...prev, ...liveProposed } : liveProposed));
+      setSendPhase("rejected");
+    } else if (liveProposed.status === "in_review") {
+      // Agent flagged it for review — keep the pending screen but reflect the update.
+      setProposedTx((prev) => (prev ? { ...prev, ...liveProposed } : liveProposed));
+    }
+  }, [liveProposed]);
 
   const resolveRecipient = useCallback(async (value: string) => {
     const trimmed = value.trim();
@@ -211,7 +240,10 @@ export function SendPanel({ onSuccess, onClose, onRefreshActivities, tokens, scr
         });
         setSendPhase("success");
       } else {
-        setProposedTx({ ...pendingTx, status: "pending" });
+        const optimistic: TransactionWithStatus = { ...pendingTx, status: "pending" };
+        setProposedTx(optimistic);
+        // Surface it in the rail/activity immediately, ahead of the next poll.
+        addOptimisticTransaction(optimistic);
         setSendPhase("proposed");
       }
     } catch (err) {
@@ -390,7 +422,7 @@ export function SendPanel({ onSuccess, onClose, onRefreshActivities, tokens, scr
     );
   }
 
-  if (!screeningMode && sendPhase === "success" && executedResult) {
+  if (sendPhase === "success" && executedResult) {
     const { to, amount: amt, token, txHash, executedAt } = executedResult;
     const explorerTxUrl = txHash ? `${BSC_EXPLORER_URL}/tx/${txHash}` : null;
     return (
@@ -437,6 +469,53 @@ export function SendPanel({ onSuccess, onClose, onRefreshActivities, tokens, scr
           onClick={() => {
             setSendPhase("form");
             setExecutedResult(null);
+            clearRecipient();
+            resetAmount();
+            onSuccess();
+          }}
+          className="w-full py-3.5"
+        >
+          Done
+        </Button>
+      </div>
+    );
+  }
+
+  // Screening ON: blocked/rejected by the agent
+  if (sendPhase === "rejected" && proposedTx) {
+    const tx = proposedTx;
+    return (
+      <div className="space-y-6">
+        <div className="flex flex-col items-center gap-3">
+          <RejectedAnimation size={80} />
+          <span className="text-sm font-semibold text-danger">Blocked</span>
+        </div>
+        <div className="flex items-center gap-3 rounded-2xl bg-foreground/6 p-4">
+          <div className="w-10 h-10 rounded-2xl bg-foreground/8 flex items-center justify-center text-gold">
+            <ArrowUpRight className="h-5 w-5" />
+          </div>
+          <TokenIcon token={tx.token} iconUrl={tx.tokenIconUrl} />
+          <span className="text-lg font-semibold text-foreground">{tx.amount} {tx.token}</span>
+        </div>
+        <dl className="space-y-3 text-sm">
+          <div className="flex justify-between gap-4">
+            <dt className="text-muted-foreground/80">To</dt>
+            <dd className="font-mono text-foreground truncate min-w-0 max-w-[50%] sm:max-w-[200px]" title={tx.to}>
+              {truncateAddress(tx.to)}
+            </dd>
+          </div>
+          {tx.rejectReason && (
+            <div className="flex justify-between gap-4">
+              <dt className="text-muted-foreground/80 shrink-0">Reason</dt>
+              <dd className="text-danger text-right min-w-0">{tx.rejectReason}</dd>
+            </div>
+          )}
+        </dl>
+        <Button
+          type="button"
+          onClick={() => {
+            setSendPhase("form");
+            setProposedTx(null);
             clearRecipient();
             resetAmount();
             onSuccess();

--- a/client/src/components/TransactionDetailDialog.tsx
+++ b/client/src/components/TransactionDetailDialog.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import Image from "next/image";
 import { motion, AnimatePresence } from "framer-motion";
 import type { TransactionWithStatus } from "@/types";
+import { useLiveTransaction } from "@/hooks/useLiveTransaction";
 import { truncateAddress, formatDate, statusLabel, formatTokenAmount } from "@/lib/format";
 import { Dialog } from "./ui/Dialog";
 import { ExecutedAnimation, ReviewAnimation, RejectedAnimation } from "./animations/StatusAnimation";
@@ -173,42 +174,52 @@ function HeroAmount({ tx, config }: { tx: TransactionWithStatus; config: OpConfi
 
 // ── Risk section ──────────────────────────────────────────────────────────────
 
+/** Severity bucket → tailwind text/bg classes. */
+function severity(score: number): { tone: "safe" | "watch" | "danger"; text: string; bg: string } {
+  if (score >= 70) return { tone: "danger", text: "text-danger", bg: "bg-danger" };
+  if (score >= 40) return { tone: "watch", text: "text-watch", bg: "bg-watch" };
+  return { tone: "safe", text: "text-safe", bg: "bg-safe" };
+}
+
 function RiskDetailsSection({
   riskScore,
   riskVerdict,
   riskReasons,
+  reviewReason,
+  rejectReason,
 }: {
   riskScore?: number;
   riskVerdict?: "APPROVE" | "REVIEW" | "BLOCK";
   riskReasons?: string[];
+  reviewReason?: string;
+  rejectReason?: string;
 }) {
   const [expanded, setExpanded] = useState(false);
-  const reasonCount = riskReasons?.length ?? 0;
-  const summary =
-    riskScore != null
-      ? reasonCount > 0
-        ? `Risk: ${riskScore} — ${reasonCount} reason${reasonCount === 1 ? "" : "s"}`
-        : `Risk score: ${riskScore}`
-      : reasonCount > 0
-        ? `${reasonCount} risk reason${reasonCount === 1 ? "" : "s"}`
-        : "Risk details";
+  const sev = riskScore != null ? severity(riskScore) : null;
 
   return (
     <div className="rounded-2xl bg-foreground/6 overflow-hidden">
       <button
         type="button"
         onClick={() => setExpanded((e) => !e)}
+        aria-expanded={expanded}
         className="w-full flex items-center gap-2 px-4 py-3 text-left hover:bg-foreground/6 transition-colors cursor-pointer"
       >
         <ShieldAlert className="h-4 w-4 text-watch/90 shrink-0" />
-        <span className="text-sm font-medium text-foreground flex-1">{summary}</span>
+        <span className="text-sm font-medium text-foreground flex-1">View analysis</span>
+        {sev && (
+          <span className={`font-mono text-xs font-semibold ${sev.text}`}>
+            {riskScore}
+            <span className="text-muted-foreground/60">/100</span>
+          </span>
+        )}
         {expanded ? (
           <ChevronUp className="h-4 w-4 text-muted-foreground/80 shrink-0" />
         ) : (
           <ChevronDown className="h-4 w-4 text-muted-foreground/80 shrink-0" />
         )}
       </button>
-      <AnimatePresence>
+      <AnimatePresence initial={false}>
         {expanded && (
           <motion.div
             initial={{ height: 0, opacity: 0 }}
@@ -217,18 +228,34 @@ function RiskDetailsSection({
             transition={{ duration: 0.2 }}
             className="border-t border-foreground/10"
           >
-            <div className="px-4 py-3 space-y-2 text-sm">
-              {riskScore != null && (
-                <div className="flex justify-between gap-2">
-                  <span className="text-muted-foreground/80">Score</span>
-                  <span className="text-foreground font-medium">{riskScore}/100</span>
+            <div className="px-4 py-3.5 space-y-3.5 text-sm">
+              {/* Risk score + bar */}
+              {riskScore != null && sev && (
+                <div>
+                  <div className="flex items-center justify-between mb-1.5">
+                    <span className="text-muted-foreground/80">Risk score</span>
+                    <span className={`font-mono font-semibold ${sev.text}`}>
+                      {riskScore}
+                      <span className="text-muted-foreground/60">/100</span>
+                    </span>
+                  </div>
+                  <div className="h-1.5 rounded-pill bg-foreground/10 overflow-hidden">
+                    <motion.span
+                      className={`block h-full rounded-pill ${sev.bg}`}
+                      initial={{ width: 0 }}
+                      animate={{ width: `${Math.min(100, Math.max(0, riskScore))}%` }}
+                      transition={{ duration: 0.5, ease: "easeOut" }}
+                    />
+                  </div>
                 </div>
               )}
+
+              {/* Verdict */}
               {riskVerdict && (
-                <div className="flex justify-between gap-2">
+                <div className="flex items-center justify-between">
                   <span className="text-muted-foreground/80">Verdict</span>
                   <span
-                    className={`font-medium ${
+                    className={`font-mono uppercase tracking-wide text-xs font-semibold ${
                       riskVerdict === "APPROVE"
                         ? "text-safe"
                         : riskVerdict === "BLOCK"
@@ -240,9 +267,27 @@ function RiskDetailsSection({
                   </span>
                 </div>
               )}
+
+              {/* Agent message */}
+              {reviewReason && (
+                <div>
+                  <span className="text-muted-foreground/80 block mb-1">Message</span>
+                  <p className="text-foreground/85 leading-relaxed">{reviewReason}</p>
+                </div>
+              )}
+
+              {/* Rejection reason */}
+              {rejectReason && (
+                <div>
+                  <span className="text-muted-foreground/80 block mb-1">Rejection reason</span>
+                  <p className="text-danger leading-relaxed">{rejectReason}</p>
+                </div>
+              )}
+
+              {/* Signals */}
               {riskReasons && riskReasons.length > 0 && (
                 <div>
-                  <span className="text-muted-foreground/80 block mb-1">Reasons</span>
+                  <span className="text-muted-foreground/80 block mb-1">Signals</span>
                   <ul className="list-disc list-inside space-y-0.5 text-foreground/80">
                     {riskReasons.map((r, i) => (
                       <li key={i}>{r}</li>
@@ -280,8 +325,18 @@ interface TransactionDetailDialogProps {
   onClose: () => void;
 }
 
-export function TransactionDetailDialog({ tx, open, onClose }: TransactionDetailDialogProps) {
-  if (!tx) return null;
+export function TransactionDetailDialog({ tx: txProp, open, onClose }: TransactionDetailDialogProps) {
+  // While the dialog is open on a Zhentan tx, poll it live so a pending/in-review
+  // item flips to executed/rejected in place (e.g. after a Telegram decision).
+  // Zerion-only items are already terminal on-chain — nothing to poll.
+  const live = useLiveTransaction(
+    open && txProp && txProp.source !== "zerion-only" ? txProp.id : null
+  );
+
+  if (!txProp) return null;
+
+  // Freshest record wins; fall back to the passed-in copy before the first poll.
+  const tx = live ?? txProp;
 
   const config = getConfig(tx);
   const op = tx.operationType ?? (tx.direction === "receive" ? "receive" : "send");
@@ -294,32 +349,45 @@ export function TransactionDetailDialog({ tx, open, onClose }: TransactionDetail
   const counterpartyLabel =
     op === "receive" ? "From" : op === "send" ? "To" : "Interacted with";
 
-  // Risk section: only for zhentan txs with risk data
+  // Analysis section: any zhentan tx that carries screening data, regardless of
+  // status — so executed / rejected decisions show their analysis too.
   const showRisk =
     isZhentanTx &&
-    (tx.inReview || tx.status === "in_review") &&
-    (tx.riskScore != null || (tx.riskReasons && tx.riskReasons.length > 0));
+    (tx.riskScore != null ||
+      tx.riskVerdict != null ||
+      (tx.riskReasons?.length ?? 0) > 0 ||
+      !!tx.reviewReason ||
+      !!tx.rejectReason);
 
   return (
     <Dialog open={open} onClose={onClose} title="Transaction details" className="max-w-md">
       <div className="space-y-6">
-        {/* Status animation */}
-        <div className="flex flex-col items-center gap-3">
-          <StatusAnimation status={tx.status} />
-          <span
-            className={`text-sm font-semibold ${
-              tx.status === "executed"
-                ? "text-gold"
-                : tx.status === "rejected"
-                  ? "text-danger"
-                  : tx.status === "in_review"
-                    ? "text-gold"
-                    : "text-watch"
-            }`}
+        {/* Status animation — morphs in place when the live status changes */}
+        <AnimatePresence mode="wait">
+          <motion.div
+            key={tx.status}
+            className="flex flex-col items-center gap-3"
+            initial={{ opacity: 0, scale: 0.92 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.92 }}
+            transition={{ duration: 0.28, ease: "easeOut" }}
           >
-            {statusLabel(tx.status)}
-          </span>
-        </div>
+            <StatusAnimation status={tx.status} />
+            <span
+              className={`text-sm font-semibold ${
+                tx.status === "executed"
+                  ? "text-gold"
+                  : tx.status === "rejected"
+                    ? "text-danger"
+                    : tx.status === "in_review"
+                      ? "text-gold"
+                      : "text-watch"
+              }`}
+            >
+              {statusLabel(tx.status)}
+            </span>
+          </motion.div>
+        </AnimatePresence>
 
         {/* Hero: op icon + token + amount(s) */}
         <HeroAmount tx={tx} config={config} />
@@ -412,21 +480,16 @@ export function TransactionDetailDialog({ tx, open, onClose }: TransactionDetail
             </div>
           )}
 
-          {/* Rejection reason */}
-          {tx.rejectReason && (
-            <div className="flex justify-between gap-2 sm:gap-4">
-              <dt className="text-muted-foreground/80 shrink-0">Reason</dt>
-              <dd className="text-danger truncate min-w-0">{tx.rejectReason}</dd>
-            </div>
-          )}
         </dl>
 
-        {/* Risk details */}
+        {/* Agent analysis — expandable: score, message, signals */}
         {showRisk && (
           <RiskDetailsSection
             riskScore={tx.riskScore}
             riskVerdict={tx.riskVerdict}
             riskReasons={tx.riskReasons}
+            reviewReason={tx.reviewReason}
+            rejectReason={tx.rejectReason}
           />
         )}
 

--- a/client/src/hooks/useAutoRefresh.ts
+++ b/client/src/hooks/useAutoRefresh.ts
@@ -1,0 +1,31 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+/**
+ * Attaches interval polling + tab-visibility refetch to any refetch function.
+ * The callback is held in a ref, so passing a fresh closure each render is fine —
+ * only `intervalMs` changes re-subscribe the timer. Refetches immediately when the
+ * tab regains visibility, so returning to a backgrounded tab shows fresh data at once.
+ *
+ * @param refetch     Refetch callback (no need to memoize).
+ * @param intervalMs  Poll interval in ms (default 30s). Pass a smaller value to poll
+ *                    faster while something is in flight, larger when idle.
+ */
+export function useAutoRefresh(refetch: () => void, intervalMs = 30_000) {
+  const refetchRef = useRef(refetch);
+  refetchRef.current = refetch;
+
+  useEffect(() => {
+    const tick = () => refetchRef.current();
+    const id = setInterval(tick, intervalMs);
+    const onVisible = () => {
+      if (document.visibilityState === "visible") tick();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    return () => {
+      clearInterval(id);
+      document.removeEventListener("visibilitychange", onVisible);
+    };
+  }, [intervalMs]);
+}

--- a/client/src/hooks/useLiveTransaction.ts
+++ b/client/src/hooks/useLiveTransaction.ts
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useApiClient } from "@/lib/api/client";
+import type { TransactionWithStatus } from "@/types";
+
+const TERMINAL = new Set(["executed", "rejected"]);
+const LIVE_POLL_MS = 3_000;
+
+/**
+ * Polls a single transaction by id every 3s while it's non-terminal, so an open
+ * detail view auto-reflects the pending → in_review → executed/rejected transition
+ * (e.g. once the owner resolves it from Telegram). Stops on its own the moment the
+ * tx reaches a terminal state, and when `id` goes null (dialog closed).
+ *
+ * Returns the freshest server record, or null before the first fetch — callers
+ * should fall back to their own copy: `const view = live ?? tx`.
+ */
+export function useLiveTransaction(id: string | null): TransactionWithStatus | null {
+  const api = useApiClient();
+  const [data, setData] = useState<TransactionWithStatus | null>(null);
+
+  useEffect(() => {
+    // Drop any prior tx's data so callers fall back to their own copy while the
+    // new id's first fetch is in flight (prevents showing stale cross-tx data).
+    setData(null);
+    if (!id) return;
+
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout>;
+
+    const tick = async () => {
+      try {
+        const { transaction } = await api.transactions.get(id);
+        if (cancelled) return;
+        setData(transaction);
+        if (!TERMINAL.has(transaction.status)) {
+          timer = setTimeout(tick, LIVE_POLL_MS);
+        }
+      } catch {
+        if (cancelled) return;
+        timer = setTimeout(tick, LIVE_POLL_MS); // retry on transient error
+      }
+    };
+    tick();
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [id, api]);
+
+  return data;
+}

--- a/client/src/hooks/useRequestActions.ts
+++ b/client/src/hooks/useRequestActions.ts
@@ -1,0 +1,92 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useAuth } from "@/app/context/AuthContext";
+import { useApiClient } from "@/lib/api/client";
+import { useActivityData } from "@/app/context/ActivityDataContext";
+import { proposeTransaction } from "@/lib/propose";
+import { findFallbackTokenBySymbol } from "@/lib/tokenFallbacks";
+import type { QueuedRequest, TokenPosition } from "@/types";
+
+/**
+ * Approve / reject handlers for payment requests, shared by the requests page and
+ * the home rail so a queued request can be acted on wherever its detail dialog is
+ * opened. Approve = propose the payment (owner signs 1 of 2) → screening; reject =
+ * bookkeeping update. Both refresh the shared activity feed afterwards.
+ */
+export function useRequestActions() {
+  const { user, wallet, getOwnerAccount, safeAddress, identityToken } = useAuth();
+  const api = useApiClient();
+  const { refresh } = useActivityData();
+  const [tokens, setTokens] = useState<TokenPosition[]>([]);
+
+  const fetchTokens = useCallback(async () => {
+    if (!safeAddress) return;
+    try {
+      const data = await api.portfolio.get(safeAddress);
+      setTokens(data.tokens);
+    } catch {
+      // silent — resolveToken falls back to known BNB Chain tokens
+    }
+  }, [safeAddress, api]);
+
+  useEffect(() => {
+    fetchTokens();
+  }, [fetchTokens]);
+
+  // Resolve a request's token (symbol only) to a contract address + decimals,
+  // preferring the user's portfolio and falling back to known BNB Chain tokens.
+  const resolveToken = useCallback(
+    (symbol: string) => {
+      const sym = symbol.trim().toLowerCase();
+      const fromPortfolio = tokens.find(
+        (t) => t.symbol.toLowerCase() === sym && t.address
+      );
+      if (fromPortfolio) return fromPortfolio;
+      return findFallbackTokenBySymbol(symbol);
+    },
+    [tokens]
+  );
+
+  const handleApprove = useCallback(
+    async (request: QueuedRequest): Promise<{ txId: string }> => {
+      if (!user || !wallet) throw new Error("Please log in first");
+
+      const token = resolveToken(request.token);
+      if (!token?.address) {
+        throw new Error(`Unsupported token: ${request.token}`);
+      }
+
+      const pendingTx = await proposeTransaction({
+        recipient: request.to,
+        amount: String(request.amount),
+        ownerAddress: wallet.address,
+        getOwnerAccount,
+        tokenAddress: token.address,
+        tokenDecimals: token.decimals,
+        tokenSymbol: token.symbol,
+        tokenIconUrl: token.iconUrl ?? undefined,
+        identityToken,
+      });
+
+      await api.requests.update({ id: request.id, status: "approved", txId: pendingTx.id });
+      refresh();
+      return { txId: pendingTx.id };
+    },
+    [user, wallet, getOwnerAccount, identityToken, resolveToken, refresh, api]
+  );
+
+  const handleReject = useCallback(
+    async (request: QueuedRequest, reason: string) => {
+      await api.requests.update({
+        id: request.id,
+        status: "rejected",
+        rejectReason: reason || undefined,
+      });
+      refresh();
+    },
+    [refresh, api]
+  );
+
+  return { handleApprove, handleReject, refresh };
+}

--- a/docs/AI_BUILD_LOG.md
+++ b/docs/AI_BUILD_LOG.md
@@ -21,7 +21,7 @@ Full commit history and contributor activity: [github.com/koshikraj/zhentan/grap
 |------|------|
 | **Claude Code** (Anthropic CLI) | Assisted with documentation, UI housekeeping, and code reviews |
 | **Cursor** | UI component updates and styling iterations |
-| **OpenClaw Agent** (Qwen3-235B / Claude Sonnet via OpenRouter) | The AI agent that IS the product — also used during development to debug server config issues |
+| **NanoBot/Hermes Agent** (Qwen3-235B / Claude Sonnet via OpenRouter) | The AI agent that IS the product — also used during development to debug server config issues |
 
 ---
 
@@ -29,7 +29,7 @@ Full commit history and contributor activity: [github.com/koshikraj/zhentan/grap
 
 ### 1. Bootstrapping (Claude Code)
 
-Claude Code helped bootstrap both the Express server and the Next.js client through heavy prompting — setting up the project structure, API route layout, middleware, TypeScript config, and Privy + viem integration scaffolding. This significantly sped up getting both ends talking to each other. From there, the core logic — risk scoring, Safe multisig setup, ERC-4337 pipeline, OpenClaw skill design — was built and iterated by hand.
+Claude Code helped bootstrap both the Express server and the Next.js client through heavy prompting — setting up the project structure, API route layout, middleware, TypeScript config, and Privy + viem integration scaffolding. This significantly sped up getting both ends talking to each other. From there, the core logic — risk scoring, Safe multisig setup, ERC-4337 pipeline, NanoBot/Hermes skill design — was built and iterated by hand.
 
 ### 2. UI Housekeeping (Claude Code + Cursor)
 
@@ -58,15 +58,15 @@ All content was reviewed and corrected where the AI got the architecture wrong (
 
 **Commit:** `80d495e` — `docs: add hackathon starter kit documentation structure`
 
-### 3. Debugging Server Config (OpenClaw Agent)
+### 3. Debugging Server Config (NanoBot/Hermes Agent)
 
-The OpenClaw agent was used beyond its product role — during development, it helped debug server-side configuration issues by inspecting config files, tracing environment variable mismatches, and suggesting fixes for the queue path setup and Telegram webhook wiring. A nice meta moment: using the product to build the product.
+The NanoBot/Hermes agent was used beyond its product role — during development, it helped debug server-side configuration issues by inspecting config files, tracing environment variable mismatches, and suggesting fixes for the queue path setup and Telegram webhook wiring. A nice meta moment: using the product to build the product.
 
 ---
 
-## AI as the Product (OpenClaw Agent)
+## AI as the Product (NanoBot/Hermes Agent)
 
-Separately from build assistance, the OpenClaw agent is the core of Zhentan itself:
+Separately from build assistance, the NanoBot/Hermes agent is the core of Zhentan itself:
 
 - **Holds the 2nd key** on every user's Safe 2-of-2 multisig — no transaction executes without its signature
 - **Communicates with the user** via Telegram — sends risk reports, approve/reject buttons, blocked alerts

--- a/docs/EXTRAS.md
+++ b/docs/EXTRAS.md
@@ -15,7 +15,7 @@ Use `←` `→` arrow keys or the on-screen controls to navigate 8 slides coveri
 ## Live Demo
 
 - **URL:** [https://zhentan.me](https://zhentan.me)
-- **Note:** This deployment is wired to an public OpenClaw agent with basic plan. For screening to be personalized per user and requires your own agent setup. Run the app locally (client + server + OpenClaw skills) for screened mode with AI approval, review, and blocking.
+- **Note:** This deployment is wired to an public NanoBot/Hermes agent with basic plan. For screening to be personalized per user and requires your own agent setup. Run the app locally (client + server + NanoBot/Hermes skills) for screened mode with AI approval, review, and blocking.
 
 
 

--- a/docs/ONCHAIN.md
+++ b/docs/ONCHAIN.md
@@ -1,6 +1,6 @@
 # Onchain Activity — BNB Chain
 
-All transactions below are ERC-4337 UserOperations submitted to EntryPoint v0.7, gasless via Pimlico paymaster. Each was co-signed by the Zhentan OpenClaw agent after passing through the screening pipeline.
+All transactions below are ERC-4337 UserOperations submitted to EntryPoint v0.7, gasless via Pimlico paymaster. Each was co-signed by the Zhentan NanoBot/Hermes agent after passing through the screening pipeline.
 
 ---
 

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -22,7 +22,7 @@ Zhentan is a personalized wallet assistant that acts as an AI co-signer on a Saf
 - **Instant risk scoring (0–100):** Every transaction is scored server-side against your learned patterns before reaching the agent
 - **Three-tier response:** APPROVE (agent auto-signs 2-of-2) / REVIEW (deep analysis + Telegram interactive buttons) / BLOCK (reject + alert)
 - **Deep analysis on REVIEW:** GoPlus + Honeypot.is checks run automatically for every REVIEW-tier transaction — address reputation, sanctions, honeypot detection, and token tax rates delivered to the user before they decide
-- **OpenClaw Agent as 2nd signer:** The agent communicates with the user via Telegram and holds the 2nd key — no transaction executes without its signature
+- **NanoBot/Hermes Agent as 2nd signer:** The agent communicates with the user via Telegram and holds the 2nd key — no transaction executes without its signature
 - **WalletConnect support:** Any DApp (PancakeSwap, Venus, etc.) routes through the same screening pipeline
 - **Gasless:** Account abstraction (ERC-4337) + bundler, zero gas fees for users
 
@@ -33,7 +33,7 @@ sequenceDiagram
     participant U as User
     participant App as Zhentan App
     participant S as Server
-    participant OC as OpenClaw Agent
+    participant OC as NanoBot/Hermes Agent
     participant EXT as GoPlus / Honeypot.is
     participant TG as Telegram
     participant BC as BNB Chain
@@ -79,7 +79,7 @@ sequenceDiagram
 - Newcomers who want guardrails without custody trade-offs
 
 **Adoption strategy:**
-1. Self-hosted, open-source agent (OpenClaw skills pack)
+1. Self-hosted, open-source agent (NanoBot/Hermes skills pack)
 2. Hosted service with per-user screening profiles
 3. SDK for other wallets to embed the risk scoring layer
 
@@ -98,7 +98,7 @@ sequenceDiagram
 **Current limitations:**
 
 - Deep analysis (GoPlus/Honeypot.is) is on-demand only with agentic communication. Can be exteded with other services
-- Live demo at zhentan.me runs with public OpenClaw agent — personalised AI screening requires local setup
+- Live demo at zhentan.me runs with public NanoBot/Hermes agent — personalised AI screening requires local setup
 
 
 **Near-term roadmap:**

--- a/docs/TECHNICAL.md
+++ b/docs/TECHNICAL.md
@@ -13,7 +13,7 @@ Zhentan is composed of three independently runnable components:
 |-----------|------|
 | `client/` | Next.js 14 frontend — onboarding, dashboard, send/receive, WalletConnect, invoices |
 | `server/` | Express API — inline risk analysis, Zerion portfolio |
-| `zhentan-skills/` | OpenClaw skill pack — conversational agent layer: responds to owner commands, runs deep analysis, signs approved txs, records patterns, handles invoices |
+| `zhentan-skills/` | NanoBot/Hermes skill pack — conversational agent layer: responds to owner commands, runs deep analysis, signs approved txs, records patterns, handles invoices |
 
 ```mermaid
 flowchart TD
@@ -21,7 +21,7 @@ flowchart TD
     D[DApp e.g. PancakeSwap] -->|WalletConnect| C
     C -->|POST /queue — user signs 1-of-2| S[Server :3001]
     S -->|analyzeRisk inline| R{Risk Score}
-    R -->|< 40 APPROVE| OC[OpenClaw Agent]
+    R -->|< 40 APPROVE| OC[NanoBot/Hermes Agent]
     R -->|40-70 REVIEW| OC
     R -->|> 70 BLOCK| OC
     OC -->|REVIEW: deep-analyze| EXT[GoPlus / Honeypot.is]
@@ -54,8 +54,8 @@ flowchart TD
 - File-based JSON storage to share with agent: `pending-queue.json`, `invoice-queue.json`, `state.json`, `patterns.json`
 
 **Zhentan Skills (`zhentan-skills/`)**
-- OpenClaw skill pack. The agent's role is **conversational** — the server handles the deterministic pipeline (inline risk scoring, auto-execute on APPROVE). The agent responds to owner commands via Telegram and provides analysis when asked.
-- Activated by symlinking the skills directory into OpenClaw's workspace and restarting the gateway (no cron setup required).
+- NanoBot/Hermes skill pack. The agent's role is **conversational** — the server handles the deterministic pipeline (inline risk scoring, auto-execute on APPROVE). The agent responds to owner commands via Telegram and provides analysis when asked.
+- Activated by symlinking the skills directory into NanoBot/Hermes's workspace and restarting the gateway (no cron setup required).
 - **Owner commands via Telegram:**
   - `approve <tx-id>` — runs `sign-and-execute`, then `record-pattern`, updates TG message with tx hash
   - `reject <tx-id>` — runs `reject-tx`, updates TG message
@@ -97,7 +97,7 @@ Score thresholds:
 sequenceDiagram
     participant C as Client
     participant S as Server
-    participant OC as OpenClaw Agent
+    participant OC as NanoBot/Hermes Agent
     participant EXT as GoPlus / Honeypot.is
     participant TG as Telegram
     participant B as Bundler
@@ -136,7 +136,7 @@ sequenceDiagram
 |------|---------|
 | Node.js | 18+ |
 | npm | 9+ |
-| OpenClaw CLI | latest |
+| NanoBot/Hermes CLI | latest |
 
 Accounts needed:
 - [Privy](https://privy.io) — app ID for embedded wallets
@@ -191,18 +191,18 @@ cd client && npm run dev
 # → http://localhost:3000
 ```
 
-### Running the OpenClaw Agent
+### Running the NanoBot/Hermes Agent
 
 ```bash
-# 1. Symlink the skills into OpenClaw's workspace
-mkdir -p ~/.openclaw/workspace/skills
-ln -sf "$(pwd)/zhentan-skills" ~/.openclaw/workspace/skills/zhentan
+# 1. Symlink the skills into NanoBot/Hermes's workspace
+mkdir -p ~/.nanobot/workspace/skills
+ln -sf "$(pwd)/zhentan-skills" ~/.nanobot/workspace/skills/zhentan
 
-# 2. Restart the OpenClaw gateway
-openclaw gateway restart
+# 2. Restart the NanoBot/Hermes gateway
+nanobot gateway restart
 
 # 3. Verify the skill is detected
-openclaw skills check
+nanobot skills check
 ```
 
 ### Verify It Works

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -10,7 +10,7 @@ Zhentan is a personalized wallet assistant that acts as an AI co-signer on a Saf
     Send, receive, and connect to DApps with AI-powered transaction screening on every action.
   </Card>
   <Card title="Technology" icon="microchip" iconType="duotone" href="/technology/overview">
-    Deep dive into the architecture — Safe multisig, ERC-4337, risk scoring, and the OpenClaw agent.
+    Deep dive into the architecture — Safe multisig, ERC-4337, risk scoring, and the NanoBot/Hermes agent.
   </Card>
   <Card title="Quickstart" icon="rocket-launch" iconType="duotone" href="/quickstart">
     Run Zhentan locally with full AI screening in minutes.
@@ -41,5 +41,5 @@ Zhentan adds an AI co-signer to your Safe wallet. Every transaction is scored 0�
 ## Live Demo
 
 <Note>
-  [zhentan.me](https://zhentan.me) runs with a public OpenClaw agent — no personalized screening. For full AI screening (APPROVE / REVIEW / BLOCK), [run locally](/quickstart) with the server and agent.
+  [zhentan.me](https://zhentan.me) runs with a public NanoBot/Hermes agent — no personalized screening. For full AI screening (APPROVE / REVIEW / BLOCK), [run locally](/quickstart) with the server and agent.
 </Note>

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -9,7 +9,7 @@ description: Get Zhentan running locally with full AI screening in minutes.
 |------|---------|
 | Node.js | 18+ |
 | pnpm | 10+ |
-| OpenClaw CLI | latest |
+| NanoBot/Hermes CLI | latest |
 
 You'll also need accounts for:
 
@@ -71,17 +71,17 @@ See `scripts/.env.example` and `server/.env.example` for full templates.
     # → http://localhost:3000
     ```
   </Step>
-  <Step title="Set up the OpenClaw agent">
+  <Step title="Set up the NanoBot/Hermes agent">
     ```bash
-    # Symlink the skills into OpenClaw's workspace
-    mkdir -p ~/.openclaw/workspace/skills
-    ln -sf "$(pwd)/agent" ~/.openclaw/workspace/skills/zhentan
+    # Symlink the skills into NanoBot/Hermes's workspace
+    mkdir -p ~/.nanobot/workspace/skills
+    ln -sf "$(pwd)/agent" ~/.nanobot/workspace/skills/zhentan
 
     # Restart the gateway
-    openclaw gateway restart
+    nanobot gateway restart
 
     # Verify detection
-    openclaw skills check
+    nanobot skills check
     ```
   </Step>
 </Steps>

--- a/docs/technology/agent.mdx
+++ b/docs/technology/agent.mdx
@@ -1,31 +1,31 @@
 ---
 title: Agent
-description: The OpenClaw skill pack — skills, transaction lifecycle, and Telegram commands.
+description: The NanoBot/Hermes skill pack — skills, transaction lifecycle, and Telegram commands.
 ---
 
 ## Overview
 
-The Zhentan agent is an OpenClaw skill pack. It holds the 2nd signing key on the Safe 2-of-2 and is the only component that communicates with the user via Telegram. The server handles deterministic screening — the agent handles everything interactive.
+The Zhentan agent is an NanoBot/Hermes skill pack. It holds the 2nd signing key on the Safe 2-of-2 and is the only component that communicates with the user via Telegram. The server handles deterministic screening — the agent handles everything interactive.
 
 **AI models:** Qwen3-235B / Claude Sonnet 4.5 via OpenRouter
 
 ## Setup
 
 <Steps>
-  <Step title="Symlink the skills into OpenClaw's workspace">
+  <Step title="Symlink the skills into NanoBot/Hermes's workspace">
     ```bash
-    mkdir -p ~/.openclaw/workspace/skills
-    ln -sf "$(pwd)/agent" ~/.openclaw/workspace/skills/zhentan
+    mkdir -p ~/.nanobot/workspace/skills
+    ln -sf "$(pwd)/agent" ~/.nanobot/workspace/skills/zhentan
     ```
   </Step>
-  <Step title="Restart the OpenClaw gateway">
+  <Step title="Restart the NanoBot/Hermes gateway">
     ```bash
-    openclaw gateway restart
+    nanobot gateway restart
     ```
   </Step>
   <Step title="Verify detection">
     ```bash
-    openclaw skills check
+    nanobot skills check
     ```
   </Step>
 </Steps>
@@ -85,5 +85,5 @@ PIMLICO_API_KEY=your_pimlico_api_key
 ```
 
 <Note>
-  Queue file paths default to `~/.openclaw/workspace/skills/zhentan/pending-queue.json`. Override with `QUEUE_PATH`.
+  Queue file paths default to `~/.nanobot/workspace/skills/zhentan/pending-queue.json`. Override with `QUEUE_PATH`.
 </Note>

--- a/docs/technology/architecture.mdx
+++ b/docs/technology/architecture.mdx
@@ -9,7 +9,7 @@ description: System overview, component breakdown, and data flow.
 |-----------|------|
 | `client/` | Next.js 14 frontend — onboarding, dashboard, send/receive, WalletConnect, invoices |
 | `server/` | Express API — inline risk analysis, queue management, Zerion portfolio |
-| `agent/` | OpenClaw skill pack — Telegram commands, deep analysis, 2nd signature, pattern recording |
+| `agent/` | NanoBot/Hermes skill pack — Telegram commands, deep analysis, 2nd signature, pattern recording |
 
 ```mermaid
 flowchart TD
@@ -17,7 +17,7 @@ flowchart TD
     D[DApp e.g. PancakeSwap] -->|WalletConnect| C
     C -->|POST /queue — user signs 1-of-2| S[Server :3001]
     S -->|analyzeRisk inline| R{Risk Score}
-    R -->|< 40 APPROVE| OC[OpenClaw Agent]
+    R -->|< 40 APPROVE| OC[NanoBot/Hermes Agent]
     R -->|40-70 REVIEW| OC
     R -->|> 70 BLOCK| OC
     OC -->|REVIEW: deep-analyze| EXT[GoPlus / Honeypot.is]
@@ -47,7 +47,7 @@ flowchart TD
 
 ## Agent
 
-- **OpenClaw skill pack** — holds the 2nd signing key
+- **NanoBot/Hermes skill pack** — holds the 2nd signing key
 - Responds to Telegram commands from the owner
 - Runs deep analysis (GoPlus + Honeypot.is) on REVIEW-tier transactions
 - Records patterns after every confirmed transaction
@@ -58,7 +58,7 @@ flowchart TD
 sequenceDiagram
     participant C as Client
     participant S as Server
-    participant OC as OpenClaw Agent
+    participant OC as NanoBot/Hermes Agent
     participant EXT as GoPlus / Honeypot.is
     participant TG as Telegram
     participant B as Bundler
@@ -107,4 +107,4 @@ sequenceDiagram
 | Auth | Privy (embedded wallets + Google OAuth) |
 | Blockchain libs | viem, permissionless.js |
 | Backend | Express, tsx (dev), PM2 (production) |
-| AI Agent | OpenClaw with Qwen3-235B / Claude Sonnet 4.5 via OpenRouter |
+| AI Agent | NanoBot/Hermes with Qwen3-235B / Claude Sonnet 4.5 via OpenRouter |

--- a/docs/technology/overview.mdx
+++ b/docs/technology/overview.mdx
@@ -13,7 +13,7 @@ Zhentan is built on three independently runnable components that work together: 
     How transactions are scored 0–100 against behavioral patterns.
   </Card>
   <Card title="Agent" icon="robot" iconType="duotone" href="/technology/agent">
-    The OpenClaw skill pack — skills, lifecycle, and Telegram commands.
+    The NanoBot/Hermes skill pack — skills, lifecycle, and Telegram commands.
   </Card>
   <Card title="Contract Deployments" icon="file-contract" iconType="duotone" href="/technology/contracts">
     Safe, ERC-4337, and infrastructure contract addresses on BNB Chain.

--- a/mcp/src/tools/requests.ts
+++ b/mcp/src/tools/requests.ts
@@ -44,8 +44,22 @@ export function registerRequestTools(server: McpServer) {
         billedFrom: PARTY.optional(),
         billedTo: PARTY.optional(),
         services: z.array(SERVICE).optional(),
-        riskScore: z.number().int().min(0).max(100).optional(),
-        riskNotes: z.string().max(500).optional(),
+        riskScore: z
+          .number()
+          .int()
+          .min(0)
+          .max(100)
+          .optional()
+          .describe(
+            "Always set this. Your 0–100 risk assessment of the request — score it yourself " +
+              "(the server does not): unknown vs known recipient, amount vs the recipient's history, " +
+              "hour-of-day, and single-tx/daily/custom limits.",
+          ),
+        riskNotes: z
+          .string()
+          .max(500)
+          .optional()
+          .describe("Always set this. One line justifying the riskScore."),
       },
     },
     async (args) => {

--- a/scripts/agent-sign.js
+++ b/scripts/agent-sign.js
@@ -162,7 +162,7 @@ async function main() {
   queue.pending[txIndex] = tx;
   writeFileSync(QUEUE_PATH, JSON.stringify(queue, null, 2));
 
-  // Output JSON for the OpenClaw agent to parse
+  // Output JSON for the NanoBot/Hermes agent to parse
   console.log(
     JSON.stringify({
       status: "executed",

--- a/server/.env.example
+++ b/server/.env.example
@@ -52,7 +52,7 @@ ADMIN_API_KEY=
 
 # Shared secret for agent → server authentication.
 # Generate with: openssl rand -hex 32
-# Must match AGENT_SECRET in your OpenClaw skill environment variables.
+# Must match AGENT_SECRET in your NanoBot/Hermes skill environment variables.
 AGENT_SECRET=
 
 # Privy — for verifying client identity tokens.

--- a/server/README.md
+++ b/server/README.md
@@ -1,6 +1,6 @@
 # Zhentan Server
 
-Express backend that handles queue and invoice file I/O. Run this server on a host with a writable filesystem and point the client at it for transactions, queue, execute, and invoices and invoking OpenClaw agent after primary screening by this server
+Express backend that handles queue and invoice file I/O. Run this server on a host with a writable filesystem and point the client at it for transactions, queue, execute, and invoices and invoking NanoBot/Hermes agent after primary screening by this server
 
 ## Setup
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -130,7 +130,7 @@ app.post("/notify-resolve", auth, async (req, res) => {
   res.json({ ok: true });
 });
 
-// POST /bot-ping — called by the OpenClaw agent on /start.
+// POST /bot-ping — called by the NanoBot/Hermes agent on /start.
 // Marks bot_connected = true for the safe mapped to this chatId and returns user details
 // so the agent can craft a proper greeting.
 app.post("/bot-ping", async (req, res) => {

--- a/server/src/routes/queue.ts
+++ b/server/src/routes/queue.ts
@@ -27,7 +27,6 @@ export function createQueueRouter(): IRouter {
       }
 
 
-      console.log("Received transaction for queue:", pendingTx);
       try {
       await createTransaction(pendingTx);
       } catch (err) { 

--- a/server/src/routes/requests.ts
+++ b/server/src/routes/requests.ts
@@ -1,7 +1,8 @@
 import { Router, Request, Response, type IRouter } from "express";
-import type { RequestStatus, RequestType, QueuedRequest } from "../types.js";
-import { getRequests, getRequest, createRequest, updateRequest } from "../lib/supabase/index.js";
+import type { RequestStatus, RequestType, QueuedRequest, PendingTransaction } from "../types.js";
+import { getRequests, getRequest, createRequest, updateRequest, getPatternsForSafe } from "../lib/supabase/index.js";
 import { getSafeAddressFromCallerId } from "../lib/caller.js";
+import { analyzeRisk } from "../risk.js";
 import { randomUUID } from "crypto";
 
 const VALID_STATUSES: RequestStatus[] = [
@@ -56,6 +57,36 @@ export function createRequestsRouter(): IRouter {
       const hasInvoiceFields = Boolean(invoiceNumber || billedFrom || billedTo || (services && services.length) || dueDate);
       const requestType: RequestType = type ?? (hasInvoiceFields ? "invoice" : "transfer");
 
+      // Risk: the agent's own assessment wins. Only when it omits a score do we
+      // fall back to the same rules engine that scores live transactions, so a
+      // request never ends up without a score for the dashboard.
+      let finalRiskScore: number | undefined =
+        riskScore != null && Number.isFinite(Number(riskScore))
+          ? Math.max(0, Math.min(100, Math.round(Number(riskScore))))
+          : undefined;
+      let finalRiskNotes: string | undefined = riskNotes ?? undefined;
+
+      if (finalRiskScore == null) {
+        try {
+          const patterns = await getPatternsForSafe(safeAddress);
+          const synthTx = {
+            to,
+            amount: String(amount),
+            token,
+          } as unknown as PendingTransaction;
+          const risk = analyzeRisk(synthTx, patterns);
+          finalRiskScore = risk.riskScore;
+          if (!finalRiskNotes) {
+            finalRiskNotes = `${risk.verdict}: ${risk.reasons.join("; ")}`;
+          }
+        } catch (err) {
+          console.error(
+            "Request risk scoring failed:",
+            err instanceof Error ? err.message : err
+          );
+        }
+      }
+
       const request: QueuedRequest = {
         id: `req-${randomUUID().slice(0, 8)}`,
         type: requestType,
@@ -70,12 +101,14 @@ export function createRequestsRouter(): IRouter {
         billedFrom: billedFrom ?? undefined,
         billedTo: billedTo ?? undefined,
         services: services ?? [],
-        riskScore: riskScore ?? undefined,
-        riskNotes: riskNotes ?? undefined,
+        riskScore: finalRiskScore,
+        riskNotes: finalRiskNotes,
         sourceChannel: sourceChannel ?? "unknown",
         queuedAt: new Date().toISOString(),
         status: "queued",
       };
+
+      console.log(request)
 
       await createRequest(request);
       res.status(201).json({ status: "queued", id: request.id, type: request.type, to: request.to, amount: request.amount, token: request.token });

--- a/server/src/routes/transactions.ts
+++ b/server/src/routes/transactions.ts
@@ -82,6 +82,9 @@ function mergeWithZerion(tx: TransactionWithStatus, z: ZerionHistoryItem): Trans
   };
 }
 
+/** Cap on how many (newest-first) transactions any list endpoint returns. */
+const MAX_TRANSACTIONS = 100;
+
 export function createTransactionsRouter(): IRouter {
   const router = Router();
 
@@ -126,10 +129,10 @@ export function createTransactionsRouter(): IRouter {
         .filter((z) => !ourHashes.has(z.hash.toLowerCase()))
         .map((z) => zerionOnlyToActivity(z, safeAddress));
 
-      // Merge and sort newest-first
-      const transactions = [...ourActivity, ...zerionOnlyActivity].sort(
-        (a, b) => new Date(b.proposedAt).getTime() - new Date(a.proposedAt).getTime()
-      );
+      // Merge, sort newest-first, cap at the 100 most recent
+      const transactions = [...ourActivity, ...zerionOnlyActivity]
+        .sort((a, b) => new Date(b.proposedAt).getTime() - new Date(a.proposedAt).getTime())
+        .slice(0, MAX_TRANSACTIONS);
 
       res.json({ transactions });
     } catch (err) {
@@ -150,11 +153,14 @@ export function createTransactionsRouter(): IRouter {
         return;
       }
       const txs = await getTransactionsByAddress(safeAddress);
-      const transactions: TransactionWithStatus[] = txs.map((tx) => ({
-        ...tx,
-        source: "zhentan-only",
-        status: getTransactionStatus(tx),
-      }));
+      const transactions: TransactionWithStatus[] = txs
+        .map((tx) => ({
+          ...tx,
+          source: "zhentan-only" as const,
+          status: getTransactionStatus(tx),
+        }))
+        .sort((a, b) => new Date(b.proposedAt).getTime() - new Date(a.proposedAt).getTime())
+        .slice(0, MAX_TRANSACTIONS);
       res.json({ transactions });
     } catch (err) {
       const message = err instanceof Error ? err.message : "Unknown error";


### PR DESCRIPTION
## Summary

Brings the `feat/brand-redesign` branch to main. The latest batch focuses on **live data updates**, bringing the **requests UX to parity** with the activity dialog, and **guaranteeing risk scores on requests**.

### Live data updates
- New shared hooks: `useAutoRefresh` (interval polling + refetch on tab focus) and `useLiveTransaction` (3s poll of a single tx while non-terminal).
- `ActivityDataContext`: silent background refetch, **adaptive cadence** (8s while a request/tx is in flight, 30s idle), and **optimistic insert** of just-proposed txs.
- Home dashboard + `ScreeningStatusContext` adopt `useAutoRefresh`; portfolio now refreshes on focus/interval (previously never polled).
- `SendPanel` optimistically surfaces a proposed tx and live-tracks it, so the dialog transitions in place to executed/blocked.
- `TransactionDetailDialog`: live polling + `AnimatePresence` status morph.

### Requests UX
- Borderless **divided list** (drops the nested `Card` + duplicate header).
- `RequestDetailDialog` now matches the activity dialog — polished status animations, hero amount, clickable explorer "To", expandable **"View analysis"**, and a BSCScan button.
- Home rail pending cards are clickable: **"You proposed"** opens the activity dialog; **"Agent proposed"** opens the request dialog (and keeps its "Screen & accept" CTA). Approve/reject extracted into `useRequestActions`.

### Risk scoring
- `/requests` falls back to the same `analyzeRisk` engine used for transactions when the agent omits `riskScore` (agent-supplied score still wins).
- Transaction list endpoints capped at the 100 newest records.
- `SKILL.md` + MCP `queue_request` now require an agent risk assessment per request.

### Earlier in the branch
Login redesign (+ landing `GuardianCard`), brand favicon, token PnL, live-readout rail, uniform page widths, and the Claude Design comp applied across rail/requests/profile/settings.

## Test plan
- `tsc --noEmit` passes for client; `pnpm --filter zhentan-server build` and `zhentan-mcp build` pass.
- Manual: propose a tx → appears instantly in rail, transitions to executed/blocked live; open both rail cards → correct dialogs; queue a request without an agent score → it gets a computed score.

🤖 Generated with [Claude Code](https://claude.com/claude-code)