### PR TITLE
fix: re-arm per-login sync latch so a second account's tour fires

### DIFF
--- a/client/src/app/context/AuthContext.tsx
+++ b/client/src/app/context/AuthContext.tsx
@@ -158,7 +158,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const { identityToken } = useIdentityToken();
 
   const hasAttemptedCreate = useRef(false);
-  const hasSyncedUser = useRef(false);
+  // Signer the /users sync last ran for. Identity-keyed rather than a boolean:
+  // this provider outlives logout/login (root layout), so a once-latch set by
+  // a previous account would swallow the next account's sync — the only
+  // pre-deploy write of its owner set + derivation version. A record without
+  // those reads as legacy/guarded until the eager deploy backfills it, which
+  // (among other things) suppressed the first-time tour.
+  const syncedUserFor = useRef<string | null>(null);
 
   // The embedded Privy wallet, when one exists (Google / no-wallet logins).
   const embeddedWallet = useMemo(
@@ -357,6 +363,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     clearOnboardingCompleteCookie();
     clearOnboardingStorage();
     clearIdentityCache();
+    // Re-arm the per-login one-shots too: the provider survives logout, so
+    // left latched they'd skip the next account's sync / wallet creation.
+    syncedUserFor.current = null;
+    hasAttemptedCreate.current = false;
     await privyLogout();
   }, [privyLogout]);
 
@@ -508,12 +518,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     // can find this account by. Never sync without it — a row written with a
     // null signer_address is invisible to that lookup forever, so the user is
     // treated as new on return and bounced back into onboarding.
-    if (!safeAddress || !identityToken || !wallet?.address || hasSyncedUser.current)
-      return;
+    if (!safeAddress || !identityToken || !wallet?.address) return;
+    const signerKey = wallet.address.toLowerCase();
+    if (syncedUserFor.current === signerKey) return;
     // Freshly derived Safes wait for the onboarding commit; record-backed
     // users sync immediately as before.
     if (safeDerived && !safeCommitted) return;
-    hasSyncedUser.current = true;
+    syncedUserFor.current = signerKey;
     const google = (privyUser as { google?: { email?: string; name?: string } } | null)?.google;
     apiFetch("/users", identityToken, {
       method: "POST",
@@ -537,11 +548,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     })
       .then((res) => {
         // Re-arm on a server error so signer_address isn't left unset forever.
-        if (!res.ok) hasSyncedUser.current = false;
+        if (!res.ok) syncedUserFor.current = null;
       })
       .catch((e) => {
         console.error("Failed to sync user details:", e);
-        hasSyncedUser.current = false;
+        syncedUserFor.current = null;
       });
   }, [
     safeAddress,

--- a/client/src/app/onboarding/page.tsx
+++ b/client/src/app/onboarding/page.tsx
@@ -688,11 +688,17 @@ function OnboardingContent() {
     });
     // Eager deploy: the Safe must exist on-chain for app.safe.global and the
     // Transaction Service. Agent pays gas; /queue re-checks as a fallback,
-    // so a failure here must not trap the user on this screen.
+    // so a failure here must not trap the user on this screen. The deploy also
+    // backfills owners/derivation_version on the record — refetch once it
+    // lands so a session holding an incomplete row (which reads as legacy and
+    // e.g. suppresses the first-time tour) heals without a reload.
     if (safeConfig) {
-      api.safe.deploy(safeConfig.owners, safeConfig.threshold).catch((err) => {
-        console.error("Eager Safe deploy failed (will retry on first tx):", err);
-      });
+      api.safe
+        .deploy(safeConfig.owners, safeConfig.threshold)
+        .then(() => refreshSafe())
+        .catch((err) => {
+          console.error("Eager Safe deploy failed (will retry on first tx):", err);
+        });
     }
     markOnboardingTelegramDone(wallet.address);
     // The in-memory record still says onboarding_completed=false — refresh it


### PR DESCRIPTION
Closes #62

## Problem

A first-time user finishing onboarding sometimes got no guided tour on /home — reliably reproducible when **another account** had used the app earlier in the same browser session — and a single refresh made it appear. Full investigation in #62; short version:

`AuthContext`'s login-time `/users` sync (the only pre-deploy write of a fresh account's `safeOwners`/`safeThreshold`/`derivationVersion`) was guarded by `hasSyncedUser = useRef(false)`. `AuthProvider` lives in the root layout and survives logout → login, so the latch set by account A silently skipped account B's sync. B's record then came back with `derivation_version: null` / `safe_owners: null`, `safeConfig` fell back to the legacy 2-of-2 owner reconstruction (profile → `guarded`), and `TourLauncher`'s `isLegacy = (derivationVersion ?? 1) === 1` sent it down the legacy branch — which fires nothing for a `guarded` profile. The eager deploy backfilled the record server-side seconds later, which is why a refresh fixed it.

## Changes

**`client/src/app/context/AuthContext.tsx`**
- Replaced the boolean latch with a signer-keyed one (`syncedUserFor`): an identity change re-arms the sync automatically, including wallet-login signer switches that never pass through logout.
- `logout()` now also re-arms `syncedUserFor` and `hasAttemptedCreate` (same latch class — it guards embedded-wallet creation and could likewise starve the next account).
- Failed syncs re-arm by resetting the key to `null` (same semantics as before).

**`client/src/app/onboarding/page.tsx`**
- Defense in depth: `handleFinish`'s eager deploy now chains `.then(() => refreshSafe())`, so once the deploy backfills owners/derivation_version the running session refetches the record and heals in place (tour fires, profile classifies correctly) instead of waiting for a reload. This is a background refresh — no loader flash.

## Side effects fixed along the way

The skipped sync also left the second account's row temporarily without `external_wallet_address` and Google `email`/`name`, and the misclassified `guarded` profile suppressed protected-only UI (backup-key co-sign options, settings hints) until reload. Both go away with the sync running again.

## Testing

- `tsc --noEmit` clean on the client.
- Manual repro path: log in as account A → log out → sign up as account B → finish onboarding → tour should now fire on first arrival at /home without a refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)