### PR TITLE
feat: offer backup-key co-sign for screened transactions

### DIFF
--- a/client/src/components/SendPanel.tsx
+++ b/client/src/components/SendPanel.tsx
@@ -385,9 +385,17 @@ export function SendPanel({ onSuccess, onClose, onRefreshActivities, tokens, scr
     );
   }
 
-  // Screening ON: proposed/pending phase (same as TransactionDetailDialog for pending)
+  // Screening ON: proposed/pending phase (same as TransactionDetailDialog for
+  // pending). Protected wallets also get the backup-key sign option — their
+  // two keys meet the threshold, so co-signing executes right away (relay-only)
+  // without waiting on the agent's verdict.
   if (screeningMode && sendPhase === "proposed" && proposedTx) {
     const tx = proposedTx;
+    const canCoSign =
+      safeConfig?.profile === "protected" &&
+      tx.txType === "safetx" &&
+      !tx.txHash &&
+      1 + (tx.userSignatures?.length ?? 0) < (tx.threshold ?? 2);
     return (
       <div className="space-y-6">
         <div className="flex flex-col items-center gap-3">
@@ -419,6 +427,38 @@ export function SendPanel({ onSuccess, onClose, onRefreshActivities, tokens, scr
             </dd>
           </div>
         </dl>
+        {canCoSign && (
+          <div className="space-y-2.5">
+            <p className="text-xs text-muted-foreground/80 text-center">
+              {tx.status === "in_review"
+                ? "Flagged for your review — signing with your backup key executes it anyway."
+                : "Zhentan is screening — signing with your backup key executes it right away."}
+            </p>
+            <CoSignButton
+              tx={tx}
+              onExecuted={(result) => {
+                setExecutedResult({
+                  to: tx.to,
+                  amount: tx.amount,
+                  token: tx.token,
+                  txHash: result.txHash ?? "",
+                  executedAt: new Date().toISOString(),
+                  tokenIconUrl: tx.tokenIconUrl ?? undefined,
+                });
+                setSendPhase("success");
+              }}
+            />
+            <a
+              href={`https://app.safe.global/transactions/queue?safe=bnb:${tx.safeAddress}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center justify-center gap-2 w-full rounded-2xl py-3 border border-gold/30 text-gold hover:bg-gold/10 transition-colors text-sm font-medium"
+            >
+              Sign in Safe app
+              <ExternalLink className="h-3.5 w-3.5 opacity-60" />
+            </a>
+          </div>
+        )}
         <Button
           type="button"
           onClick={() => {

--- a/client/src/components/SwapPanel.tsx
+++ b/client/src/components/SwapPanel.tsx
@@ -11,7 +11,7 @@ import { ThemeLoaderSpinner } from "./ThemeLoader";
 import { TickButtonSpinner } from "./TwinTickLoader";
 import { ExecutedAnimation, ReviewAnimation } from "./animations/StatusAnimation";
 import { CoSignButton } from "@/components/CoSignButton";
-import type { CoSignableTx } from "@/hooks/useCoSignTransaction";
+import { useLiveTransaction } from "@/hooks/useLiveTransaction";
 import {
   ArrowDownUp,
   ChevronDown,
@@ -20,14 +20,13 @@ import {
   Search,
   X,
 } from "lucide-react";
-import { formatTokenAmount, truncateAddress, formatDate } from "@/lib/format";
+import { formatTokenAmount, truncateAddress, formatDate, statusLabel } from "@/lib/format";
 import { BSC_EXPLORER_URL, NATIVE_TOKEN_ADDRESS } from "@/lib/constants";
 import { proposeSwap, type SwapQuote } from "@/lib/proposeSwap";
-import { pollForExecution } from "@/lib/pollExecution";
 import { useApiClient } from "@/lib/api/client";
 import type { SearchedToken } from "@/lib/api/tokens";
 import { parseUnits, formatUnits } from "viem";
-import type { TokenPosition } from "@/types";
+import type { TokenPosition, TransactionWithStatus } from "@/types";
 import { useTokenAmountInput } from "@/lib/useTokenAmountInput";
 
 // Popular BNB Chain tokens shown in the buy token selector even if not in portfolio
@@ -204,8 +203,9 @@ export function SwapPanel({ onSuccess, onClose, tokens }: SwapPanelProps) {
   const [swapStatus, setSwapStatus] = useState<string>("Processing swap");
   const [txHash, setTxHash] = useState<string | null>(null);
   const [executedAt, setExecutedAt] = useState<string | null>(null);
-  // Screening-off swap queued at 1/n — held for the queued phase's co-sign.
-  const [queuedTx, setQueuedTx] = useState<CoSignableTx | null>(null);
+  // Unresolved swap resting on the queued screen: screening off (awaiting the
+  // backup key) or screening on (agent verdict pending / flagged for review).
+  const [queuedTx, setQueuedTx] = useState<TransactionWithStatus | null>(null);
   const [fromSelectorOpen, setFromSelectorOpen] = useState(false);
   const [toSelectorOpen, setToSelectorOpen] = useState(false);
   const [tokenSearch, setTokenSearch] = useState("");
@@ -213,6 +213,26 @@ export function SwapPanel({ onSuccess, onClose, tokens }: SwapPanelProps) {
   const [searchLoading, setSearchLoading] = useState(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Live-track the queued swap so the screen transitions in place when the
+  // agent, the owner (Telegram), or the Safe app resolves it.
+  const liveQueued = useLiveTransaction(
+    phase === "queued" && queuedTx ? queuedTx.id : null
+  );
+  useEffect(() => {
+    if (!liveQueued) return;
+    if (liveQueued.status === "executed") {
+      setTxHash(liveQueued.txHash ?? null);
+      setExecutedAt(liveQueued.executedAt ?? new Date().toISOString());
+      setPhase("success");
+    } else if (liveQueued.status === "rejected") {
+      setError(liveQueued.rejectReason || "Swap rejected by Zhentan");
+      setPhase("error");
+    } else if (liveQueued.status === "in_review") {
+      // Agent flagged it — keep the queued screen but reflect the update.
+      setQueuedTx((prev) => (prev ? { ...prev, ...liveQueued } : liveQueued));
+    }
+  }, [liveQueued]);
 
   // Portfolio tokens that can be sold (have balance)
   const sellableTokens = tokens.filter(
@@ -398,28 +418,31 @@ export function SwapPanel({ onSuccess, onClose, tokens }: SwapPanelProps) {
           identityToken,
         });
 
-        let swapTxHash: string | null;
         if (screeningOn) {
-          // Agent screens, co-signs and executes — poll for the outcome.
-          swapTxHash = await pollForExecution(pendingTx.id, safeAddress, identityToken ?? null);
-        } else {
-          // Screening OFF below threshold (backup key not connected): queued
-          // at 1/n awaiting the backup co-signature — complete from history
-          // or the Safe app. The server refuses to execute until then.
-          // Owner-computed profile: upgraded v1 accounts queue for co-sign
-          // like any protected wallet (see SendPanel for the rationale).
-          const sigCount = 1 + (pendingTx.userSignatures?.length ?? 0);
-          const awaitingCoSign =
-            sigCount < pendingTx.threshold && safeConfig.profile === "protected";
-          if (awaitingCoSign) {
-            setQueuedTx(pendingTx);
-            setPhase("queued");
-            setLoading(false);
-            return;
-          }
-          const result = await api.execute.run(pendingTx.id);
-          swapTxHash = result.txHash ?? null;
+          // Rest on the queued screen while the agent screens — the live poll
+          // flips it to success/error in place, and protected wallets can sign
+          // with the backup key to execute right away (relay-only).
+          setQueuedTx({ ...pendingTx, status: "pending" });
+          setPhase("queued");
+          setLoading(false);
+          return;
         }
+        // Screening OFF below threshold (backup key not connected): queued
+        // at 1/n awaiting the backup co-signature — complete from history
+        // or the Safe app. The server refuses to execute until then.
+        // Owner-computed profile: upgraded v1 accounts queue for co-sign
+        // like any protected wallet (see SendPanel for the rationale).
+        const sigCount = 1 + (pendingTx.userSignatures?.length ?? 0);
+        const awaitingCoSign =
+          sigCount < pendingTx.threshold && safeConfig.profile === "protected";
+        if (awaitingCoSign) {
+          setQueuedTx({ ...pendingTx, status: "pending" });
+          setPhase("queued");
+          setLoading(false);
+          return;
+        }
+        const result = await api.execute.run(pendingTx.id);
+        const swapTxHash = result.txHash ?? null;
         setTxHash(swapTxHash);
         setExecutedAt(new Date().toISOString());
         setPhase("success");
@@ -484,16 +507,34 @@ export function SwapPanel({ onSuccess, onClose, tokens }: SwapPanelProps) {
     );
   }
 
-  // Queued phase: screening off, awaiting the backup key's co-signature.
+  // Queued phase: an unresolved swap at 1/n. Screening off: awaiting the
+  // backup key (the only completion path). Screening on: the agent's verdict
+  // is pending or flagged for review — protected wallets can co-sign to
+  // execute right away (relay-only) instead of waiting.
   if (phase === "queued") {
+    const screeningOff = !!queuedTx?.screeningDisabled;
+    const inReview = queuedTx?.status === "in_review";
+    const canCoSign =
+      !!queuedTx &&
+      safeConfig?.profile === "protected" &&
+      1 + (queuedTx.userSignatures?.length ?? 0) < (queuedTx.threshold ?? 2);
+    const heading = screeningOff
+      ? "Awaiting your backup key"
+      : statusLabel(queuedTx?.status ?? "pending");
+    const caption = screeningOff
+      ? "Swap queued. Sign with your backup key to execute it now — the quote may expire if it waits too long."
+      : inReview
+        ? "Flagged for your review — signing with your backup key executes it anyway."
+        : canCoSign
+          ? "Zhentan is screening your swap — signing with your backup key executes it right away."
+          : "Zhentan is screening your swap — it executes automatically once approved.";
     return (
       <div className="space-y-6">
         <div className="flex flex-col items-center gap-3">
           <ReviewAnimation size={80} />
-          <span className="text-sm font-semibold text-watch">Awaiting your backup key</span>
+          <span className="text-sm font-semibold text-watch">{heading}</span>
           <p className="text-xs text-muted-foreground/80 text-center leading-relaxed max-w-xs">
-            Swap queued. Sign with your backup key to execute it now — the
-            quote may expire if it waits too long.
+            {caption}
           </p>
         </div>
         <div className="rounded-2xl bg-foreground/6 p-4 space-y-3">
@@ -513,7 +554,7 @@ export function SwapPanel({ onSuccess, onClose, tokens }: SwapPanelProps) {
             </span>
           </div>
         </div>
-        {queuedTx && (
+        {canCoSign && queuedTx && (
           <CoSignButton
             tx={queuedTx}
             onExecuted={(result) => {
@@ -523,7 +564,7 @@ export function SwapPanel({ onSuccess, onClose, tokens }: SwapPanelProps) {
             }}
           />
         )}
-        {safeAddress && (
+        {canCoSign && safeAddress && (
           <a
             href={`https://app.safe.global/transactions/queue?safe=bnb:${safeAddress}`}
             target="_blank"

--- a/client/src/components/TransactionDetailDialog.tsx
+++ b/client/src/components/TransactionDetailDialog.tsx
@@ -308,19 +308,25 @@ function RiskDetailsSection({
 // ── Co-sign section ───────────────────────────────────────────────────────────
 
 /**
- * Completion actions for a screening-off SafeTx queued below threshold: sign
- * with the backup key in-app (relay-only execution — the agent never signs
- * unscreened txs), or finish in the Safe app. When the backup wallet has no
- * live session, the button opens Privy's connect modal first.
+ * Backup-key completion actions for a SafeTx queued below threshold: sign
+ * in-app (relay-only execution — the agent never signs what it didn't screen,
+ * and once the user's keys meet the threshold it doesn't need to), or finish
+ * in the Safe app. Available whether screening is on (executes ahead of — or
+ * over — the agent's verdict) or off (the backup key is the only completion
+ * path). When the backup wallet has no live session, the button opens Privy's
+ * connect modal first.
  */
 function CoSignSection({ tx }: { tx: TransactionWithStatus }) {
+  const caption =
+    tx.status === "in_review"
+      ? "Flagged for your review — signing with your backup key executes it anyway."
+      : tx.screeningDisabled
+        ? `Waiting for your backup key — ${1 + (tx.userSignatures?.length ?? 0)} of ${tx.threshold} signatures.`
+        : "Zhentan is screening — signing with your backup key executes it right away.";
   // On success, useLiveTransaction flips the dialog to executed in place.
   return (
     <div className="space-y-2.5">
-      <p className="text-xs text-muted-foreground/80 text-center">
-        Waiting for your backup key — {1 + (tx.userSignatures?.length ?? 0)} of{" "}
-        {tx.threshold} signatures.
-      </p>
+      <p className="text-xs text-muted-foreground/80 text-center">{caption}</p>
       <CoSignButton tx={tx} />
       <motion.a
         href={`https://app.safe.global/transactions/queue?safe=bnb:${tx.safeAddress}`}
@@ -529,34 +535,19 @@ export function TransactionDetailDialog({ tx: txProp, open, onClose }: Transacti
           />
         )}
 
-        {/* Screening-off tx queued below threshold: the backup key completes
-            it — in-app co-sign (relay-only execution) or the Safe app. */}
+        {/* Unresolved SafeTx below threshold: the backup key can complete it —
+            in-app co-sign (relay-only execution) or the Safe app. Screening
+            off: the only completion path. Screening on (pending/in_review):
+            the user-override path — their two keys meet the threshold, so
+            signing executes without waiting on the agent's verdict. Only
+            protected wallets have a backup key to sign with. */}
         {tx.txType === "safetx" &&
-          tx.status === "pending" &&
+          (tx.status === "pending" || tx.status === "in_review") &&
           !tx.txHash &&
-          !!tx.screeningDisabled &&
           overrideAvailable &&
           1 + (tx.userSignatures?.length ?? 0) < (tx.threshold ?? 2) && (
             <CoSignSection tx={tx} />
           )}
-
-        {/* Override path: a flagged SafeTx already sits in the Safe app queue
-            at 1 of 2 — the user can confirm with their backup key and execute
-            there, going around the agent entirely. Only protected wallets
-            have a backup key to sign with. */}
-        {tx.txType === "safetx" && tx.status === "in_review" && !tx.txHash && overrideAvailable && (
-          <motion.a
-            href={`https://app.safe.global/transactions/queue?safe=bnb:${tx.safeAddress}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center justify-center gap-2 w-full rounded-2xl py-3 border border-gold/30 text-gold hover:bg-gold/10 transition-colors text-sm font-medium"
-            whileHover={{ scale: 1.02 }}
-            whileTap={{ scale: 0.98 }}
-          >
-            Sign with your backup key at Safe
-            <ExternalLink className="h-3.5 w-3.5 opacity-60" />
-          </motion.a>
-        )}
 
         {/* BSCScan explorer link */}
         {explorerTxUrl && (


### PR DESCRIPTION
Closes #60

## What

The in-app backup-key sign option (`CoSignButton`) was only offered when screening is **off**. This PR offers it in **both** screening modes, wherever an unresolved below-threshold SafeTx is shown — so a protected wallet can execute immediately (or override a flagged verdict) instead of waiting on the agent.

## Changes

**TransactionDetailDialog**
- Dropped the `screeningDisabled` gate on the co-sign section; it now renders for any unresolved below-threshold SafeTx, `pending` or `in_review`.
- Folded the old in_review-only "Sign with your backup key at Safe" external link into the co-sign section, so flagged txs get the full in-app sign button too.
- Caption adapts to the state: screening off ("Waiting for your backup key — 1 of 2 signatures"), screening on ("Zhentan is screening — signing with your backup key executes it right away"), flagged ("Flagged for your review — signing with your backup key executes it anyway").

**SendPanel**
- The screening-on "proposed" screen now shows the `CoSignButton` + Safe app link (same state-aware caption) above Done; a successful co-sign flips straight to the success screen.

**SwapPanel**
- The screening-on path no longer blocks on `pollForExecution` with a spinner. After proposing, it rests on the queued screen — same as the screening-off path — and a `useLiveTransaction` poll flips it in place: executed → success, rejected → error with the agent's reason, flagged → stays with review copy.
- The sign options render there in both modes, gated on `profile === "protected"` and below-threshold.
- `queuedTx` widened from `CoSignableTx` to `TransactionWithStatus`; unused `pollForExecution` import removed (still used by the WalletConnect flow).

## Why no server changes

`POST /transactions/:id/cosign` already accepts a backup-key signature on any unresolved SafeTx, and `/execute` switches to relay-only whenever user signatures meet the threshold. The "agent never signs what it didn't screen" invariant holds — on this path the agent contributes no signature, it only relays and pays gas.

## Scope notes

- Only **protected** wallets get the option (guarded wallets have no backup key to sign with; starter executes at t=1).
- Behavior change in the swap flow: the slippage-ladder retry no longer applies to agent-side execution reverts on the screening-on path (the user re-submits from the error screen instead). It still applies to quote fetching and the screening-off immediate-execution path.

## Testing

- `tsc --noEmit` clean on the client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)