### PR TITLE
Twin Tick loaders + real token icons on requests

### DIFF
--- a/client/src/app/(app)/requests/page.tsx
+++ b/client/src/app/(app)/requests/page.tsx
@@ -6,6 +6,7 @@ import { RequestList } from "@/components/RequestList";
 import { AuthGuard } from "@/components/AuthGuard";
 import { useAuth } from "@/app/context/AuthContext";
 import { useActivityData } from "@/app/context/ActivityDataContext";
+import { TwinTickLoader } from "@/components/TwinTickLoader";
 import { useSafeAddress } from "@/lib/useSafeAddress";
 import { proposeTransaction } from "@/lib/propose";
 import { useApiClient } from "@/lib/api/client";
@@ -112,7 +113,7 @@ function RequestsPageContent() {
       <div className="flex flex-col h-screen bg-background">
       
         <div className="flex-1 flex items-center justify-center">
-          <div className="animate-spin rounded-full h-8 w-8 border-2 border-gold border-t-transparent" />
+          <TwinTickLoader variant="sequential" size={120} label="Loading requests" />
         </div>
       </div>
     );

--- a/client/src/components/PrivyLoginButton.tsx
+++ b/client/src/components/PrivyLoginButton.tsx
@@ -4,7 +4,8 @@ import { useState } from "react";
 import { useLoginWithOAuth } from "@privy-io/react-auth";
 import { useAuth } from "@/app/context/AuthContext";
 import { Button } from "./ui/Button";
