### PR TITLE
docs: rewrite Mintlify docs for the 2-of-3 signing model

### DIFF
--- a/docs/api/cosign-transaction.mdx
+++ b/docs/api/cosign-transaction.mdx
@@ -1,0 +1,45 @@
+---
+title: Co-Sign Transaction
+description: Add the backup key's signature to a queued screening-off SafeTx, then relay-execute.
+---
+
+## POST /transactions/:id/cosign
+
+Completes a **user-proposed screening-off SafeTx** queued below the threshold: the backup key signs the transaction's `safeTxHash`, the server verifies the signature recovers to a **distinct non-agent owner** of that Safe, appends it, and triggers execution — **relay-only**, since the user's signatures now meet the threshold and the agent signs nothing it didn't screen.
+
+This is the mirror image of `POST /transactions/:id/sign`, which completes an *agent-proposed* (pre-signed) transaction with the user's primary signature.
+
+The same transaction can always be completed in the Safe app instead — confirm with the backup key at app.safe.global and Zhentan's sync worker reconciles the execution.
+
+## Request
+
+```json
+{
+  "signature": "0x..."
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `signature` | `string` | Yes | Backup key's EIP-712 signature over the transaction's `safeTxHash` |
+
+## Validation
+
+- The transaction must be a queued SafeTx with a proposer signature and no terminal state
+- The signature must recover to an owner of the Safe that is **not the agent** and has **not already signed**
+- Ownership: authenticated calls must belong to the transaction's Safe
+
+## Response
+
+```json
+{
+  "status": "cosigned",
+  "txId": "tx-1a2b3c4d",
+  "execution": { "status": "executed", "txHash": "0x..." }
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `status` | `cosigned` — the signature was verified and stored |
+| `execution` | Result of the relay execution triggered immediately after |

--- a/docs/api/execute-transaction.mdx
+++ b/docs/api/execute-transaction.mdx
@@ -1,32 +1,41 @@
 ---
 title: Execute Transaction
-description: Agent co-signs a pending transaction and submits it to the bundler.
+description: Relay a queued SafeTx on-chain — the agent pays gas, and signs only what it screened.
 ---
 
 ## POST /execute
 
-Called by the agent after the owner approves a REVIEW-tier transaction via Telegram. The agent co-signs 2-of-2 and submits the UserOperation to the Pimlico bundler.
+Executes a queued SafeTx. The agent EOA relays `execTransaction` and pays BNB gas. Its signing behavior depends on whose signatures are already on the row:
+
+- **User signatures below threshold, screening on:** the agent adds its confirmation (2 of 2) via the Safe Transaction Service, then executes. Called after an APPROVE verdict or a Telegram approval.
+- **User signatures meet the threshold** (starter wallets, or screening-off with a backup co-signature): **relay-only** — the agent submits and pays gas but contributes **no signature**.
+- **Screening off, below threshold:** refused with *"Awaiting backup co-signature"* — no caller (client, Telegram, MCP, or the agent itself) can make the agent sign an unscreened transaction. Complete the row via [`/cosign`](/api/cosign-transaction) or the Safe app. [Legacy v1 accounts](/technology/legacy) without a backup key are exempt.
+
+Idempotency and nonce races are handled server-side: if the Safe's on-chain nonce already passed the row's nonce, the server checks whether **this** transaction was executed from the Safe app (the override path) before marking it superseded.
 
 ## Request
 
 ```json
 {
-  "txId": "tx-1234567890"
+  "txId": "tx-1a2b3c4d"
 }
 ```
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `txId` | `string` | Yes | ID of the pending transaction to execute |
+| `txId` | `string` | Yes | ID of the queued transaction to execute |
 
 ## Response
 
 ```json
 {
+  "status": "executed",
+  "txId": "tx-1a2b3c4d",
   "txHash": "0x..."
 }
 ```
 
 | Field | Description |
 |-------|-------------|
-| `txHash` | On-chain transaction hash after successful execution |
+| `status` | `executed`, `already_executed`, or `superseded` |
+| `txHash` | On-chain transaction hash |

--- a/docs/api/introduction.mdx
+++ b/docs/api/introduction.mdx
@@ -20,9 +20,14 @@ The API is currently unauthenticated. It is designed to run locally alongside th
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| `POST` | `/queue` | Queue a transaction and get a risk verdict |
-| `POST` | `/execute` | Agent co-signs and submits a UserOperation |
-| `GET` | `/transactions` | List pending transactions |
+| `POST` | `/queue` | Propose a signed SafeTx — validated, mirrored to the Safe Transaction Service, risk-scored |
+| `POST` | `/execute` | Relay a queued SafeTx on-chain (agent pays gas; relay-only when user signatures meet the threshold) |
+| `POST` | `/transactions/:id/cosign` | Backup key completes a screening-off SafeTx queued below threshold |
+| `POST` | `/transactions/:id/sign` | User completes an agent-proposed (pre-signed) transaction |
+| `GET` | `/transactions` | List transactions with status |
+| `POST` | `/safe/derive` | Server-side counterfactual address derivation for a new account |
+| `GET` | `/users/by-signer/:address` | Resolve an existing account by its signer key |
+| `GET` | `/safe/nonce` | Next unused Safe nonce (Transaction Service queue-aware) |
 | `GET` | `/invoices` | List pending invoices |
 | `POST` | `/notify-resolve` | Update Telegram message with final outcome |
 | `GET` | `/portfolio` | Live portfolio data via Zerion |

--- a/docs/api/queue-transaction.mdx
+++ b/docs/api/queue-transaction.mdx
@@ -1,25 +1,51 @@
 ---
 title: Queue Transaction
-description: Submit a transaction for risk scoring and queuing.
+description: Propose a signed SafeTx for risk scoring, service mirroring, and queuing.
 ---
 
 ## POST /queue
 
-Receives a proposed transaction from the client. Runs `analyzeRisk()` inline and returns a verdict of APPROVE, REVIEW, or BLOCK.
+Receives a **signed SafeTx proposal** from the client. The server hard-validates it (signature recovery against the recorded owner set, threshold arithmetic, nonce/hash consistency), mirrors it to the **Safe Transaction Service** — so it appears in app.safe.global at 1 of 2 — then runs `analyzeRisk()` inline.
 
-- **APPROVE (< 40):** co-signs and executes the UserOperation immediately, returns `txHash`
-- **REVIEW (40–70):** queues for Telegram review, returns `id` and `verdict`
-- **BLOCK (> 70):** rejects and alerts via Telegram, returns `verdict`
+- **Screening on:**
+  - **APPROVE (< 40):** the agent confirms via the service and relays `execTransaction`
+  - **REVIEW (40–70):** queued for Telegram review, returns `id` and `verdict`
+  - **BLOCK (> 70):** rejected with alert — the pre-signed same-nonce cancel consumes the nonce
+- **Screening off (`screeningDisabled: true`):** queue-only — the server never analyzes, and the agent never signs. If the user signatures already meet the threshold, the client calls [`/execute`](/api/execute-transaction) (relay-only). Below threshold, the row waits for the backup key's [co-signature](/api/cosign-transaction).
+
+<Note>
+Proposals with `screeningDisabled` below the threshold are **rejected outright** for wallets whose own keys can never meet it (guarded wallets) — screening cannot be disabled there. [Legacy v1 accounts](/technology/legacy) without a backup key are exempt.
+</Note>
 
 ## Request
 
 ```json
 {
-  "to": "0xRecipientAddress",
-  "value": "0",
-  "data": "0x",
+  "id": "tx-1a2b3c4d",
+  "txType": "safetx",
   "safeAddress": "0xYourSafeAddress",
+  "safeTx": {
+    "to": "0xRecipientOrToken",
+    "value": "0",
+    "data": "0x...",
+    "operation": 0,
+    "safeTxGas": "0",
+    "baseGas": "0",
+    "gasPrice": "0",
+    "gasToken": "0x0000000000000000000000000000000000000000",
+    "refundReceiver": "0x0000000000000000000000000000000000000000",
+    "nonce": 7
+  },
+  "safeTxHash": "0x...",
+  "safeNonce": 7,
+  "proposedBy": "0xEmbeddedOwner",
   "userSignature": "0x...",
+  "userSignatures": [{ "signer": "0xBackupOwner", "data": "0x..." }],
+  "rejectionSignature": "0x...",
+  "ownerAddresses": ["0xEmbedded", "0xBackup", "0xAgent"],
+  "threshold": 2,
+  "screeningDisabled": false,
+  "to": "0xRecipientAddress",
   "token": "USDC",
   "amount": "100"
 }
@@ -27,28 +53,31 @@ Receives a proposed transaction from the client. Runs `analyzeRisk()` inline and
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `to` | `string` | Yes | Recipient address |
-| `value` | `string` | Yes | Native value in wei (usually `"0"` for token transfers) |
-| `data` | `string` | Yes | Calldata |
-| `safeAddress` | `string` | Yes | User's Safe smart account address |
-| `userSignature` | `string` | Yes | Owner's 1-of-2 signature |
-| `token` | `string` | No | Token symbol for display |
-| `amount` | `string` | No | Human-readable amount for display |
+| `id` | `string` | Yes | Client-generated transaction ID |
+| `txType` | `string` | Yes | `"safetx"` for all user transactions |
+| `safeAddress` | `string` | Yes | User's Safe address |
+| `safeTx` | `object` | Yes | The full SafeTx payload (EIP-712 message) |
+| `safeTxHash` | `string` | Yes | EIP-712 hash — recomputed and verified server-side |
+| `safeNonce` | `number` | Yes | Safe nonce (queue-tail, or current with force-execute) |
+| `proposedBy` | `string` | Yes | Owner address the signature must recover to |
+| `userSignature` | `string` | Yes | Proposer's EIP-712 signature over `safeTxHash` |
+| `userSignatures` | `array` | No | Additional co-signatures (each must recover to a distinct non-agent owner) |
+| `rejectionSignature` | `string` | Yes | Proposer's signature over the same-nonce empty cancel tx |
+| `screeningDisabled` | `boolean` | No | Queue-only mode — requires user signatures to meet the threshold before execution |
+| `token`, `amount`, `to` | `string` | No | Display metadata |
 
 ## Response
 
 ```json
 {
-  "id": "tx-1234567890",
-  "verdict": "APPROVE",
-  "score": 15,
-  "txHash": "0x..."
+  "success": true,
+  "id": "tx-1a2b3c4d",
+  "risk": { "riskScore": 15, "verdict": "APPROVE", "reasons": [] }
 }
 ```
 
 | Field | Description |
 |-------|-------------|
 | `id` | Transaction ID in the queue |
-| `verdict` | `APPROVE`, `REVIEW`, or `BLOCK` |
-| `score` | Risk score (0–100) |
-| `txHash` | On-chain hash (present only if APPROVE) |
+| `risk` | Present when screening is on — score, verdict, reasons |
+| `serviceWarning` | Present if the Safe Transaction Service mirror failed (queuing still succeeds) |

--- a/docs/app/overview.mdx
+++ b/docs/app/overview.mdx
@@ -20,15 +20,29 @@ Zhentan is a smart wallet with built-in AI screening. Every transaction you init
   </Card>
 </CardGroup>
 
+## Wallet Profiles
+
+Your wallet is a Safe multisig with one of four [computed profiles](/technology/signing#wallet-profiles):
+
+| Profile | Keys | What it means |
+|---------|------|---------------|
+| **Starter** | You | Instant onboarding — your signature alone executes; no screening yet |
+| **Guarded** | You + agent | Screening always on (your key can't reach the threshold alone) |
+| **Protected** | You + backup + agent | The full model — screening by choice, override always available |
+| **Detached** | You + backup | Exit state — a stock Safe, agent removed |
+
+Add a backup key anytime (paste an address, ENS/.bnb name, or connect a wallet — no signature needed) to move from Guarded to Protected.
+
 ## Screening Modes
 
 | Mode | Behavior |
 |------|----------|
 | **ON** | Full pipeline — APPROVE / REVIEW / BLOCK on every transaction |
-| **OFF** | Regular multisig — agent auto-executes without screening |
+| **OFF** (Protected) | Transactions queue at 1 of 2 and execute once your backup key co-signs — in-app or in the Safe app. The agent relays without signing |
+| **OFF** (Legacy v1) | The agent co-signs without risk analysis — see [Legacy Accounts](/technology/legacy) |
 
-Toggle anytime from Telegram: `screening on` / `screening off`
+Toggle from Settings (Zhentan Guard) or Telegram: `screening on` / `screening off`. Guarded wallets can't turn screening off — add a backup key first.
 
-## Gasless Transactions
+## Gas
 
-All transactions on Zhentan are gasless. The Pimlico paymaster sponsors gas fees via ERC-4337 account abstraction — you never need BNB to execute transactions.
+You never need BNB — the agent relays every execution on-chain and pays gas. Your signatures authorize; the agent submits.

--- a/docs/app/screening.mdx
+++ b/docs/app/screening.mdx
@@ -54,6 +54,19 @@ When a transaction is in REVIEW, you'll get a Telegram message with:
 
 Tap **Approve** to execute, or **Reject** to block it.
 
+## Overriding the Agent
+
+The agent advises — it doesn't gatekeep. In a **Protected** wallet, every proposal already sits in [app.safe.global](https://app.safe.global) at 1 of 2 signatures. If the agent flags or blocks something you're sure about, confirm it there with your backup key and execute — Zhentan syncs the result back automatically.
+
+## Turning Screening Off
+
+Screening is a choice in Protected wallets:
+
+1. Toggle it off in **Settings → Zhentan Guard** (or via Telegram).
+2. Your transactions now need **both of your keys** — the agent never signs what it didn't screen. Each send queues at 1 of 2 and completes when you co-sign with your backup wallet, either in-app (from transaction history) or in the Safe app.
+
+Guarded wallets can't turn screening off — with one user key against a threshold of two, no second signature could exist. Add a backup key first. [Legacy v1 accounts](/technology/legacy) are the exception: their agent co-signs without analysis until they upgrade.
+
 ## Learning Over Time
 
 After every confirmed transaction, Zhentan records the pattern. Recipients you transact with regularly become "known," amounts normalize, and your screening becomes more accurate over time — with fewer false REVIEW alerts.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -61,9 +61,11 @@
             "group": "Technology",
             "pages": [
               "technology/overview",
+              "technology/signing",
               "technology/architecture",
               "technology/risk-scoring",
               "technology/agent",
+              "technology/legacy",
               "technology/contracts"
             ]
           }
@@ -88,7 +90,8 @@
           {
             "group": "Execute",
             "pages": [
-              "api/execute-transaction"
+              "api/execute-transaction",
+              "api/cosign-transaction"
             ]
           },
           {

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -3,14 +3,14 @@ title: Introduction
 description: Your personalized onchain detective and assistant that learns and guards your onchain behavior.
 ---
 
-Zhentan is a personalized wallet assistant that acts as an AI co-signer on a Safe 2-of-2 multisig. It learns your behavioral patterns and screens every transaction before it executes — blocking threats, flagging anomalies for review, and auto-approving routine activity.
+Zhentan is a personalized wallet assistant that acts as an AI co-signer on a Safe multisig **where you always hold the majority of keys**. In the full 2-of-3 model — your embedded key, your backup key, and the agent — it learns your behavioral patterns and screens every transaction before it executes: blocking threats, flagging anomalies for review, and auto-approving routine activity. And because your two keys meet the signing threshold, you can always execute from the official Safe app without the agent.
 
 <CardGroup cols="2">
   <Card title="Zhentan App" icon="shield-check" iconType="duotone" href="/app/overview">
     Send, receive, and connect to DApps with AI-powered transaction screening on every action.
   </Card>
   <Card title="Technology" icon="microchip" iconType="duotone" href="/technology/overview">
-    Deep dive into the architecture — Safe multisig, ERC-4337, risk scoring, and the NanoBot/Hermes agent.
+    Deep dive into the architecture — the 2-of-3 signing model, Safe Transaction Service, risk scoring, and the NanoBot/Hermes agent.
   </Card>
   <Card title="Quickstart" icon="rocket-launch" iconType="duotone" href="/quickstart">
     Run Zhentan locally with full AI screening in minutes.
@@ -30,7 +30,7 @@ DeFi wallets offer no protection between "sign" and "execute." Once you click ap
 
 ## How It Works
 
-Zhentan adds an AI co-signer to your Safe wallet. Every transaction is scored 0–100 against your learned behavioral patterns before anything executes.
+Zhentan adds an AI co-signer to your Safe wallet. Every transaction is a standard SafeTx — visible in [app.safe.global](https://app.safe.global) from the moment you sign — scored 0–100 against your learned behavioral patterns before anything executes. The agent relays execution and pays gas; it never signs a transaction it didn't screen, and it can never move funds alone.
 
 | Score | Verdict | Action |
 |-------|---------|--------|

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -13,10 +13,15 @@ description: Get Zhentan running locally with full AI screening in minutes.
 
 You'll also need accounts for:
 
-- [Privy](https://privy.io) — embedded wallet + Google OAuth
-- [Pimlico](https://pimlico.io) — gasless bundler API key
+- [Privy](https://privy.io) — embedded wallets, Google OAuth, and wallet login
+- [Safe API key](https://developer.safe.global) — Safe Transaction Service access (proposal mirroring + sync)
 - Telegram bot token — for review notifications
 - [Zerion](https://zerion.io) — portfolio data (optional)
+- [Pimlico](https://pimlico.io) — **legacy accounts only** (pre-refactor 4337 rows and treasury payouts)
+
+<Note>
+The agent EOA relays every execution and deploys Safes — it must hold BNB for gas. The `AGENT_MIN_BNB` threshold (default 0.05) triggers a low-balance alert.
+</Note>
 
 ## Install
 
@@ -34,7 +39,6 @@ pnpm install
 
     ```env
     NEXT_PUBLIC_PRIVY_APP_ID=your_privy_app_id
-    NEXT_PUBLIC_PIMLICO_API_KEY=your_pimlico_api_key
     NEXT_PUBLIC_AGENT_ADDRESS=0xYourAgentAddress
     NEXT_PUBLIC_BACKEND_URL=http://localhost:3001
     NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=your_walletconnect_project_id
@@ -45,9 +49,12 @@ pnpm install
 
     ```env
     AGENT_PRIVATE_KEY=0xYourAgentPrivateKey
-    PIMLICO_API_KEY=your_pimlico_api_key
+    SAFE_API_KEY=your_safe_transaction_service_key
+    SAFE_DERIVATION_VERSION=2
+    AGENT_MIN_BNB=0.05
     TELEGRAM_BOT_TOKEN=your_telegram_bot_token
     ZERION_API_KEY=your_zerion_api_key
+    PIMLICO_API_KEY=your_pimlico_api_key   # legacy 4337 rows + treasury only
     PORT=3001
     QUEUE_PATH=./pending-queue.json
     ```
@@ -89,25 +96,25 @@ See `scripts/.env.example` and `server/.env.example` for full templates.
 ## Verify It Works
 
 1. Visit `http://localhost:3000`
-2. Sign in with Google → embedded wallet is created
-3. A Safe smart account is deployed on BNB Chain
+2. Sign in with Google (embedded wallet) or connect a wallet — then pick a [profile](/technology/signing#wallet-profiles) during onboarding
+3. A Safe multisig is deployed on BNB Chain (the agent pays gas)
 4. Navigate to **Send** → enter a recipient and amount
-5. Confirm → transaction is queued
+5. Confirm → the SafeTx is queued **and visible at app.safe.global at 1/2**
 6. Check server logs for the risk score and verdict
-7. **APPROVE**: tx executes automatically, txHash appears in the UI
-8. **REVIEW**: check Telegram for the interactive approve/reject message
+7. **APPROVE**: the agent confirms and relays — txHash appears in the UI
+8. **REVIEW**: check Telegram for the interactive approve/reject message (or override with your backup key in the Safe app)
 
 ## Troubleshooting
 
 <AccordionGroup>
   <Accordion title="Transaction stuck in queue">
-    Check server logs for Pimlico API errors. Verify `AGENT_PRIVATE_KEY` is correctly set in `server/.env`.
+    Verify `AGENT_PRIVATE_KEY` is set and the agent EOA holds BNB — it relays every execution. If the proposal isn't visible in app.safe.global, check `SAFE_API_KEY`.
   </Accordion>
   <Accordion title="No Telegram notification">
     Verify `TELEGRAM_BOT_TOKEN` is set in `server/.env` and the bot has been started in your Telegram chat.
   </Accordion>
   <Accordion title="Safe not deploying">
-    Confirm BNB Chain RPC is reachable and your Pimlico API key has BSC network access enabled.
+    Confirm BNB Chain RPC is reachable and the agent EOA has enough BNB to pay deployment gas.
   </Accordion>
   <Accordion title="Balance not showing">
     `ZERION_API_KEY` may be missing from `server/.env`. Portfolio data requires a valid Zerion API key.

--- a/docs/technology/architecture.mdx
+++ b/docs/technology/architecture.mdx
@@ -7,15 +7,17 @@ description: System overview, component breakdown, and data flow.
 
 | Component | Role |
 |-----------|------|
-| `client/` | Next.js 14 frontend — onboarding, dashboard, send/receive, WalletConnect, invoices |
-| `server/` | Express API — inline risk analysis, queue management, Zerion portfolio |
-| `agent/` | NanoBot/Hermes skill pack — Telegram commands, deep analysis, 2nd signature, pattern recording |
+| `client/` | Next.js 14 frontend — onboarding, wallet profiles, dashboard, send/swap, WalletConnect, invoices |
+| `server/` | Express API — inline risk analysis, queue management, Safe Transaction Service integration, address derivation, relay execution, Zerion portfolio |
+| `agent/` | NanoBot/Hermes skill pack — Telegram commands, deep analysis, screening decisions, pattern recording |
 
 ```mermaid
 flowchart TD
-    U[User Browser] -->|Privy login + embedded wallet| C[Client :3000]
+    U[User Browser] -->|Privy login — Google + embedded wallet, or wallet login| C[Client :3000]
     D[DApp e.g. PancakeSwap] -->|WalletConnect| C
-    C -->|POST /queue — user signs 1-of-2| S[Server :3001]
+    C -->|POST /queue — SafeTx, EIP-712 signed 1-of-2| S[Server :3001]
+    S -->|propose 1/2| TS[Safe Transaction Service]
+    TS -->|visible + confirmable| SA[app.safe.global]
     S -->|analyzeRisk inline| R{Risk Score}
     R -->|< 40 APPROVE| OC[NanoBot/Hermes Agent]
     R -->|40-70 REVIEW| OC
@@ -23,19 +25,20 @@ flowchart TD
     OC -->|REVIEW: deep-analyze| EXT[GoPlus / Honeypot.is]
     EXT -->|address + token report| OC
     OC <-->|REVIEW: report + buttons\nBLOCK: alert| TG[Telegram / User]
-    OC -->|signs 2-of-2| B[Bundler]
-    B -->|UserOperation| BC[BNB Chain]
+    OC -->|confirm 2/2 via service| TS
+    OC -->|execTransaction — agent pays gas| BC[BNB Chain]
+    SA -->|override: backup key confirms + executes| BC
     BC -->|txHash| C
     BC -->|confirmed| OC
-    OC -->|record-pattern| P[(patterns.json)]
+    OC -->|record-pattern| P[(patterns)]
 ```
 
 ## Client
 
 - **Next.js 14** App Router, React 18, TypeScript, Tailwind CSS, Framer Motion
-- **Privy** for Google OAuth + embedded wallet creation
-- Deploys a Safe 2-of-2 smart account per user (owner = user's embedded wallet, co-signer = agent address)
-- Signs 1-of-2, then POSTs to `/queue`
+- **Privy** auth — Google OAuth + embedded wallet, or **wallet login** (MetaMask / Rabby as the signing key), plus a signature-free backup-key link
+- Wallets are Safe multisigs with [computed profiles](/technology/signing#wallet-profiles) — starter / guarded / protected / detached
+- Signs standard SafeTxs (EIP-712), 1 of the threshold, then POSTs to `/queue`
 - **WalletConnect v2** — acts as a wallet for DApps; requests flow through the same pipeline
 - **Portfolio** via Zerion API (live balances, prices, 24h change)
 
@@ -43,14 +46,18 @@ flowchart TD
 
 - **Express** with TypeScript (`tsx` for dev, PM2 for production)
 - Runs `analyzeRisk()` inline on every `/queue` request — no async roundtrip
-- File-based JSON storage shared with the agent
+- **Hard-validates every proposal**: signature recovery against the recorded owner set, threshold arithmetic for screening-off, and owner-management transitions
+- Mirrors every proposal to the **Safe Transaction Service** so it appears in app.safe.global at 1/2; a `safeSync` worker reconciles transactions confirmed or executed there directly
+- **Relays execution**: the agent EOA submits `execTransaction` and pays BNB gas — relay-only (no agent signature) whenever user signatures meet the threshold
+- Derives addresses server-side through a [versioned registry](/technology/signing#address-derivation); user records and transactions persist in Supabase (Postgres)
 
 ## Agent
 
-- **NanoBot/Hermes skill pack** — holds the 2nd signing key
+- **NanoBot/Hermes skill pack** — holds the agent owner key
 - Responds to Telegram commands from the owner
 - Runs deep analysis (GoPlus + Honeypot.is) on REVIEW-tier transactions
 - Records patterns after every confirmed transaction
+- **Never signs unscreened transactions** — with screening off it either relays only (v2) or, for [legacy v1 accounts](/technology/legacy), co-signs by explicit exemption
 
 ## Data Flow
 
@@ -58,19 +65,19 @@ flowchart TD
 sequenceDiagram
     participant C as Client
     participant S as Server
+    participant TS as Safe Tx Service
     participant OC as NanoBot/Hermes Agent
     participant EXT as GoPlus / Honeypot.is
     participant TG as Telegram
-    participant B as Bundler
     participant BC as BNB Chain
 
-    C->>S: POST /queue {tx, userSignature 1-of-2}
+    C->>S: POST /queue {SafeTx, EIP-712 signature 1-of-2}
+    S->>TS: propose (1/2 in app.safe.global)
     S->>S: analyzeRisk() → score
     S->>OC: notify (verdict + score)
     alt APPROVE
-        OC->>OC: sign 2-of-2
-        OC->>B: sendUserOperation
-        B->>BC: execute
+        OC->>TS: confirm (2/2)
+        OC->>BC: execTransaction (agent pays gas)
         BC-->>C: txHash
         OC->>S: record-pattern
     else REVIEW
@@ -78,33 +85,34 @@ sequenceDiagram
         EXT-->>OC: address reputation, token security
         OC->>TG: analysis report + [Approve] [Reject]
         TG-->>OC: user responds
-        OC->>OC: sign 2-of-2 (if approved)
-        OC->>B: sendUserOperation
-        B->>BC: execute
+        OC->>BC: execTransaction (if approved)
         OC->>S: record-pattern
     else BLOCK
         OC->>TG: blocked alert
+        Note over C,BC: Override: user confirms with backup key in the Safe app — safeSync reconciles
     end
 ```
 
-## State Files
+Rejections execute a **pre-signed empty transaction at the same nonce**, so a rejected proposal never leaves a nonce hole blocking later transactions.
 
-| File | Purpose |
-|------|---------|
-| `pending-queue.json` | Queued transactions awaiting processing |
-| `invoice-queue.json` | Pending invoice requests |
-| `state.json` | Screening mode and agent decisions |
-| `patterns.json` | Learned behavioral patterns |
+## State
+
+| Store | Purpose |
+|-------|---------|
+| Supabase (Postgres) | User records (owner sets, thresholds, immutable creation snapshots), transaction queue and outcomes |
+| Safe Transaction Service | Proposal mirror — the source the Safe app reads and writes |
+| `state.json` | Screening mode and agent decisions (agent runtime) |
+| `patterns.json` | Learned behavioral patterns (agent runtime) |
 
 ## Tech Stack
 
 | Layer | Technology |
 |-------|-----------|
 | Chain | BNB Chain (BSC), Chain ID 56 |
-| Smart Account | Safe 1.4.1 + ERC-4337 (EntryPoint v0.7) |
-| Bundler/Paymaster | Pimlico (gasless) |
+| Smart Account | Safe 1.4.1 multisig — standard SafeTx flow via the Safe Transaction Service |
+| Gas | Agent EOA relays `execTransaction` and pays BNB (ERC-4337/Pimlico survives only for legacy queued rows) |
 | Frontend | Next.js 14, React 18, TypeScript, Tailwind CSS, Framer Motion |
-| Auth | Privy (embedded wallets + Google OAuth) |
-| Blockchain libs | viem, permissionless.js |
-| Backend | Express, tsx (dev), PM2 (production) |
+| Auth | Privy (Google OAuth + embedded wallets, wallet login, backup-key linking) |
+| Blockchain libs | viem, @safe-global/protocol-kit + api-kit |
+| Backend | Express, Supabase (Postgres), tsx (dev), PM2 (production) |
 | AI Agent | NanoBot/Hermes with Qwen3-235B / Claude Sonnet 4.5 via OpenRouter |

--- a/docs/technology/contracts.mdx
+++ b/docs/technology/contracts.mdx
@@ -1,9 +1,16 @@
 ---
 title: Contract Deployments
-description: Safe, ERC-4337, and infrastructure contract addresses on BNB Chain.
+description: Safe and infrastructure contract addresses on BNB Chain.
 ---
 
-All Zhentan smart accounts are Safe 1.4.1 proxies with an ERC-4337 module, deployed on BNB Chain (BSC). Transactions are submitted as ERC-4337 UserOperations via Pimlico's bundler and paymaster.
+All Zhentan smart accounts are **Safe 1.4.1 proxies** on BNB Chain (BSC). Account creation is versioned — the recipe that derives an account's address is pinned forever in its immutable creation snapshot:
+
+| Derivation | Recipe | Applies to |
+|------------|--------|-----------|
+| **v2** (current) | Vanilla stock Safe — protocol-kit initializer, `CompatibilityFallbackHandler`, **no modules** | All new accounts |
+| **v1** (legacy) | Permissionless initializer with the `Safe4337Module` enabled | Pre-refactor accounts, [pinned forever](/technology/legacy) |
+
+Transactions execute as standard Safe `execTransaction` calls relayed by the agent EOA (which pays BNB gas). ERC-4337 UserOperations survive **only** for legacy pre-refactor queued transactions.
 
 ## Smart Account Infrastructure
 
@@ -11,13 +18,20 @@ All Zhentan smart accounts are Safe 1.4.1 proxies with an ERC-4337 module, deplo
 |----------|---------|-------------|
 | Safe Singleton 1.4.1 | [`0x29fcB43b46531BcA003ddC8FCB67FFE91900C762`](https://bscscan.com/address/0x29fcB43b46531BcA003ddC8FCB67FFE91900C762) | Smart account implementation used by all Safe proxies |
 | Safe Proxy Factory | [`0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67`](https://bscscan.com/address/0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67) | Deploys per-user Safe proxy instances |
-| Safe4337Module | [`0x75cf11467937ce3F2f357CE24ffc3DBF8fD5c226`](https://bscscan.com/address/0x75cf11467937ce3F2f357CE24ffc3DBF8fD5c226) | ERC-4337 module enabling UserOperation support on Safe |
+| Safe4337Module | [`0x75cf11467937ce3F2f357CE24ffc3DBF8fD5c226`](https://bscscan.com/address/0x75cf11467937ce3F2f357CE24ffc3DBF8fD5c226) | ERC-4337 module — **v1 (legacy) accounts only** |
 
-## ERC-4337
+## ERC-4337 (Legacy Only)
 
 | Contract | Address | Description |
 |----------|---------|-------------|
-| EntryPoint v0.7 | [`0x0000000071727De22E5E9d8BAf0edAc6f37da032`](https://bscscan.com/address/0x0000000071727De22E5E9d8BAf0edAc6f37da032) | ERC-4337 entry point — all UserOperations submitted via `handleUserOps()` |
+| EntryPoint v0.7 | [`0x0000000071727De22E5E9d8BAf0edAc6f37da032`](https://bscscan.com/address/0x0000000071727De22E5E9d8BAf0edAc6f37da032) | ERC-4337 entry point — used only for pre-refactor queued transactions |
+
+## Services
+
+| Service | Role |
+|---------|------|
+| [Safe Transaction Service](https://docs.safe.global/core-api/transaction-service-overview) | Every proposal is mirrored here at 1/2 — the same backend app.safe.global reads, which is what makes the [user override path](/technology/signing#the-2-of-3-model) work |
+| [Pimlico](https://pimlico.io) | Bundler/paymaster — legacy 4337 rows and treasury payouts only |
 
 ## Network
 
@@ -25,6 +39,5 @@ All Zhentan smart accounts are Safe 1.4.1 proxies with an ERC-4337 module, deplo
 |-----------|-------|
 | Chain | BNB Chain (BSC) |
 | Chain ID | 56 |
-| RPC | `https://1rpc.io/bnb` |
+| RPC | `https://1rpc.io/bnb` (overridable via env) |
 | Explorer | [bscscan.com](https://bscscan.com) |
-| Bundler / Paymaster | [Pimlico](https://pimlico.io) |

--- a/docs/technology/legacy.mdx
+++ b/docs/technology/legacy.mdx
@@ -1,0 +1,60 @@
+---
+title: Legacy Accounts (v1)
+description: How pre-refactor 2-of-2 accounts work today, what rules apply to them, and how they upgrade to the full model.
+---
+
+Accounts created before the 2-of-3 refactor are **v1 accounts**: Safe 2-of-2 multisigs with owners `[embedded, agent]`, deployed with the ERC-4337 module enabled and originally executed as gasless UserOperations via Pimlico.
+
+They keep working without any action — but they run under a few carefully-scoped exceptions, and everything normalizes the moment they upgrade.
+
+## What v1 Means Today
+
+| Aspect | v1 behavior |
+|--------|-------------|
+| **Profile** | Classifies as **Guarded** — one user key, agent co-signer, threshold 2 |
+| **Address derivation** | Pinned to the v1 recipe (4337-module initializer) **forever** — the derivation version is part of the account's immutable creation snapshot, so its address stays re-derivable |
+| **Execution** | New transactions use the standard SafeTx flow like everyone else; ERC-4337 survives **only** for pre-refactor queued rows (`tx_type='4337'`) |
+| **Screening off** | Allowed, with the agent as blind co-signer (see below) |
+
+## The Screening-Off Exception
+
+The strict rule — *the agent never signs what it didn't screen* — would strand a v1 user the instant they paused screening: their single key can't reach the threshold, and no backup key exists to complete the transaction. These users have relied on the agent as co-signer since before the rule existed.
+
+So v1 accounts get a capability-scoped exemption:
+
+<Note>
+A v1 account **without a backup key** may pause screening; the agent still co-signs (it just skips risk analysis). The exemption is keyed on **capability, not version** — it applies only while the account's own keys cannot meet the threshold. The moment a backup key is added, the strict v2 rules apply automatically.
+</Note>
+
+This is enforced in three places: at proposal validation, again at execution (defense in depth — no surface can make the agent sign an unscreened transaction for an upgraded account), and in the client flow.
+
+## Upgrading to the Full Model
+
+The upgrade is a single owner-management Safe transaction on the **same address**:
+
+```
+addOwnerWithThreshold(backupKey, 2)
+```
+
+After it executes, the account is a standard **Protected** wallet:
+
+- **Owner set**: `[embedded, backup, agent]`, threshold 2 — your two keys hold the majority.
+- **Screening becomes a real choice**: pausing it now routes transactions through the [queue-and-co-sign flow](/technology/signing#screening-off-queue-and-co-sign) — the agent relays without signing.
+- **The override path opens**: any flagged transaction can be completed from app.safe.global with your backup key.
+- **Same address, same history** — nothing migrates; the profile is recomputed from the new owner set.
+
+The app guides upgraded users through what changed with a short settings walkthrough on their first visit after upgrading.
+
+<Warning>
+The derivation version does **not** change on upgrade — it is the recipe that produced the account's address and must stay pinned for the address to remain re-derivable. "v1" describes how an account was born, not how it behaves: an upgraded v1 account follows every v2 signing rule.
+</Warning>
+
+## Adding a Backup Key
+
+The backup key is deliberately low-friction — it needs **no signature and no session** to be registered:
+
+- Paste any address
+- Resolve an ENS or `.bnb` name
+- Connect a wallet (signature-free read of the address)
+
+A cold or hardware wallet works fine as a backup: co-signing is only needed for screening-off execution or the override path, and both can also be completed in the Safe app.

--- a/docs/technology/overview.mdx
+++ b/docs/technology/overview.mdx
@@ -3,9 +3,12 @@ title: Overview
 description: Technical overview of how Zhentan is built.
 ---
 
-Zhentan is built on three independently runnable components that work together: an instant deterministic scoring layer, an interactive AI agent layer, and a smart account execution layer.
+Zhentan is built on three independently runnable components that work together: an instant deterministic scoring layer, an interactive AI agent layer, and a Safe multisig execution layer where **the user always holds the majority of keys**.
 
 <CardGroup cols="2">
+  <Card title="Signing & Wallet Profiles" icon="signature" iconType="duotone" href="/technology/signing">
+    The 2-of-3 model — profiles, transitions, relay-only execution, and the Safe Transaction Service flow.
+  </Card>
   <Card title="Architecture" icon="diagram-project" iconType="duotone" href="/technology/architecture">
     System overview, component breakdown, and data flow diagrams.
   </Card>
@@ -15,14 +18,18 @@ Zhentan is built on three independently runnable components that work together: 
   <Card title="Agent" icon="robot" iconType="duotone" href="/technology/agent">
     The NanoBot/Hermes skill pack — skills, lifecycle, and Telegram commands.
   </Card>
+  <Card title="Legacy Accounts" icon="clock-rotate-left" iconType="duotone" href="/technology/legacy">
+    How pre-refactor 2-of-2 accounts work and how they upgrade to the full model.
+  </Card>
   <Card title="Contract Deployments" icon="file-contract" iconType="duotone" href="/technology/contracts">
-    Safe, ERC-4337, and infrastructure contract addresses on BNB Chain.
+    Safe and infrastructure contract addresses on BNB Chain.
   </Card>
 </CardGroup>
 
 ## Design Principles
 
+- **The user holds the majority** — in the full 2-of-3 model your two keys meet the threshold. The agent is an advisory speed bump you can always go around via the Safe app, never a gatekeeper.
+- **The agent never signs what it didn't screen** — when your signatures alone meet the threshold, the agent relays and pays gas without contributing a signature. Enforced server-side at proposal and again at execution.
 - **No LLM on the hot path** — inline risk scoring is deterministic and instant. The agent only steps in after a verdict is reached.
-- **Safe multisig is the foundation** — battle-tested infrastructure. Zhentan adds AI intelligence on top without replacing key management.
-- **The agent owns communication and the 2nd key** — no transaction executes without its signature, making it genuinely agentic.
+- **Safe multisig is the foundation** — every transaction is a standard SafeTx, visible and actionable in the official Safe app at every stage. Zhentan adds intelligence on top without replacing key management.
 - **Continuous learning** — patterns are recorded after every confirmed transaction. The profile improves automatically.

--- a/docs/technology/signing.mdx
+++ b/docs/technology/signing.mdx
@@ -1,0 +1,114 @@
+---
+title: Signing & Wallet Profiles
+description: The 2-of-3 signing model — user-held majority, agent as advisor, and how every transaction reaches the chain.
+---
+
+Zhentan wallets are Safe multisigs where **the user always holds the majority of keys**. The agent co-signs and pays gas, but it can never move funds alone — and in the full model, it can't stop you either.
+
+## The 2-of-3 Model
+
+A fully set up Zhentan wallet has three owners and a threshold of 2:
+
+| Owner | Held by | Role |
+|-------|---------|------|
+| **Embedded key** | You (Privy embedded wallet, or your connected wallet for wallet login) | Proposes and signs every transaction |
+| **Backup key** | You (any external wallet — pasted address, ENS/.bnb name, or connected) | Your override and recovery key |
+| **Agent key** | Zhentan agent | Screens, co-signs approved transactions, relays and pays gas |
+
+Your two keys meet the threshold — so the agent is an **advisory speed bump, not a gatekeeper**. If it ever blocks something you want (or disappears entirely), you can execute from [app.safe.global](https://app.safe.global) with your embedded + backup keys and go around it.
+
+<Note>
+**Two hard invariants**, enforced server-side on every proposal:
+
+1. The agent **never reaches the threshold alone** — it cannot move funds without you.
+2. The agent **never signs a transaction it didn't screen** — when screening is off, your own keys must meet the threshold and the agent only relays.
+</Note>
+
+## Wallet Profiles
+
+Profiles are **computed from the live owner set and threshold** — never stored. Every wallet is exactly one of:
+
+| Profile | Owners | Threshold | Screening | Notes |
+|---------|--------|-----------|-----------|-------|
+| **Starter** | `[embedded]` | 1 | Unavailable | Instant onboarding. Your signature alone executes; the agent relays and pays gas without signing. |
+| **Guarded** | `[embedded, agent]` | 2 | Structurally mandatory | Your key can't reach the threshold alone, so screening can't be turned off. Lockout risk is disclosed at creation; the app persistently nudges you to add a backup key. |
+| **Protected** | `[embedded, backup, agent]` | 2 | On by default, toggleable | The full model. Your two keys meet the threshold — screening is a choice, and the Safe-app override is always available. |
+| **Detached** | `[embedded, backup]` | 2 | None | Exit state. "Detach Zhentan" removes the agent — same address, stock Safe. |
+
+### Transitions
+
+All transitions are hard-validated owner-management SafeTxs **on the same address** — your Safe address never changes:
+
+| From → To | Mechanism |
+|-----------|-----------|
+| Starter → Guarded | Add agent + raise threshold |
+| Starter → Protected | Atomic MultiSend batch — never passes through an unmanaged intermediate state |
+| Guarded → Protected | `addOwnerWithThreshold(backup)` |
+| Protected → Detached | Remove agent (the exit) |
+
+Every account keeps an **immutable creation snapshot** (creation owners, threshold, salt nonce, derivation version — frozen by a database trigger), so its address stays re-derivable forever even after transitions rewrite the live owner set.
+
+## Transaction Flow
+
+Every user transaction is a standard Safe transaction (EIP-712 SafeTx) — visible and actionable in the official Safe app at every stage:
+
+```mermaid
+sequenceDiagram
+    participant U as User (embedded key)
+    participant S as Zhentan Server
+    participant TS as Safe Transaction Service
+    participant A as Agent
+    participant BC as BNB Chain
+
+    U->>S: POST /queue — SafeTx + EIP-712 signature (1 of 2)
+    S->>TS: propose — appears in app.safe.global at 1/2
+    S->>S: analyzeRisk() → APPROVE / REVIEW / BLOCK
+    alt APPROVE (screened)
+        A->>TS: confirm (2 of 2)
+        A->>BC: execTransaction — agent EOA pays BNB gas
+        BC-->>U: executed
+    else REVIEW
+        A->>U: Telegram report + [Approve] [Reject]
+    else BLOCK
+        A->>U: blocked alert (override still available in the Safe app)
+    end
+```
+
+Key properties:
+
+- **The agent relays and pays gas.** Users never need BNB — the agent EOA submits `execTransaction` on-chain.
+- **Rejections never leave nonce holes.** Every proposal pre-signs a same-nonce empty cancel transaction, so a rejection consumes the nonce cleanly and later proposals aren't blocked.
+- **The Safe app is a first-class surface.** A sync worker reconciles transactions confirmed or executed directly from app.safe.global — the override path is fully supported, not an afterthought.
+
+## Relay-Only Execution
+
+Whenever your own signatures meet the threshold, the agent contributes **no signature** — it only submits the transaction and pays gas:
+
+- **Starter** (threshold 1): your signature alone.
+- **Protected with screening off**: your embedded + backup signatures.
+
+This is what makes "the agent never signs what it didn't screen" enforceable rather than aspirational.
+
+## Screening Off: Queue and Co-Sign
+
+In a Protected wallet you can pause screening. Your transactions then need **both of your keys**:
+
+1. You propose and sign as usual — the transaction queues at **1 of 2** and is mirrored to the Safe Transaction Service.
+2. Complete it whenever you like, from either surface:
+   - **In-app** — open the transaction in your history and tap **Sign with [your backup wallet]**. If the backup wallet isn't connected, the app walks you through a signature-free connection first. The agent then relay-executes.
+   - **Safe app** — confirm with your backup key at app.safe.global; Zhentan's sync worker picks up the execution automatically.
+
+Guarded wallets **cannot** turn screening off — one user key against a threshold of two means no second signature could ever exist. The server rejects such proposals outright with a prompt to add a backup key first. (Legacy v1 accounts are the one exception — see [Legacy Accounts](/technology/legacy).)
+
+## Address Derivation
+
+Safe addresses are derived **server-side only**, through a versioned registry:
+
+| Version | Recipe | Who |
+|---------|--------|-----|
+| **v1** | Legacy permissionless initializer with the Safe4337Module enabled | All pre-refactor accounts, pinned forever |
+| **v2** | Vanilla stock Safe (protocol-kit initializer, CompatibilityFallbackHandler, no modules) | Default for all new accounts |
+
+The client never derives locally — it asks `GET /users/by-signer` (returning users) or `POST /safe/derive` (new users, with their chosen profile). Owner order for derivation is canonical `[embedded, backup, agent]`; deployed Safes read their live owner set from chain. Derivation runs **once at account creation**; the frozen creation snapshot keeps every address auditable and re-derivable — the server ships `safe:verify-derivations` to re-derive and check every account.
+
+Safes are deployed eagerly at onboarding (the agent pays deployment gas), because the Safe Transaction Service only indexes deployed Safes.


### PR DESCRIPTION
## Summary

The deployed Mintlify docs still described the v1 world — a 2-of-2 Safe where the agent held the deciding key and every transaction was a gasless 4337 UserOperation. This PR rewrites them for the signing configuration shipped in #58 (v2.0.0).

### New pages
- **Technology → Signing & Wallet Profiles** — the 2-of-3 owner model and its two hard invariants, computed profiles (starter / guarded / protected / detached) with the transitions table, the SafeTx → Transaction Service → screen → relay sequence diagram, relay-only execution, the screening-off queue-and-co-sign flow, and the versioned derivation registry + immutable creation snapshot.
- **Technology → Legacy Accounts** — what v1 means today, the capability-scoped screening-off exemption, the `addOwnerWithThreshold` upgrade path, and why the derivation version stays pinned while behavior becomes fully v2 after upgrade.

### Updated pages
- **Architecture** — both diagrams redrawn for the Transaction Service + relay flow with the Safe-app override path; component/state/stack tables corrected (Supabase, wallet login, safeSync).
- **Contracts** — v1/v2 derivation recipes; 4337 rows marked legacy-only; services table added.
- **Overview / Introduction** — design principles now lead with the user-held majority; the "no transaction executes without the agent" claim (false by design in v2) is gone.
- **App: Overview & Screening** — profiles for users, corrected screening-off behavior (queue at 1/n + backup co-sign, not "agent auto-executes"), agent-paid gas instead of the paymaster claim, override guide.
- **Quickstart** — `SAFE_API_KEY` / `SAFE_DERIVATION_VERSION` / `AGENT_MIN_BNB` env vars, client Pimlico key removed, troubleshooting points at agent BNB balance.
- **API tab** — `/queue` documents the real SafeTx payload and `screeningDisabled` semantics, `/execute` documents relay-only and the "awaiting backup co-signature" refusal, new `/transactions/:id/cosign` page, expanded endpoint index.

## Verification
- `docs.json` parses; navigation includes the two new guide pages and the cosign API page
- `mintlify broken-links`: no broken links

🤖 Generated with [Claude Code](https://claude.com/claude-code)