### PR TITLE
hotfix: allow BSC RPC override via env var

### DIFF
--- a/client/src/lib/constants.ts
+++ b/client/src/lib/constants.ts
@@ -48,7 +48,7 @@ export const ERC20_BALANCE_OF_ABI = [
 export const NATIVE_TOKEN_ADDRESS = "0x0000000000000000000000000000000000000000";
 export const NATIVE_DECIMALS = 18;
 
-export const BSC_RPC = "https://1rpc.io/bnb";
+export const BSC_RPC = process.env.NEXT_PUBLIC_BSC_RPC_URL || "https://1rpc.io/bnb";
 export const BSC_EXPLORER_URL = "https://bscscan.com";
 
 export function getPimlicoRpcUrl(apiKey: string): string {

--- a/server/src/lib/constants.ts
+++ b/server/src/lib/constants.ts
@@ -6,7 +6,7 @@ export const SAFE_PROXY_FACTORY: Hex =
   "0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67";
 export const SAFE_VERSION = "1.4.1" as const;
 
-export const BSC_RPC = "https://1rpc.io/bnb";
+export const BSC_RPC =  process.env.BSC_RPC_URL || "https://1rpc.io/bnb";
 
 /** Zero address used to identify native BNB transfers. */
 export const NATIVE_TOKEN_ADDRESS =


### PR DESCRIPTION
## What
Make the BSC RPC endpoint overridable via env var instead of being hardcoded to the public `https://1rpc.io/bnb`.

- **Client** (`client/src/lib/constants.ts`): reads `NEXT_PUBLIC_BSC_RPC_URL` (browser-exposed), falls back to 1rpc.io.
- **Server** (`server/src/lib/constants.ts`): reads `BSC_RPC_URL`, falls back to 1rpc.io.

## Why
Onboarding (and other client flows) were pinned to the public 1rpc.io endpoint with no way to override, so a flaky/rate-limited public RPC could break the flow. Both env vars are already documented in `server/.env.example`; set `NEXT_PUBLIC_BSC_RPC_URL` in the client env for a custom/reliable endpoint (requires a dev-server restart — NEXT_PUBLIC vars are inlined at build).

## Notes
- No secrets committed; `.env` is untracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)