-import { Loader2, LogOut } from "lucide-react";
+import { TickButtonSpinner } from "./TwinTickLoader";
+import { LogOut } from "lucide-react";
 import { truncateAddress } from "@/lib/format";
 
 export function PrivyLoginButton() {
@@ -25,7 +26,7 @@ export function PrivyLoginButton() {
   if (loading) {
     return (
       <Button variant="secondary" disabled>
-        <Loader2 className="h-4 w-4 animate-spin" />
+        <TickButtonSpinner size={16} />
         Loading...
       </Button>
     );
@@ -52,7 +53,7 @@ export function PrivyLoginButton() {
       <Button onClick={handleGoogleLogin} disabled={isLoading}>
         {isLoading ? (
           <>
-            <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+            <TickButtonSpinner size={16} className="mr-2" />
             Signing in...
           </>
         ) : (

--- a/client/src/components/RequestDetailDialog.tsx
+++ b/client/src/components/RequestDetailDialog.tsx
@@ -9,7 +9,7 @@ import { useApiClient } from "@/lib/api/client";
 import { BSC_EXPLORER_URL } from "@/lib/constants";
 import { Dialog } from "./ui/Dialog";
 import { Button } from "./ui/Button";
-import { UsdcIcon } from "./icons/UsdcIcon";
+import { TokenGlyph } from "./TokenGlyph";
 import {
   FileText,
   ArrowUpRight,
@@ -339,9 +339,7 @@ export function RequestDetailDialog({
           <div className="w-10 h-10 rounded-2xl bg-foreground/[0.08] flex items-center justify-center shrink-0 text-gold">
             {isInvoice ? <FileText className="h-5 w-5" /> : <ArrowUpRight className="h-5 w-5" />}
           </div>
-          <div className="w-9 h-9 rounded-full bg-foreground/8 flex items-center justify-center shrink-0 overflow-hidden">
-            <UsdcIcon size={22} className="opacity-90" />
-          </div>
+          <TokenGlyph symbol={request.token} size={36} />
           <div className="flex-1 min-w-0">
             <p className="text-base font-semibold text-foreground">
               {request.amount} {request.token}
@@ -573,7 +571,7 @@ function ScreeningView({
     <div className="space-y-6">
       <div className="flex flex-col items-center gap-3 text-center">
         {isLoading ? (
-          <ThemeLoaderSpinner variant="transaction" />
+          <ThemeLoaderSpinner motion="scan" />
         ) : phase === "review" ? (
           <ReviewAnimation size={80} />
         ) : phase === "executed" ? (
@@ -605,7 +603,7 @@ function ScreeningView({
         <div className="w-10 h-10 rounded-2xl bg-foreground/8 flex items-center justify-center text-gold">
           <Send className="h-5 w-5" />
         </div>
-        <UsdcIcon size={24} className="shrink-0 opacity-90" />
+        <TokenGlyph symbol={request.token} size={24} />
         <span className="text-lg font-semibold text-foreground">
           {request.amount} {request.token}
         </span>

--- a/client/src/components/RequestRow.tsx
+++ b/client/src/components/RequestRow.tsx
@@ -3,7 +3,7 @@
 import { motion } from "framer-motion";
 import type { QueuedRequest } from "@/types";
 import { truncateAddress } from "@/lib/format";
-import { UsdcIcon } from "./icons/UsdcIcon";
+import { TokenGlyph } from "./TokenGlyph";
 import { FileText, ArrowUpRight } from "lucide-react";
 import { clsx } from "clsx";
 
@@ -89,7 +89,7 @@ export function RequestRow({ request, index = 0, onClick }: RequestRowProps) {
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2 flex-wrap">
           <span className="text-sm font-medium text-foreground truncate inline-flex items-center gap-1.5">
-            <UsdcIcon size={16} className="shrink-0 opacity-90" />
+            <TokenGlyph symbol={request.token} size={16} />
             {request.amount} {request.token}
           </span>
           <span className="text-muted-foreground/60">{isInvoice ? "←" : "→"}</span>

--- a/client/src/components/SendPanel.tsx
+++ b/client/src/components/SendPanel.tsx
@@ -302,7 +302,7 @@ export function SendPanel({ onSuccess, onClose, onRefreshActivities, tokens, scr
     return (
       <div className="flex flex-col gap-6">
         <div className="flex flex-col items-center gap-4">
-          <ThemeLoaderSpinner variant="transaction" />
+          <ThemeLoaderSpinner motion="scan" />
           <p className="text-sm font-semibold text-gold">Proposing transaction</p>
           <p className="text-xs text-muted-foreground/80 uppercase tracking-widest">Awaiting your signature</p>
         </div>

--- a/client/src/components/SwapPanel.tsx
+++ b/client/src/components/SwapPanel.tsx
@@ -8,6 +8,7 @@ import { Dialog } from "./ui/Dialog";
 import { TokenRow } from "./TokenRow";
 import { useAuth } from "@/app/context/AuthContext";
 import { ThemeLoaderSpinner } from "./ThemeLoader";
+import { TickButtonSpinner } from "./TwinTickLoader";
 import { ExecutedAnimation } from "./animations/StatusAnimation";
 import {
   ArrowDownUp,
@@ -16,7 +17,6 @@ import {
   CheckCircle2,
   Search,
   X,
-  Loader2,
 } from "lucide-react";
 import { formatTokenAmount, truncateAddress, formatDate } from "@/lib/format";
 import { BSC_EXPLORER_URL, NATIVE_TOKEN_ADDRESS } from "@/lib/constants";
@@ -595,7 +595,7 @@ export function SwapPanel({ onSuccess, onClose, tokens }: SwapPanelProps) {
 
         {searchLoading ? (
           <div className="flex items-center justify-center py-10 gap-2 text-muted-foreground/80">
-            <Loader2 className="h-4 w-4 animate-spin" />
+            <TickButtonSpinner size={16} />
             <span className="text-sm">Searching…</span>
           </div>
         ) : tokenSearch.trim() ? (

--- a/client/src/components/ThemeLoader.tsx
+++ b/client/src/components/ThemeLoader.tsx
@@ -1,116 +1,53 @@
 "use client";
 
-import Image from "next/image";
-import { motion } from "framer-motion";
-import { ArrowRightLeft } from "lucide-react";
-import { TwinTick } from "@/components/BrandMark";
+import { motion as fmotion } from "framer-motion";
+import { TwinTickLoader, type TwinTickVariant } from "@/components/TwinTickLoader";
 
 export type ThemeLoaderVariant = "auth" | "transaction" | "default";
 
 interface ThemeLoaderProps {
-  /** Loading context: auth (shield), transaction (arrows), or default (rings only) */
+  /** Loading context (kept for API compat; the Twin Tick mark is shown regardless). */
   variant?: ThemeLoaderVariant;
-  /** Custom icon to show instead of variant default */
+  /** Custom icon — kept for API compat, no longer rendered (the mark is the loader). */
   icon?: React.ReactNode;
-  /** Custom image src (overrides icon and variant); use for logos etc. */
   imageSrc?: string;
-  /** Alt text when imageSrc is used */
   imageAlt?: string;
-  /** Primary message, e.g. "Loading Zhentan" or "Processing transaction..." */
+  /** Primary message, e.g. "Loading Zhentan". */
   message?: string;
-  /** Secondary line, e.g. "Securing your session" */
+  /** Secondary line, e.g. "Securing your session". */
   subtext?: string;
 }
 
-const VARIANT_ICONS: Record<ThemeLoaderVariant, React.ReactNode> = {
-  auth: <TwinTick size={26} halo="none" />,
-  transaction: <ArrowRightLeft className="w-7 h-7 text-gold" />,
-  default: (
-    <div className="w-2 h-2 rounded-full bg-gold shadow-[0_0_12px_rgba(196,148,40,0.8)] animate-pulse" />
-  ),
-};
-
-function SpinnerRing() {
-  return (
-    <>
-      <div
-        className="absolute inset-0 w-14 h-14 rounded-full border-2 border-transparent border-t-gold border-r-gold/60 animate-spin"
-        aria-hidden
-      />
-      <div
-        className="absolute inset-0 w-14 h-14 rounded-full border-2 border-transparent border-b-gold/40 border-l-gold/80 animate-spin"
-        style={{ animationDuration: "1.2s", animationDirection: "reverse" }}
-        aria-hidden
-      />
-    </>
-  );
-}
-
-function getCenterContent(
-  variant: ThemeLoaderVariant,
-  icon?: React.ReactNode,
-  imageSrc?: string,
-  imageAlt?: string
-) {
-  if (imageSrc) {
-    return (
-      <div className="relative w-10 h-10">
-        <Image src={imageSrc} alt={imageAlt ?? ""} fill className="object-contain" sizes="40px" />
-      </div>
-    );
-  }
-  if (icon != null) return icon;
-  return VARIANT_ICONS[variant];
-}
-
-/** Compact spinner matching ThemeLoader (rings + center icon). Use in dialogs/cards. */
+/**
+ * Compact Twin Tick spinner for dialogs / cards. Defaults to the "orbit"
+ * treatment (processing); pass `motion="scan"` for the screening/analysis beat.
+ */
 export function ThemeLoaderSpinner({
-  variant = "default",
-  icon,
-  imageSrc,
-  imageAlt,
+  motion = "orbit",
+  size = 56,
 }: {
+  /** Twin Tick motion treatment. */
+  motion?: Extract<TwinTickVariant, "orbit" | "scan" | "pulse" | "sequential">;
+  size?: number;
+  // legacy props kept so existing call sites compile unchanged:
   variant?: ThemeLoaderVariant;
   icon?: React.ReactNode;
   imageSrc?: string;
   imageAlt?: string;
 }) {
-  return (
-    <div className="relative w-14 h-14 flex items-center justify-center shrink-0">
-      <div className="absolute inset-0 w-14 h-14 rounded-full border-2 border-gold/30" aria-hidden />
-      <SpinnerRing />
-      <div className="absolute inset-0 flex items-center justify-center">
-        {getCenterContent(variant, icon, imageSrc, imageAlt)}
-      </div>
-    </div>
-  );
+  return <TwinTickLoader variant={motion} size={size} />;
 }
 
+/** Full-screen loader — calm "pulse" Twin Tick with message + subtext. */
 export function ThemeLoader({
-  variant = "default",
-  icon,
-  imageSrc,
-  imageAlt = "Loading",
   message = "Loading...",
   subtext = "Securing your session",
 }: ThemeLoaderProps) {
-  const centerContent = getCenterContent(variant, icon, imageSrc, imageAlt);
-
   return (
     <div className="flex flex-col items-center justify-center h-screen hero-gradient gap-8">
       <div className="flex flex-col items-center gap-6">
-        <div className="relative w-14 h-14 flex items-center justify-center">
-          {/* Background ring (always) */}
-          <div
-            className="absolute inset-0 w-14 h-14 rounded-full border-2 border-gold/30"
-            aria-hidden
-          />
-          <SpinnerRing />
-          <div className="absolute inset-0 flex items-center justify-center">
-            {centerContent}
-          </div>
-        </div>
-        <motion.div
+        <TwinTickLoader variant="pulse" size={96} label={message} />
+        <fmotion.div
           initial={{ opacity: 0, y: 8 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.2, duration: 0.4 }}
@@ -118,7 +55,7 @@ export function ThemeLoader({
         >
           <p className="text-sm font-medium text-foreground/80">{message}</p>
           <p className="eyebrow text-muted-foreground/80">{subtext}</p>
-        </motion.div>
+        </fmotion.div>
       </div>
     </div>
   );

--- a/client/src/components/TokenGlyph.tsx
+++ b/client/src/components/TokenGlyph.tsx
@@ -1,0 +1,49 @@
+import Image from "next/image";
+import { clsx } from "clsx";
+import { UsdcIcon } from "./icons/UsdcIcon";
+import { findFallbackTokenBySymbol } from "@/lib/tokenFallbacks";
+
+interface TokenGlyphProps {
+  /** Token symbol, e.g. "USDC" / "BNB". */
+  symbol: string;
+  /** Explicit icon URL (e.g. from a portfolio position); wins over symbol lookup. */
+  iconUrl?: string | null;
+  size?: number;
+  className?: string;
+}
+
+/**
+ * Renders a token's icon from its symbol. Resolution order:
+ *   explicit iconUrl → known BNB Chain token (findFallbackTokenBySymbol) → UsdcIcon.
+ * Used where we only have a token symbol (e.g. payment requests), so the row/dialog
+ * shows the real asset instead of a hardcoded USDC mark.
+ */
+export function TokenGlyph({ symbol, iconUrl, size = 24, className }: TokenGlyphProps) {
+  const sym = (symbol || "").trim().toUpperCase();
+  const resolved = iconUrl ?? findFallbackTokenBySymbol(symbol)?.iconUrl ?? null;
+
+  if (sym === "BNB") {
+    return (
+      <Image
+        src="/bsc-yellow.png"
+        alt=""
+        width={size}
+        height={size}
+        className={clsx("object-contain shrink-0", className)}
+      />
+    );
+  }
+
+  if (resolved) {
+    return (
+      <span
+        className={clsx("relative inline-block shrink-0 rounded-full overflow-hidden bg-foreground/10", className)}
+        style={{ width: size, height: size }}
+      >
+        <Image src={resolved} alt="" fill className="object-cover" sizes={`${size}px`} unoptimized />
+      </span>
+    );
+  }
+
+  return <UsdcIcon size={size} className={clsx("shrink-0 opacity-90", className)} />;
+}

--- a/client/src/components/TwinTickLoader.module.css
+++ b/client/src/components/TwinTickLoader.module.css
@@ -1,0 +1,107 @@
+/* Twin Tick loaders — ported from the Zhentan Loaders design comp.
+   The mark resolves the way an approval does: your tick draws first (ghost),
+   the agent's co-signs second (bright). One duration, scaled by --tt-spd. */
+
+.wrap {
+  --tt-acc: #e8b93a;
+  --tt-accB: #f5d060;
+  --tt-ghost: #9a7526;
+  --tt-ring: rgba(196, 148, 40, 0.22);
+  --tt-ink: #0a0d0e;
+  --tt-spd: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+/* ===== sequential draw — ghost tick, then bright tick, then settle pop ===== */
+@keyframes tt-ghost {
+  0%   { stroke-dashoffset: 100; opacity: 1; }
+  18%  { stroke-dashoffset: 0;   opacity: 1; }
+  80%  { stroke-dashoffset: 0;   opacity: 1; }
+  90%  { stroke-dashoffset: 0;   opacity: 0; }
+  91%  { stroke-dashoffset: 100; opacity: 0; }
+  100% { stroke-dashoffset: 100; opacity: 0; }
+}
+@keyframes tt-bright {
+  0%   { stroke-dashoffset: 100; opacity: 1; }
+  24%  { stroke-dashoffset: 100; opacity: 1; }
+  46%  { stroke-dashoffset: 0;   opacity: 1; }
+  80%  { stroke-dashoffset: 0;   opacity: 1; }
+  90%  { stroke-dashoffset: 0;   opacity: 0; }
+  91%  { stroke-dashoffset: 100; opacity: 0; }
+  100% { stroke-dashoffset: 100; opacity: 0; }
+}
+@keyframes tt-pop {
+  0%, 42%   { transform: scale(1); }
+  50%       { transform: scale(1.06); }
+  58%, 100% { transform: scale(1); }
+}
+
+@keyframes tt-spin { to { transform: rotate(360deg); } }
+
+/* pulse / heartbeat — each tick fades + lifts in turn */
+@keyframes tt-pulse-ghost {
+  0%, 100% { opacity: .18; transform: translateY(2px); }
+  18%      { opacity: 1;   transform: translateY(0); }
+  46%      { opacity: .5;  transform: translateY(0); }
+}
+@keyframes tt-pulse-bright {
+  0%, 30%   { opacity: .18; transform: translateY(2px); }
+  50%       { opacity: 1;   transform: translateY(0); }
+  78%, 100% { opacity: .35; transform: translateY(1px); }
+}
+@keyframes tt-glow {
+  0%, 30%, 100% { filter: drop-shadow(0 0 0 rgba(232, 185, 58, 0)); }
+  52%           { filter: drop-shadow(0 0 7px rgba(245, 208, 96, .7)); }
+}
+
+/* scanline sweep */
+@keyframes tt-scan {
+  0%   { transform: translateY(-46px); opacity: 0; }
+  12%  { opacity: 1; }
+  88%  { opacity: 1; }
+  100% { transform: translateY(46px); opacity: 0; }
+}
+
+@keyframes tt-ring-pulse { 0%, 100% { opacity: .35; } 50% { opacity: .9; } }
+
+/* ── shared element animations (drive by class) ── */
+.ring        { animation: tt-ring-pulse calc(2.6s / var(--tt-spd)) ease-in-out infinite; }
+.ringStatic  { opacity: .5; }
+.ghost       { stroke-dasharray: 100; animation: tt-ghost calc(2.6s / var(--tt-spd)) ease infinite; }
+.bright      { stroke-dasharray: 100; animation: tt-bright calc(2.6s / var(--tt-spd)) ease infinite; }
+.pop         { transform-box: fill-box; transform-origin: center; animation: tt-pop calc(2.6s / var(--tt-spd)) ease infinite; }
+
+.orbitArc    { transform-origin: center; animation: tt-spin calc(1.4s / var(--tt-spd)) linear infinite; }
+
+.pulseGhost  { transform-box: fill-box; transform-origin: center; animation: tt-pulse-ghost calc(1.8s / var(--tt-spd)) ease-in-out infinite; }
+.pulseBright { transform-box: fill-box; transform-origin: center;
+  animation: tt-pulse-bright calc(1.8s / var(--tt-spd)) ease-in-out infinite,
+             tt-glow calc(1.8s / var(--tt-spd)) ease-in-out infinite; }
+
+/* scan wrapper + line */
+.scanBox { position: relative; overflow: hidden; }
+.scanLine {
+  position: absolute; left: 0; right: 0; top: 50%; height: 2px;
+  background: linear-gradient(90deg, transparent, var(--tt-accB), transparent);
+  box-shadow: 0 0 12px 2px rgba(245, 208, 96, .5);
+  animation: tt-scan calc(2.2s / var(--tt-spd)) ease-in-out infinite;
+}
+
+/* compact circular spinner — busy buttons / rows (currentColor follows text) */
+.btnSpinnerTrack { opacity: 0.25; }
+.btnSpinnerArc   { transform-origin: center; animation: tt-spin calc(0.9s / var(--tt-spd)) linear infinite; }
+
+@media (prefers-reduced-motion: reduce) {
+  .ring, .ghost, .bright, .pop, .orbitArc, .pulseGhost, .pulseBright,
+  .scanLine, .btnSpinnerArc { animation: none; }
+  .ghost, .bright { stroke-dashoffset: 0; }
+}

--- a/client/src/components/TwinTickLoader.tsx
+++ b/client/src/components/TwinTickLoader.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { clsx } from "clsx";
+import s from "./TwinTickLoader.module.css";
+
+export type TwinTickVariant = "sequential" | "orbit" | "pulse" | "scan" | "inline";
+
+interface TwinTickLoaderProps {
+  /** Motion treatment. See the Zhentan Loaders comp for intent. */
+  variant?: TwinTickVariant;
+  /** Pixel size (square). Defaults per variant. */
+  size?: number;
+  /** Animation speed multiplier (1 = comp default). */
+  speed?: number;
+  className?: string;
+  /** Accessible label; defaults to "Loading". */
+  label?: string;
+}
+
+const DEFAULT_SIZE: Record<TwinTickVariant, number> = {
+  sequential: 148,
+  orbit: 96,
+  pulse: 96,
+  scan: 96,
+  inline: 26,
+};
+
+/** The two strokes of the bright (foreground) tick — ink halo + gold + shine. */
+function BrightTick({ d, ink, gold, shine }: { d: string; ink: number; gold: number; shine?: number }) {
+  return (
+    <>
+      <path d={d} pathLength={100} fill="none" stroke="var(--tt-ink)" strokeWidth={ink} strokeLinecap="round" strokeLinejoin="round" className={s.bright} />
+      <path d={d} pathLength={100} fill="none" stroke="var(--tt-acc)" strokeWidth={gold} strokeLinecap="round" strokeLinejoin="round" className={s.bright} />
+      {shine != null && (
+        <path d={d} pathLength={100} fill="none" stroke="rgba(255,255,255,0.34)" strokeWidth={shine} strokeLinecap="round" strokeLinejoin="round" className={s.bright} />
+      )}
+    </>
+  );
+}
+
+export function TwinTickLoader({
+  variant = "orbit",
+  size,
+  speed = 1,
+  className,
+  label = "Loading",
+}: TwinTickLoaderProps) {
+  const px = size ?? DEFAULT_SIZE[variant];
+  const style = { width: px, height: px, ["--tt-spd" as string]: String(speed) } as React.CSSProperties;
+
+  // ── Inline: compact mark for rows / toasts (no ring) ──
+  if (variant === "inline") {
+    return (
+      <span className={clsx(s.wrap, className)} style={style} role="status" aria-label={label}>
+        <svg viewBox="0 0 128 128" className={s.svg} aria-hidden>
+          <path d="M22 56 L44 76 L82 30" pathLength={100} fill="none" stroke="var(--tt-ghost)" strokeWidth={14} strokeLinecap="round" strokeLinejoin="round" className={s.ghost} />
+          <BrightTick d="M40 74 L62 94 L100 48" ink={26} gold={16} />
+        </svg>
+      </span>
+    );
+  }
+
+  // ── Scan: lens line sweeps the drawing mark ──
+  if (variant === "scan") {
+    return (
+      <span className={clsx(s.wrap, s.scanBox, className)} style={style} role="status" aria-label={label}>
+        <svg viewBox="0 0 128 128" className={s.svg} aria-hidden>
+          <circle cx={60} cy={64} r={56} fill="none" stroke="var(--tt-ring)" strokeWidth={2} className={s.ringStatic} />
+          <path d="M22 56 L44 76 L82 30" pathLength={100} fill="none" stroke="var(--tt-ghost)" strokeWidth={13} strokeLinecap="round" strokeLinejoin="round" className={s.ghost} />
+          <BrightTick d="M40 74 L62 94 L100 48" ink={24} gold={15} shine={3.5} />
+        </svg>
+        <span className={s.scanLine} aria-hidden />
+      </span>
+    );
+  }
+
+  // ── Orbit: gold arc orbits the ring while the mark resolves ──
+  if (variant === "orbit") {
+    return (
+      <span className={clsx(s.wrap, className)} style={style} role="status" aria-label={label}>
+        <svg viewBox="0 0 128 128" className={s.svg} aria-hidden>
+          <circle cx={64} cy={64} r={56} fill="none" stroke="var(--tt-ring)" strokeWidth={2} className={s.ringStatic} />
+          <circle cx={64} cy={64} r={56} fill="none" stroke="var(--tt-acc)" strokeWidth={3} strokeLinecap="round" pathLength={100} strokeDasharray="22 78" className={s.orbitArc} />
+          <path d="M28 58 L48 76 L84 36" pathLength={100} fill="none" stroke="var(--tt-ghost)" strokeWidth={11} strokeLinecap="round" strokeLinejoin="round" className={s.ghost} />
+          <BrightTick d="M44 74 L62 90 L96 50" ink={20} gold={12} />
+        </svg>
+      </span>
+    );
+  }
+
+  // ── Pulse: the two ticks breathe in turn — calmest, ambient ──
+  if (variant === "pulse") {
+    return (
+      <span className={clsx(s.wrap, className)} style={style} role="status" aria-label={label}>
+        <svg viewBox="0 0 128 128" className={s.svg} aria-hidden>
+          <circle cx={60} cy={64} r={56} fill="none" stroke="var(--tt-ring)" strokeWidth={2} className={s.ringStatic} />
+          <g className={s.pulseGhost}>
+            <path d="M22 56 L44 76 L82 30" fill="none" stroke="var(--tt-ghost)" strokeWidth={13} strokeLinecap="round" strokeLinejoin="round" />
+          </g>
+          <g className={s.pulseBright}>
+            <path d="M40 74 L62 94 L100 48" fill="none" stroke="var(--tt-ink)" strokeWidth={24} strokeLinecap="round" strokeLinejoin="round" />
+            <path d="M40 74 L62 94 L100 48" fill="none" stroke="var(--tt-acc)" strokeWidth={15} strokeLinecap="round" strokeLinejoin="round" />
+          </g>
+        </svg>
+      </span>
+    );
+  }
+
+  // ── Sequential draw (primary): ring + ghost draw, then bright draw + pop ──
+  return (
+    <span className={clsx(s.wrap, className)} style={style} role="status" aria-label={label}>
+      <svg viewBox="0 0 128 128" className={s.svg} aria-hidden>
+        <circle cx={60} cy={64} r={56} fill="none" stroke="var(--tt-ring)" strokeWidth={2} className={s.ring} />
+        <path d="M22 56 L44 76 L82 30" pathLength={100} fill="none" stroke="var(--tt-ghost)" strokeWidth={13} strokeLinecap="round" strokeLinejoin="round" className={s.ghost} />
+        <g className={s.pop}>
+          <BrightTick d="M40 74 L62 94 L100 48" ink={24} gold={15} shine={3.5} />
+        </g>
+      </svg>
+    </span>
+  );
+}
+
+/**
+ * Compact circular spinner for busy buttons / inline rows. Uses `currentColor`,
+ * so it follows the button's text color (gold on dark, ink on gold buttons).
+ */
+export function TickButtonSpinner({ size = 18, className }: { size?: number; className?: string }) {
+  return (
+    <span className={clsx(s.wrap, className)} style={{ width: size, height: size }} role="status" aria-label="Loading">
+      <svg viewBox="0 0 50 50" className={s.svg} aria-hidden>
+        <circle cx={25} cy={25} r={20} fill="none" stroke="currentColor" strokeWidth={5} className={s.btnSpinnerTrack} />
+        <circle cx={25} cy={25} r={20} fill="none" stroke="currentColor" strokeWidth={5} strokeLinecap="round" pathLength={100} strokeDasharray="25 75" className={s.btnSpinnerArc} />
+      </svg>
+    </span>
+  );
+}

--- a/client/src/components/ui/Button.tsx
+++ b/client/src/components/ui/Button.tsx
@@ -1,5 +1,5 @@
 import { clsx } from "clsx";
-import { Loader2 } from "lucide-react";
+import { TickButtonSpinner } from "@/components/TwinTickLoader";
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: "primary" | "secondary" | "ghost";
@@ -29,7 +29,7 @@ export function Button({
       disabled={disabled || loading}
       {...props}
     >
-      {loading && <Loader2 className="h-5 w-5 animate-spin" />}
+      {loading && <TickButtonSpinner size={18} />}
       {children}
     </button>
   );

--- a/client/src/components/ui/Spinner.tsx
+++ b/client/src/components/ui/Spinner.tsx
@@ -1,16 +1,12 @@
-import { Loader2 } from "lucide-react";
 import { clsx } from "clsx";
+import { TickButtonSpinner } from "@/components/TwinTickLoader";
 
 interface SpinnerProps {
   className?: string;
   size?: number;
 }
 
+/** Compact brand spinner (Twin Tick circular). Follows `currentColor`. */
 export function Spinner({ className, size = 24 }: SpinnerProps) {
-  return (
-    <Loader2
-      className={clsx("animate-spin text-gold", className)}
-      size={size}
-    />
-  );
+  return <TickButtonSpinner size={size} className={clsx("text-gold", className)} />;
 }


### PR DESCRIPTION
## Summary
Follow-up to #52.

- **Twin Tick loaders** — new `TwinTickLoader` (sequential / orbit / pulse / scan / inline) + `TickButtonSpinner`, ported from the Zhentan Loaders design comp (gold, single duration, honors `prefers-reduced-motion`).
  - `ThemeLoader` → **pulse**; `ThemeLoaderSpinner` → **orbit**, with **scan** for the screening/analysis beats (SendPanel proposing, RequestDetailDialog screening).
  - Requests route loader → **sequential**.
  - Inline `Loader2` spinners swapped for `TickButtonSpinner` in `Button`, `Spinner`, `PrivyLoginButton`, and SwapPanel search.
  - No progress-bar variant used; RightRail sonar left untouched.
- **Real token icons on requests** — new `TokenGlyph` resolves a request's token icon from its symbol (fallback token list, optional `iconUrl` override) instead of a hardcoded USDC mark. Wired into `RequestRow` and `RequestDetailDialog`.

## Test plan
- `tsc --noEmit` passes; `next build` passes (all 14 routes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)