### PR TITLE
feat: grouped settings, redesigned onboarding, milestone-triggered tours

### DIFF
--- a/client/src/app/(app)/settings/page.tsx
+++ b/client/src/app/(app)/settings/page.tsx
@@ -18,8 +18,6 @@ import {
   AlertCircle,
   LayoutGrid,
   Zap,
-  Globe,
-  Search,
   RotateCw,
   LogOut,
 } from "lucide-react";
@@ -515,22 +513,6 @@ function SettingsPageContent() {
                   />
                   <SettingsRow
                     className="border-t border-border"
-                    icon={<Globe className="h-[18px] w-[18px]" />}
-                    iconTint="bg-foreground/5 text-muted-foreground"
-                    title="Network"
-                    desc="Chain the agent co-signs on"
-                    action={
-                      <span className="shrink-0 inline-flex items-center gap-2 text-[13px] font-medium text-foreground">
-                        <span
-                          className="h-1.5 w-1.5 rounded-pill bg-safe shadow-[0_0_8px_rgba(63,190,118,0.6)]"
-                          aria-hidden
-                        />
-                        BNB Chain · Mainnet
-                      </span>
-                    }
-                  />
-                  <SettingsRow
-                    className="border-t border-border"
                     icon={<Zap className="h-[18px] w-[18px]" />}
                     iconTint="bg-gold/10 text-gold"
                     title="Force-execute"
@@ -555,24 +537,6 @@ function SettingsPageContent() {
                           )}
                         />
                       </button>
-                    }
-                  />
-                  <SettingsRow
-                    className="border-t border-border"
-                    icon={<Search className="h-[18px] w-[18px]" />}
-                    iconTint="bg-foreground/5 text-muted-foreground"
-                    title="Block explorer"
-                    desc="Where transaction links open"
-                    action={
-                      <a
-                        href="https://bscscan.com"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-xl border border-border text-[13px] font-medium text-foreground hover:border-gold/30 hover:text-gold transition-colors"
-                      >
-                        BscScan
-                        <ExternalLink className="h-3 w-3" />
-                      </a>
                     }
                   />
                   {safeAddress && (

--- a/client/src/app/(app)/settings/page.tsx
+++ b/client/src/app/(app)/settings/page.tsx
@@ -569,6 +569,9 @@ function SettingsPageContent() {
                 </div>
               </motion.div>
 
+              {/* DANGER ZONE — detach the agent (protected wallets only) */}
+              <DetachZhentanCard />
+
               {/* UPGRADE — future plans */}
               <motion.div variants={staggerItem}>
                 <SectionHeader label="Upgrade" />
@@ -586,10 +589,7 @@ function SettingsPageContent() {
                         Soon
                       </span>
                     </div>
-                    <span className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-gold/[0.06] text-[11px] font-mono text-gold-300/80">
-                      Claude Sonnet 4.5
-                    </span>
-                    <p className="text-[11px] text-muted-foreground/80 mt-2.5 leading-relaxed">
+                    <p className="text-[11px] text-muted-foreground/80 leading-relaxed">
                       Dedicated NanoBot/Hermes instance with advanced AI model
                     </p>
                   </div>
@@ -617,9 +617,6 @@ function SettingsPageContent() {
                   </div>
                 </div>
               </motion.div>
-
-              {/* DANGER ZONE — detach the agent (protected wallets only) */}
-              <DetachZhentanCard />
             </motion.div>
           </>
         )}

--- a/client/src/app/(app)/settings/page.tsx
+++ b/client/src/app/(app)/settings/page.tsx
@@ -20,9 +20,13 @@ import {
   Zap,
   RotateCw,
   LogOut,
+  KeyRound,
 } from "lucide-react";
 import { clsx } from "clsx";
 import { useApiClient } from "@/lib/api/client";
+import { Dialog } from "@/components/ui/Dialog";
+import { BackupAddressPicker } from "@/components/BackupAddressPicker";
+import { truncateAddress } from "@/lib/format";
 import { UpgradeBanner } from "@/components/UpgradeBanner";
 import { useSafeTransitions } from "@/lib/useSafeUpgrade";
 import { useForceExecuteSetting } from "@/lib/useForceExecute";
@@ -88,6 +92,82 @@ function SettingsRow({
     </button>
   ) : (
     <div className={clsx("flex items-center gap-3.5 p-[18px]", className)}>{inner}</div>
+  );
+}
+
+/**
+ * Change the backup key (protected wallets only): an on-chain owner swap —
+ * the new key replaces the old at the same address, hard-validated
+ * server-side and co-signed by the agent like any profile transition.
+ */
+function BackupKeyRow() {
+  const { swapBackup, busy, error, profile } = useSafeTransitions();
+  const { externalWalletAddress } = useAuth();
+  const [open, setOpen] = useState(false);
+
+  if (profile !== "protected" || !externalWalletAddress) return null;
+
+  return (
+    <>
+      <SettingsRow
+        className="border-t border-border"
+        icon={<KeyRound className="h-[17px] w-[17px]" />}
+        iconTint="bg-foreground/5 text-muted-foreground"
+        title="Backup key"
+        desc={
+          <span className="font-mono text-[11px] truncate block" title={externalWalletAddress}>
+            {truncateAddress(externalWalletAddress, 13)}
+          </span>
+        }
+        action={
+          <button
+            type="button"
+            onClick={() => setOpen(true)}
+            className="shrink-0 inline-flex items-center px-3 py-1.5 rounded-xl border border-border text-[13px] font-medium text-foreground hover:border-gold/30 hover:text-gold transition-colors cursor-pointer"
+          >
+            Change
+          </button>
+        }
+      />
+      <Dialog
+        open={open}
+        onClose={() => {
+          if (!busy) setOpen(false);
+        }}
+        title="Change backup key"
+        className="max-w-md"
+      >
+        <div className="space-y-4">
+          <p className="text-xs text-muted-foreground/85 leading-relaxed">
+            Swaps your override key on-chain at the same vault address: the new
+            key replaces{" "}
+            <span className="font-mono text-foreground/75">
+              {truncateAddress(externalWalletAddress, 13)}
+            </span>{" "}
+            as an owner. Pick a wallet you control — it never signs during this
+            step.
+          </p>
+          {busy ? (
+            <div className="flex items-center justify-center gap-2 py-8 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin text-gold" />
+              Swapping owner on-chain...
+            </div>
+          ) : (
+            <BackupAddressPicker
+              onSelect={async (addr) => {
+                try {
+                  await swapBackup(addr);
+                  setOpen(false);
+                } catch {
+                  // error surfaced by the hook
+                }
+              }}
+            />
+          )}
+          {error && <p className="text-xs text-danger">{error}</p>}
+        </div>
+      </Dialog>
+    </>
   );
 }
 
@@ -511,6 +591,7 @@ function SettingsPageContent() {
                       )
                     }
                   />
+                  <BackupKeyRow />
                   <SettingsRow
                     className="border-t border-border"
                     icon={<Zap className="h-[18px] w-[18px]" />}

--- a/client/src/app/(app)/settings/page.tsx
+++ b/client/src/app/(app)/settings/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback, type ReactNode } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { useLinkAccount, usePrivy } from "@privy-io/react-auth";
 import { AuthGuard } from "@/components/AuthGuard";
@@ -18,6 +18,10 @@ import {
   AlertCircle,
   LayoutGrid,
   Zap,
+  Globe,
+  Search,
+  RotateCw,
+  LogOut,
 } from "lucide-react";
 import { clsx } from "clsx";
 import { useApiClient } from "@/lib/api/client";
@@ -26,6 +30,68 @@ import { useSafeTransitions } from "@/lib/useSafeUpgrade";
 import { useForceExecuteSetting } from "@/lib/useForceExecute";
 import { useTour } from "@/components/tour/TourProvider";
 import { mainTour, upgradeTour } from "@/lib/tours";
+
+/** Section label + hairline rule, per the grouped settings design. */
+function SectionHeader({ label, danger }: { label: string; danger?: boolean }) {
+  return (
+    <div className="flex items-center gap-3 mb-3">
+      <span className={clsx("eyebrow", danger ? "text-danger/70" : "text-muted-foreground/60")}>
+        {label}
+      </span>
+      <span className={clsx("h-px flex-1", danger ? "bg-danger/15" : "bg-border")} aria-hidden />
+    </div>
+  );
+}
+
+/**
+ * One row of a grouped settings card: icon tile · title/description · action.
+ * With `onClick` the whole row is the button (the action then renders as a
+ * chip-styled span, since buttons can't nest).
+ */
+function SettingsRow({
+  icon,
+  iconTint,
+  title,
+  desc,
+  action,
+  onClick,
+  className,
+}: {
+  icon: ReactNode;
+  iconTint: string;
+  title: ReactNode;
+  desc?: ReactNode;
+  action?: ReactNode;
+  onClick?: () => void;
+  className?: string;
+}) {
+  const inner = (
+    <>
+      <div className={clsx("w-9 h-9 rounded-xl flex items-center justify-center shrink-0", iconTint)}>
+        {icon}
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 text-sm font-semibold text-foreground">{title}</div>
+        {desc && <div className="text-xs text-muted-foreground/85 mt-1 leading-relaxed">{desc}</div>}
+      </div>
+      {action}
+    </>
+  );
+  return onClick ? (
+    <button
+      type="button"
+      onClick={onClick}
+      className={clsx(
+        "w-full flex items-center gap-3.5 p-[18px] text-left hover:bg-foreground/[0.03] transition-colors cursor-pointer",
+        className
+      )}
+    >
+      {inner}
+    </button>
+  ) : (
+    <div className={clsx("flex items-center gap-3.5 p-[18px]", className)}>{inner}</div>
+  );
+}
 
 /**
  * The exit door: removes the agent as an owner, leaving a plain 2-of-2 Safe
@@ -41,40 +107,42 @@ function DetachZhentanCard() {
 
   return (
     <motion.div variants={staggerItem}>
-      <div className="pt-6 border-t border-dashed border-border">
-        <span className="eyebrow text-danger/70">Danger zone</span>
-      </div>
-      <div className="mt-4 p-5 rounded-lg bg-card border border-danger/15">
-        <div className="flex items-center gap-4">
-          <div className="flex-1 min-w-0">
-            <h3 className="text-sm font-semibold text-foreground">Detach Zhentan</h3>
-            <p className="text-xs text-muted-foreground/80 mt-0.5">
+      <SectionHeader label="Danger zone" danger />
+      <div className="rounded-2xl bg-card border border-danger/15 overflow-hidden">
+        <SettingsRow
+          icon={<LogOut className="h-[17px] w-[17px]" />}
+          iconTint="bg-danger/10 text-danger"
+          title="Detach Zhentan"
+          desc={
+            <>
               {confirming
                 ? "Removes the agent as an owner. Your Safe becomes a plain 2-of-2 (your two keys, both required) at the same address. Screening ends permanently."
                 : "Leave with a stock Safe — remove the screening agent from your wallet."}
-            </p>
-            {error && <p className="text-xs text-danger mt-1">{error}</p>}
-          </div>
-          <button
-            onClick={async () => {
-              if (!confirming) {
-                setConfirming(true);
-                return;
-              }
-              try {
-                await detach();
-                setDone(true);
-              } catch {
-                // error surfaced by the hook
-              }
-            }}
-            disabled={busy}
-            className="shrink-0 inline-flex items-center gap-2 px-3.5 py-2 rounded-md border border-danger/40 text-danger text-xs font-semibold hover:bg-danger/10 transition-colors disabled:opacity-60"
-          >
-            {busy ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}
-            {busy ? "Detaching..." : confirming ? "Yes, detach permanently" : "Detach"}
-          </button>
-        </div>
+              {error && <p className="text-danger mt-1">{error}</p>}
+            </>
+          }
+          action={
+            <button
+              onClick={async () => {
+                if (!confirming) {
+                  setConfirming(true);
+                  return;
+                }
+                try {
+                  await detach();
+                  setDone(true);
+                } catch {
+                  // error surfaced by the hook
+                }
+              }}
+              disabled={busy}
+              className="shrink-0 inline-flex items-center gap-2 px-3.5 py-2 rounded-xl border border-danger/40 text-danger text-xs font-semibold hover:bg-danger/10 transition-colors disabled:opacity-60 cursor-pointer"
+            >
+              {busy ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}
+              {busy ? "Detaching..." : confirming ? "Yes, detach permanently" : "Detach"}
+            </button>
+          }
+        />
       </div>
     </motion.div>
   );
@@ -276,7 +344,7 @@ function SettingsPageContent() {
 
   return (
     <div className="flex flex-col h-screen bg-background">
-      <main className="flex-1 w-full px-4 sm:px-8 lg:px-10 py-6 sm:py-8 overflow-y-auto pb-24 sm:pb-10">
+      <main className="flex-1 w-full px-4 sm:px-8 lg:px-10 py-6 sm:py-8 overflow-y-auto scrollbar-hide pb-24 sm:pb-10">
         {loading ? (
           <div className="flex justify-center py-16">
             <Loader2 className="h-6 w-6 animate-spin text-gold" />
@@ -293,106 +361,108 @@ function SettingsPageContent() {
               variants={staggerContainer}
               initial="hidden"
               animate="visible"
-              className="space-y-7"
+              className="space-y-8"
             >
-              {/* Zhentan Guard card */}
+              {/* PROTECTION — guard, alerts, and the backup-key nudge, one card */}
               <motion.div variants={staggerItem}>
-                <div data-tour="guard-card" className="relative rounded-lg bg-card overflow-hidden shadow-[0_20px_50px_-38px_rgba(0,0,0,0.7)]">
-                  {/* Guard block */}
-                  <div className="flex items-center gap-4 p-5 border-b border-border">
-                    <div
-                      className={clsx(
-                        "w-10 h-10 rounded-md flex items-center justify-center shrink-0 transition-colors",
-                        isScreeningActive ? "bg-gold/10 text-gold" : "bg-foreground/6 text-muted-foreground/80"
-                      )}
-                    >
-                      {isScreeningActive ? <ShieldCheck className="h-5 w-5" /> : <ShieldOff className="h-5 w-5" />}
-                    </div>
-
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-2">
-                        <h3 className="text-sm font-semibold text-foreground">Zhentan Guard</h3>
+                <SectionHeader label="Protection" />
+                <div data-tour="guard-card" className="rounded-2xl bg-card overflow-hidden shadow-[0_20px_50px_-38px_rgba(0,0,0,0.7)]">
+                  <SettingsRow
+                    icon={
+                      isScreeningActive ? (
+                        <ShieldCheck className="h-[18px] w-[18px]" />
+                      ) : (
+                        <ShieldOff className="h-[18px] w-[18px]" />
+                      )
+                    }
+                    iconTint={clsx(
+                      "transition-colors",
+                      isScreeningActive ? "bg-gold/10 text-gold" : "bg-foreground/6 text-muted-foreground/80"
+                    )}
+                    title={
+                      <>
+                        <h3 className="text-sm font-semibold">Zhentan Guard</h3>
                         <span
                           className={clsx(
-                            "inline-flex items-center gap-1.5 px-2 py-0.5 rounded-pill text-[10px] font-mono uppercase tracking-wider",
+                            "inline-flex items-center gap-1.5 px-2 py-0.5 rounded-pill text-[10px] font-mono font-medium uppercase tracking-wider",
                             isScreeningActive ? "bg-safe/12 text-safe" : "bg-foreground/8 text-muted-foreground"
                           )}
                         >
                           <span className={clsx("h-1.5 w-1.5 rounded-pill", isScreeningActive ? "bg-safe" : "bg-muted-foreground")} />
                           {isScreeningActive ? "Active" : "Paused"}
                         </span>
-                      </div>
-                      <p className="text-xs text-muted-foreground/80 mt-0.5">
-                        {profile === "guarded"
-                          ? legacyV1Guarded
-                            ? isScreeningActive
-                              ? "AI screening every signature — pause it and the agent still co-signs"
-                              : "Screening off — the agent co-signs without risk analysis"
-                            : "Screening is always on — add a backup key to control it"
-                          : profile === "starter" || profile === "detached"
-                            ? "No agent on this wallet — activate protection to enable screening"
-                            : isScreeningActive
-                              ? "AI screening every signature against your patterns"
-                              : !fullyActivated
-                                ? "Finish setup to arm the co-signer"
-                                : "Screening off — your backup key co-signs instead of the agent"}
-                      </p>
-                    </div>
+                      </>
+                    }
+                    desc={
+                      profile === "guarded"
+                        ? legacyV1Guarded
+                          ? isScreeningActive
+                            ? "AI screening every signature — pause it and the agent still co-signs"
+                            : "Screening off — the agent co-signs without risk analysis"
+                          : "Screening is always on — add a backup key to control it"
+                        : profile === "starter" || profile === "detached"
+                          ? "No agent on this wallet — activate protection to enable screening"
+                          : isScreeningActive
+                            ? "AI screening every signature against your patterns"
+                            : !fullyActivated
+                              ? "Finish setup to arm the co-signer"
+                              : "Screening off — your backup key co-signs instead of the agent"
+                    }
+                    action={
+                      <button
+                        onClick={handleToggle}
+                        disabled={toggling || !screeningTogglable}
+                        aria-label="Toggle screening"
+                        className={clsx(
+                          "relative w-12 h-6 rounded-pill transition-colors focus:outline-none focus:ring-2 focus:ring-gold/30 shrink-0 cursor-pointer disabled:cursor-default",
+                          isScreeningActive ? "bg-gold" : "bg-foreground/12"
+                        )}
+                      >
+                        {toggling ? (
+                          <span className="absolute inset-0 flex items-center justify-center">
+                            <Loader2 className="h-3 w-3 animate-spin text-ink-900" />
+                          </span>
+                        ) : (
+                          <span
+                            className={clsx(
+                              "absolute top-0.5 w-5 h-5 rounded-pill bg-ink-0 shadow-md transition-all",
+                              isScreeningActive ? "left-6" : "left-0.5"
+                            )}
+                          />
+                        )}
+                      </button>
+                    }
+                  />
 
-                    <button
-                      onClick={handleToggle}
-                      disabled={toggling || !screeningTogglable}
-                      aria-label="Toggle screening"
-                      className={clsx(
-                        "relative w-12 h-6 rounded-pill transition-colors focus:outline-none focus:ring-2 focus:ring-gold/30 shrink-0 cursor-pointer disabled:cursor-default",
-                        isScreeningActive ? "bg-gold" : "bg-foreground/12"
-                      )}
-                    >
-                      {toggling ? (
-                        <span className="absolute inset-0 flex items-center justify-center">
-                          <Loader2 className="h-3 w-3 animate-spin text-ink-900" />
-                        </span>
+                  {/* Telegram / activation — the whole row opens the dialog */}
+                  <SettingsRow
+                    className="border-t border-border"
+                    onClick={() => setActivationOpen(true)}
+                    icon={
+                      fullyActivated ? (
+                        <CheckCircle2 className="h-[17px] w-[17px]" />
                       ) : (
-                        <span
-                          className={clsx(
-                            "absolute top-0.5 w-5 h-5 rounded-pill bg-ink-0 shadow-md transition-all",
-                            isScreeningActive ? "left-6" : "left-0.5"
-                          )}
-                        />
-                      )}
-                    </button>
-                  </div>
-
-                  {/* Activation inset row */}
-                  <div className="p-4">
-                    <button
-                      onClick={() => setActivationOpen(true)}
-                      className="w-full flex items-center gap-3 p-3.5 rounded-md bg-foreground/[0.03] border border-border hover:bg-foreground/[0.05] transition-colors cursor-pointer text-left"
-                    >
-                      {fullyActivated ? (
-                        <div className="w-8 h-8 rounded-md bg-safe/10 flex items-center justify-center shrink-0">
-                          <CheckCircle2 className="h-4 w-4 text-safe" />
-                        </div>
-                      ) : (
-                        <div className="w-8 h-8 rounded-md bg-watch/10 flex items-center justify-center shrink-0">
-                          <AlertCircle className="h-4 w-4 text-watch" />
-                        </div>
-                      )}
-                      <div className="flex-1 min-w-0">
-                        <p className="text-[13px] font-semibold text-foreground">
-                          {fullyActivated ? "Telegram alerts" : "Setup required"}
-                        </p>
-                        <p className="text-[11px] font-mono text-muted-foreground/80 truncate mt-0.5">
-                          {fullyActivated
-                            ? `${tgDisplayName ?? "Telegram"} · notifications active`
-                            : "Complete 2 steps to enable the agent"}
-                        </p>
-                      </div>
-                      <span className="shrink-0 px-3.5 py-2 rounded-md border border-gold/30 text-gold text-xs font-semibold hover:bg-gold/10 transition-colors">
+                        <AlertCircle className="h-[17px] w-[17px]" />
+                      )
+                    }
+                    iconTint={fullyActivated ? "bg-safe/10 text-safe" : "bg-watch/10 text-watch"}
+                    title={fullyActivated ? "Telegram alerts" : "Setup required"}
+                    desc={
+                      <span className="font-mono text-[11px] truncate block">
+                        {fullyActivated
+                          ? `${tgDisplayName ?? "Telegram"} · notifications active`
+                          : "Complete 2 steps to enable the agent"}
+                      </span>
+                    }
+                    action={
+                      <span className="shrink-0 px-3.5 py-2 rounded-xl border border-gold/30 text-gold text-xs font-semibold hover:bg-gold/10 transition-colors">
                         {fullyActivated ? "Manage" : "Activate"}
                       </span>
-                    </button>
-                  </div>
+                    }
+                  />
+
+                  {/* Backup-key nudge (guarded/starter wallets only) */}
+                  <UpgradeBanner variant="row" />
                 </div>
               </motion.div>
 
@@ -414,91 +484,145 @@ function SettingsPageContent() {
                 )}
               </AnimatePresence>
 
-              {/* Legacy 2-of-2 → 2-of-3 upgrade */}
-              <UpgradeBanner />
-
-              {/* WALLET section — every tx is a standard SafeTx, no modes */}
+              {/* WALLET — standard Safe + network, one card */}
               <motion.div variants={staggerItem}>
-                <div className="pt-6 border-t border-dashed border-border">
-                  <span className="eyebrow text-muted-foreground/60">Wallet</span>
+                <SectionHeader label="Wallet" />
+                <div data-tour="wallet-card" className="rounded-2xl bg-card overflow-hidden shadow-[0_20px_50px_-38px_rgba(0,0,0,0.7)]">
+                  <SettingsRow
+                    icon={<LayoutGrid className="h-[18px] w-[18px]" />}
+                    iconTint="bg-gold/10 text-gold"
+                    title="Standard Safe wallet"
+                    desc={
+                      profile === "guarded"
+                        ? "Add your backup key to unlock the full Safe app experience"
+                        : profile === "starter"
+                          ? "A standard Safe with your key — activate protection anytime"
+                          : "Every transaction appears in app.safe.global — sign there with your backup key anytime"
+                    }
+                    action={
+                      safeAddress && (
+                        <a
+                          href={`https://app.safe.global/home?safe=bnb:${safeAddress}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-xl border border-border text-[13px] font-medium text-foreground hover:border-gold/30 hover:text-gold transition-colors"
+                        >
+                          Open Safe
+                          <ExternalLink className="h-3 w-3" />
+                        </a>
+                      )
+                    }
+                  />
+                  <SettingsRow
+                    className="border-t border-border"
+                    icon={<Globe className="h-[18px] w-[18px]" />}
+                    iconTint="bg-foreground/5 text-muted-foreground"
+                    title="Network"
+                    desc="Chain the agent co-signs on"
+                    action={
+                      <span className="shrink-0 inline-flex items-center gap-2 text-[13px] font-medium text-foreground">
+                        <span
+                          className="h-1.5 w-1.5 rounded-pill bg-safe shadow-[0_0_8px_rgba(63,190,118,0.6)]"
+                          aria-hidden
+                        />
+                        BNB Chain · Mainnet
+                      </span>
+                    }
+                  />
                 </div>
-                <div data-tour="wallet-card" className="mt-4 rounded-lg bg-card overflow-hidden shadow-[0_20px_50px_-38px_rgba(0,0,0,0.7)]">
-                  <div className="flex items-center gap-4 p-5">
-                    <div className="w-10 h-10 rounded-md flex items-center justify-center shrink-0 bg-gold/10 text-gold">
-                      <LayoutGrid className="h-5 w-5" />
-                    </div>
+              </motion.div>
 
-                    <div className="flex-1 min-w-0">
-                      <h3 className="text-sm font-semibold text-foreground">Standard Safe wallet</h3>
-                      <p className="text-xs text-muted-foreground/80 mt-0.5">
-                        {profile === "guarded"
-                          ? "Add your backup key to unlock the full Safe app experience"
-                          : profile === "starter"
-                            ? "A standard Safe with your key — activate protection anytime"
-                            : "Every transaction appears in app.safe.global — sign there with your backup key anytime"}
-                      </p>
-                    </div>
+              {/* ADVANCED — force-execute */}
+              <motion.div variants={staggerItem}>
+                <SectionHeader label="Advanced" />
+                <div className="rounded-2xl bg-card overflow-hidden shadow-[0_20px_50px_-38px_rgba(0,0,0,0.7)]">
+                  <SettingsRow
+                    icon={<Zap className="h-[18px] w-[18px]" />}
+                    iconTint="bg-gold/10 text-gold"
+                    title="Force-execute"
+                    desc={
+                      forceExecuteEnabled
+                        ? "Send shows a “skip the queue” option — takes the current nonce, replacing any stuck transaction there. Screening still applies."
+                        : "Let a new transaction skip a stuck one by taking the current executable nonce (replaces whatever is pending there)."
+                    }
+                    action={
+                      <button
+                        onClick={() => setForceExecuteEnabled(!forceExecuteEnabled)}
+                        aria-label="Toggle force-execute"
+                        className={clsx(
+                          "relative w-12 h-6 rounded-pill transition-colors focus:outline-none focus:ring-2 focus:ring-gold/30 shrink-0 cursor-pointer",
+                          forceExecuteEnabled ? "bg-gold" : "bg-foreground/12"
+                        )}
+                      >
+                        <span
+                          className={clsx(
+                            "absolute top-0.5 w-5 h-5 rounded-pill bg-ink-0 shadow-md transition-all",
+                            forceExecuteEnabled ? "left-6" : "left-0.5"
+                          )}
+                        />
+                      </button>
+                    }
+                  />
+                </div>
+              </motion.div>
 
-                    {safeAddress && (
+              {/* APP — explorer + product tour, one card */}
+              <motion.div variants={staggerItem}>
+                <SectionHeader label="App" />
+                <div className="rounded-2xl bg-card overflow-hidden shadow-[0_20px_50px_-38px_rgba(0,0,0,0.7)]">
+                  <SettingsRow
+                    icon={<Search className="h-[18px] w-[18px]" />}
+                    iconTint="bg-foreground/5 text-muted-foreground"
+                    title="Block explorer"
+                    desc="Where transaction links open"
+                    action={
                       <a
-                        href={`https://app.safe.global/home?safe=bnb:${safeAddress}`}
+                        href="https://bscscan.com"
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md border border-border text-[13px] font-medium text-foreground hover:border-gold/30 hover:text-gold transition-colors"
+                        className="shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-xl border border-border text-[13px] font-medium text-foreground hover:border-gold/30 hover:text-gold transition-colors"
                       >
-                        Open Safe
+                        BscScan
                         <ExternalLink className="h-3 w-3" />
                       </a>
-                    )}
-                  </div>
+                    }
+                  />
+                  {safeAddress && (
+                    <SettingsRow
+                      className="border-t border-border"
+                      icon={<RotateCw className="h-[18px] w-[18px]" />}
+                      iconTint="bg-foreground/5 text-muted-foreground"
+                      title="Product tour"
+                      desc="Replay the walkthrough of your wallet"
+                      action={
+                        <button
+                          type="button"
+                          onClick={() =>
+                            startTour(
+                              /* Upgraded legacy accounts get their settings-focused
+                                 tour; everyone else replays the full walkthrough. */
+                              (safeConfig?.derivationVersion ?? 1) === 1 &&
+                                safeConfig?.profile === "protected"
+                                ? upgradeTour(safeAddress)
+                                : mainTour(safeAddress)
+                            )
+                          }
+                          className="shrink-0 inline-flex items-center px-3 py-1.5 rounded-xl border border-border text-[13px] font-medium text-foreground hover:border-gold/30 hover:text-gold transition-colors cursor-pointer"
+                        >
+                          Replay
+                        </button>
+                      }
+                    />
+                  )}
                 </div>
               </motion.div>
 
-              {/* FORCE-EXECUTE (advanced) */}
+              {/* UPGRADE — future plans */}
               <motion.div variants={staggerItem}>
-                <div className="pt-6 border-t border-dashed border-border">
-                  <span className="eyebrow text-muted-foreground/60">Advanced</span>
-                </div>
-                <div className="mt-4 rounded-lg bg-card overflow-hidden shadow-[0_20px_50px_-38px_rgba(0,0,0,0.7)]">
-                  <div className="flex items-center gap-4 p-5">
-                    <div className="w-10 h-10 rounded-md flex items-center justify-center shrink-0 bg-gold/10 text-gold">
-                      <Zap className="h-5 w-5" />
-                    </div>
-                    <div className="flex-1 min-w-0">
-                      <h3 className="text-sm font-semibold text-foreground">Force-execute</h3>
-                      <p className="text-xs text-muted-foreground/80 mt-0.5">
-                        {forceExecuteEnabled
-                          ? "Send shows a “skip the queue” option — takes the current nonce, replacing any stuck transaction there. Screening still applies."
-                          : "Let a new transaction skip a stuck one by taking the current executable nonce (replaces whatever is pending there)."}
-                      </p>
-                    </div>
-                    <button
-                      onClick={() => setForceExecuteEnabled(!forceExecuteEnabled)}
-                      aria-label="Toggle force-execute"
-                      className={clsx(
-                        "relative w-12 h-6 rounded-pill transition-colors focus:outline-none focus:ring-2 focus:ring-gold/30 shrink-0 cursor-pointer",
-                        forceExecuteEnabled ? "bg-gold" : "bg-foreground/12"
-                      )}
-                    >
-                      <span
-                        className={clsx(
-                          "absolute top-0.5 w-5 h-5 rounded-pill bg-ink-0 shadow-md transition-all",
-                          forceExecuteEnabled ? "left-6" : "left-0.5"
-                        )}
-                      />
-                    </button>
-                  </div>
-                </div>
-              </motion.div>
-
-              {/* UPGRADE section */}
-              <motion.div variants={staggerItem}>
-                <div className="pt-6 border-t border-dashed border-border">
-                  <span className="eyebrow text-muted-foreground/60">Upgrade</span>
-                </div>
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-4">
+                <SectionHeader label="Upgrade" />
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                   {/* Advanced Plan */}
-                  <div className="p-4 rounded-md bg-card border border-border opacity-60 pointer-events-none">
+                  <div className="p-[18px] rounded-2xl bg-card opacity-60 pointer-events-none">
                     <div className="flex items-center justify-between mb-3">
                       <div className="flex items-center gap-2.5">
                         <div className="w-9 h-9 rounded-md bg-gold/[0.08] flex items-center justify-center">
@@ -519,7 +643,7 @@ function SettingsPageContent() {
                   </div>
 
                   {/* Self-hosted Plan */}
-                  <div className="p-4 rounded-md bg-card border border-border opacity-60 pointer-events-none">
+                  <div className="p-[18px] rounded-2xl bg-card opacity-60 pointer-events-none">
                     <div className="flex items-center justify-between mb-3">
                       <div className="flex items-center gap-2.5">
                         <div className="w-9 h-9 rounded-md bg-foreground/[0.05] flex items-center justify-center">
@@ -542,58 +666,8 @@ function SettingsPageContent() {
                 </div>
               </motion.div>
 
-              {/* Danger zone — detach the agent (protected wallets only) */}
+              {/* DANGER ZONE — detach the agent (protected wallets only) */}
               <DetachZhentanCard />
-
-              {/* APP section */}
-              <motion.div variants={staggerItem}>
-                <div className="pt-6 border-t border-dashed border-border">
-                  <span className="eyebrow text-muted-foreground/60">App</span>
-                </div>
-                <div className="mt-1">
-                  <div className="flex items-center justify-between gap-6 py-4">
-                    <div className="min-w-0">
-                      <p className="eyebrow text-muted-foreground">Block explorer</p>
-                      <p className="text-xs text-muted-foreground/60 mt-1">Where transaction links open</p>
-                    </div>
-                    <a
-                      href="https://bscscan.com"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md border border-border text-[13px] font-medium text-foreground hover:border-gold/30 hover:text-gold transition-colors shrink-0"
-                    >
-                      BscScan
-                      <ExternalLink className="h-3 w-3" />
-                    </a>
-                  </div>
-                  {safeAddress && (
-                    <div className="flex items-center justify-between gap-6 py-4 border-t border-border/60">
-                      <div className="min-w-0">
-                        <p className="eyebrow text-muted-foreground">Product tour</p>
-                        <p className="text-xs text-muted-foreground/60 mt-1">
-                          Replay the walkthrough of your wallet
-                        </p>
-                      </div>
-                      <button
-                        type="button"
-                        onClick={() =>
-                          startTour(
-                            /* Upgraded legacy accounts get their settings-focused
-                               tour; everyone else replays the full walkthrough. */
-                            (safeConfig?.derivationVersion ?? 1) === 1 &&
-                              safeConfig?.profile === "protected"
-                              ? upgradeTour(safeAddress)
-                              : mainTour(safeAddress)
-                          )
-                        }
-                        className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md border border-border text-[13px] font-medium text-foreground hover:border-gold/30 hover:text-gold transition-colors shrink-0 cursor-pointer"
-                      >
-                        Replay
-                      </button>
-                    </div>
-                  )}
-                </div>
-              </motion.div>
             </motion.div>
           </>
         )}

--- a/client/src/app/(app)/settings/page.tsx
+++ b/client/src/app/(app)/settings/page.tsx
@@ -484,9 +484,9 @@ function SettingsPageContent() {
                 )}
               </AnimatePresence>
 
-              {/* WALLET — standard Safe + network, one card */}
+              {/* APP — wallet, network, force-execute, explorer, tour: one card */}
               <motion.div variants={staggerItem}>
-                <SectionHeader label="Wallet" />
+                <SectionHeader label="App" />
                 <div data-tour="wallet-card" className="rounded-2xl bg-card overflow-hidden shadow-[0_20px_50px_-38px_rgba(0,0,0,0.7)]">
                   <SettingsRow
                     icon={<LayoutGrid className="h-[18px] w-[18px]" />}
@@ -529,14 +529,8 @@ function SettingsPageContent() {
                       </span>
                     }
                   />
-                </div>
-              </motion.div>
-
-              {/* ADVANCED — force-execute */}
-              <motion.div variants={staggerItem}>
-                <SectionHeader label="Advanced" />
-                <div className="rounded-2xl bg-card overflow-hidden shadow-[0_20px_50px_-38px_rgba(0,0,0,0.7)]">
                   <SettingsRow
+                    className="border-t border-border"
                     icon={<Zap className="h-[18px] w-[18px]" />}
                     iconTint="bg-gold/10 text-gold"
                     title="Force-execute"
@@ -563,14 +557,8 @@ function SettingsPageContent() {
                       </button>
                     }
                   />
-                </div>
-              </motion.div>
-
-              {/* APP — explorer + product tour, one card */}
-              <motion.div variants={staggerItem}>
-                <SectionHeader label="App" />
-                <div className="rounded-2xl bg-card overflow-hidden shadow-[0_20px_50px_-38px_rgba(0,0,0,0.7)]">
                   <SettingsRow
+                    className="border-t border-border"
                     icon={<Search className="h-[18px] w-[18px]" />}
                     iconTint="bg-foreground/5 text-muted-foreground"
                     title="Block explorer"

--- a/client/src/app/context/AuthContext.tsx
+++ b/client/src/app/context/AuthContext.tsx
@@ -158,12 +158,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const { identityToken } = useIdentityToken();
 
   const hasAttemptedCreate = useRef(false);
-  // Signer the /users sync last ran for. Identity-keyed rather than a boolean:
-  // this provider outlives logout/login (root layout), so a once-latch set by
-  // a previous account would swallow the next account's sync — the only
-  // pre-deploy write of its owner set + derivation version. A record without
-  // those reads as legacy/guarded until the eager deploy backfills it, which
-  // (among other things) suppressed the first-time tour.
+  // "signer|safeAddress" the /users sync last ran for. Identity-keyed rather
+  // than a boolean: this provider outlives logout/login (root layout), so a
+  // once-latch set by a previous account would swallow the next account's
+  // sync — the only pre-deploy write of its owner set + derivation version.
+  // The Safe address is part of the key so a derivation that corrects the
+  // address mid-onboarding re-syncs the corrected row too.
   const syncedUserFor = useRef<string | null>(null);
 
   // The embedded Privy wallet, when one exists (Google / no-wallet logins).
@@ -519,12 +519,16 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     // null signer_address is invisible to that lookup forever, so the user is
     // treated as new on return and bounced back into onboarding.
     if (!safeAddress || !identityToken || !wallet?.address) return;
-    const signerKey = wallet.address.toLowerCase();
-    if (syncedUserFor.current === signerKey) return;
+    // Keyed by signer AND Safe address: if the resolved address changes for
+    // the same signer (e.g. a derivation correcting mid-onboarding), the
+    // corrected row must get its own full sync — a signer-only latch would
+    // leave it without owners/derivation_version/backup registration.
+    const syncKey = `${wallet.address.toLowerCase()}|${safeAddress.toLowerCase()}`;
+    if (syncedUserFor.current === syncKey) return;
     // Freshly derived Safes wait for the onboarding commit; record-backed
     // users sync immediately as before.
     if (safeDerived && !safeCommitted) return;
-    syncedUserFor.current = signerKey;
+    syncedUserFor.current = syncKey;
     const google = (privyUser as { google?: { email?: string; name?: string } } | null)?.google;
     apiFetch("/users", identityToken, {
       method: "POST",

--- a/client/src/app/onboarding/page.tsx
+++ b/client/src/app/onboarding/page.tsx
@@ -3,10 +3,23 @@
 import { useState, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { motion, AnimatePresence } from "framer-motion";
-import { ArrowRight, ArrowLeft, AtSign, Check, KeyRound, MessageCircle, Loader2, ShieldCheck, X, XIcon } from "lucide-react";
+import {
+  AlertTriangle,
+  ArrowLeft,
+  ArrowRight,
+  Check,
+  ChevronRight,
+  KeyRound,
+  Loader2,
+  Minus,
+  ShieldCheck,
+  Wallet,
+  X,
+} from "lucide-react";
+import { clsx } from "clsx";
 import { Button } from "@/components/ui/Button";
 import { AuthGuard } from "@/components/AuthGuard";
-import { BackupAddressPicker } from "@/components/BackupAddressPicker";
+import { useBackupCandidate } from "@/components/BackupAddressPicker";
 import { BrandMark } from "@/components/BrandMark";
 import { useAuth } from "@/app/context/AuthContext";
 import { useApiClient } from "@/lib/api/client";
@@ -18,29 +31,75 @@ import {
   markOnboardingTelegramDone,
   readOnboardingStep,
 } from "@/lib/useOnboarding";
+import { queueTour } from "@/lib/tours";
 
-/* ─── Step Indicator ─────────────────────────────────────────────── */
+/* ─── Progress header: step dashes + label ───────────────────────── */
 
-function StepIndicator({ current, total }: { current: number; total: number }) {
+function ProgressHeader({ step }: { step: number }) {
   return (
-    <div className="flex items-center gap-2">
-      {Array.from({ length: total }, (_, i) => (
-        <div
+    <div className="flex items-center gap-[7px] mb-6">
+      {[0, 1, 2, 3].map((i) => (
+        <span
           key={i}
-          className={`h-1.5 rounded-full transition-all duration-300 ${
-            i === current
-              ? "w-8 bg-gold"
-              : i < current
-              ? "w-4 bg-gold/40"
-              : "w-4 bg-foreground/10"
-          }`}
+          className={clsx(
+            "h-1 rounded-pill transition-all duration-300",
+            i === step ? "w-[30px] bg-gold" : i < step ? "w-4 bg-gold/40" : "w-4 bg-foreground/10"
+          )}
         />
       ))}
+      <span className="flex-1" />
+      <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground/70">
+        Step {step + 1} of 4
+      </span>
     </div>
   );
 }
 
-/* ─── Step 1: Gradual protection (add agent → add backup key) ─────── */
+/* ─── Shared bits ─────────────────────────────────────────────────── */
+
+function Tick({ selected }: { selected: boolean }) {
+  return (
+    <span
+      className={clsx(
+        "w-5 h-5 rounded-pill shrink-0 flex items-center justify-center mt-1.5 transition-all duration-200",
+        selected ? "bg-gold" : "border-[1.5px] border-foreground/16"
+      )}
+    >
+      {selected && <Check className="h-3 w-3 text-ink-900" strokeWidth={3.5} />}
+    </span>
+  );
+}
+
+const optionClass = (selected: boolean) =>
+  clsx(
+    "w-full text-left p-[15px] rounded-[18px] cursor-pointer transition-all duration-200 border",
+    selected
+      ? "border-gold/45 bg-gold/[0.075] hover:bg-gold/10"
+      : "border-foreground/8 bg-foreground/[0.025] hover:bg-foreground/[0.045]"
+  );
+
+const segClass = (on: boolean) =>
+  clsx(
+    "flex-1 py-[9px] rounded-[11px] text-xs font-semibold transition-all duration-200 cursor-pointer",
+    on ? "bg-gold/16 text-gold" : "text-muted-foreground hover:text-foreground"
+  );
+
+interface Cta {
+  label: string;
+  enabled: boolean;
+  onClick: () => void;
+}
+
+function PrimaryCta({ cta }: { cta: Cta }) {
+  return (
+    <Button onClick={cta.onClick} disabled={!cta.enabled} className="w-full mt-4">
+      {cta.label}
+      {cta.enabled && <ArrowRight className="ml-2 h-4 w-4" />}
+    </Button>
+  );
+}
+
+/* ─── Step 1: Protection choice + override key ────────────────────── */
 
 function ProtectionStep({ onContinue }: { onContinue: () => void }) {
   const {
@@ -52,38 +111,87 @@ function ProtectionStep({ onContinue }: { onContinue: () => void }) {
     safeAddress,
     safeLoading,
   } = useAuth();
-  // Two screens: "agent" (add screening → guarded, or skip → starter), then
-  // "backup" (add a backup key → protected, or skip → stay guarded). The end
-  // profile is wherever the user stops — each is a valid creation profile and
-  // upgrades later never change the address.
-  const [screen, setScreen] = useState<"agent" | "backup">("agent");
-  const [guardedAgreed, setGuardedAgreed] = useState(false);
+
+  // Two screens: "protect" (screening choice) then "backup" (override key).
+  // The end profile is wherever the user stops — each is a valid creation
+  // profile and upgrades later never change the address.
+  const [screen, setScreen] = useState<"protect" | "backup">("protect");
+  const [mode, setMode] = useState<"connect" | "address">("connect");
+  const [skipPanel, setSkipPanel] = useState(false);
+  // Skipping through the warning panel IS the lockout-risk acknowledgment
+  // (replaces the old consent checkbox).
+  const [skipped, setSkipped] = useState(false);
+  // Candidate confirmed via the primary CTA — auto-advance once the
+  // protected derivation lands ("Use this key & create my vault" is one tap).
+  const [advancePending, setAdvancePending] = useState(false);
+
+  const cand = useBackupCandidate();
 
   const derived = !!safeAddress && !safeLoading;
-  const starterReady = pendingProfile === "starter" && derived;
-  const guardedReady = pendingProfile === "guarded" && guardedAgreed && derived;
-  const protectedReady =
-    pendingProfile === "protected" && !!externalWalletAddress && derived;
+  const guardedSelected = pendingProfile === "guarded" || pendingProfile === "protected";
+  const starterSelected = pendingProfile === "starter";
+  const starterReady = starterSelected && derived;
+  const protectedReady = pendingProfile === "protected" && !!externalWalletAddress && derived;
+  const guardedReady = pendingProfile === "guarded" && derived;
 
-  const chooseAgent = () => {
-    setPendingProfile("guarded");
-    setScreen("backup");
+  useEffect(() => {
+    if (advancePending && protectedReady) {
+      setAdvancePending(false);
+      onContinue();
+    }
+  }, [advancePending, protectedReady, onContinue]);
+
+  // A backup key that already exists (resumed session, pre-linked wallet)
+  // makes the wallet protected — without this the ready-gate can never pass.
+  useEffect(() => {
+    if (screen === "backup" && externalWalletAddress && pendingProfile === "guarded") {
+      setPendingProfile("protected");
+    }
+  }, [screen, externalWalletAddress, pendingProfile, setPendingProfile]);
+
+  const pickGuarded = () => {
+    if (pendingProfile !== "protected") setPendingProfile("guarded");
   };
-  const chooseStarter = () => setPendingProfile("starter");
-  const chooseBackup = (addr: string) => {
-    setBackupAddress(addr);
+  const pickStarter = () => {
+    setBackupAddress(null);
+    setPendingProfile("starter");
+  };
+
+  const confirmCandidate = () => {
+    if (!cand.candidate) return;
+    setBackupAddress(cand.candidate.address);
     setPendingProfile("protected");
+    cand.clearCandidate();
+    setSkipped(false);
+    setSkipPanel(false);
+    setAdvancePending(true);
   };
+
   const clearBackup = () => {
     setBackupAddress(null);
     setPendingProfile("guarded");
   };
-  const backToAgent = () => {
-    setScreen("agent");
-    setBackupAddress(null);
-    setGuardedAgreed(false);
-    setPendingProfile(null);
-  };
+
+  const protectCta: Cta = !pendingProfile
+    ? { label: "Choose an option", enabled: false, onClick: () => {} }
+    : starterSelected
+      ? starterReady
+        ? { label: "Create my wallet", enabled: true, onClick: onContinue }
+        : { label: "Creating your vault...", enabled: false, onClick: () => {} }
+      : { label: "Turn on screening", enabled: true, onClick: () => setScreen("backup") };
+
+  const creating: Cta = { label: "Creating your vault...", enabled: false, onClick: () => {} };
+  const backupCta: Cta = cand.candidate
+    ? { label: "Use this key & create my vault", enabled: true, onClick: confirmCandidate }
+    : externalWalletAddress
+      ? advancePending || !protectedReady
+        ? creating
+        : { label: "Create my vault", enabled: true, onClick: onContinue }
+      : skipped
+        ? guardedReady
+          ? { label: "Create vault anyway", enabled: true, onClick: onContinue }
+          : creating
+        : { label: "Add a key", enabled: false, onClick: () => {} };
 
   return (
     <motion.div
@@ -92,162 +200,276 @@ function ProtectionStep({ onContinue }: { onContinue: () => void }) {
       animate={{ opacity: 1, x: 0 }}
       exit={{ opacity: 0, x: -40 }}
       transition={{ type: "spring", bounce: 0.15 }}
-      className="flex flex-col items-center w-full"
+      className="w-full"
     >
-      {screen === "agent" ? (
-        /* ── Screen 1: add the screening agent? ── */
+      {screen === "protect" ? (
+        /* ── 1a: how should this wallet be protected? ── */
         <>
-          <div className="w-14 h-14 rounded-2xl bg-gold/10 flex items-center justify-center mb-6">
-            <ShieldCheck className="w-7 h-7 text-gold" />
-          </div>
-
-          <h2 className="text-2xl font-bold text-center mb-2">Add AI screening?</h2>
-          <p className="text-sm text-muted-foreground text-center mb-6 max-w-xs">
-            Zhentan reviews every transaction before it executes — catching
-            scams and mistakes. Add it now or anytime later; your address never
-            changes.
+          <h2 className="text-[23px] font-bold tracking-tight mb-2">
+            How should this wallet be protected?
+          </h2>
+          <p className="text-[13.5px] leading-relaxed text-muted-foreground mb-5">
+            Pick one now — you can switch anytime in Settings and your wallet
+            address never changes.
           </p>
 
-          <div className="w-full max-w-xs space-y-3">
-            <button
-              onClick={chooseAgent}
-              className="w-full text-left rounded-2xl px-5 py-4 border border-gold/25 bg-gold/[0.06] hover:bg-gold/[0.09] hover:border-gold/40 transition-all duration-200"
-            >
-              <div className="flex items-center gap-2">
-                <ShieldCheck className="h-4 w-4 text-gold shrink-0" />
-                <p className="text-sm font-semibold text-foreground">
-                  Add the screening agent
-                </p>
-                <span className="px-2 py-0.5 rounded-pill bg-gold/12 text-gold text-[10px] font-mono uppercase tracking-wider">
-                  Recommended
+          <div className="flex flex-col gap-2.5">
+            <button type="button" onClick={pickGuarded} className={optionClass(guardedSelected)}>
+              <span className="flex items-start gap-3">
+                <span className="w-[34px] h-[34px] rounded-xl shrink-0 flex items-center justify-center bg-gold/12">
+                  <ShieldCheck className="h-[17px] w-[17px] text-gold" />
                 </span>
-              </div>
-              <p className="text-xs text-muted-foreground mt-1">
-                Zhentan reviews and co-signs every transaction.
-              </p>
+                <span className="flex-1 min-w-0">
+                  <span className="flex items-center gap-2 flex-wrap">
+                    <span className="text-[14.5px] font-bold tracking-tight">AI screening on</span>
+                    <span className="font-mono text-[9.5px] uppercase tracking-[0.1em] px-2 py-[3px] rounded-pill bg-gold/14 text-gold">
+                      Recommended
+                    </span>
+                  </span>
+                  <span className="block text-xs leading-relaxed text-muted-foreground mt-1">
+                    Zhentan reviews and co-signs every transaction, catching
+                    scams and mistakes before they land.
+                  </span>
+                </span>
+                <Tick selected={guardedSelected} />
+              </span>
             </button>
 
-            <button
-              onClick={chooseStarter}
-              className={`w-full text-left rounded-2xl px-5 py-4 border transition-all duration-200 ${
-                pendingProfile === "starter"
-                  ? "border-gold/40 bg-foreground/6"
-                  : "border-foreground/8 bg-foreground/4 hover:bg-foreground/6 hover:border-foreground/15"
-              }`}
-            >
-              <div className="flex items-center gap-2">
-                <KeyRound className="h-4 w-4 text-muted-foreground shrink-0" />
-                <p className="text-sm font-semibold text-foreground">
-                  Just my key for now
-                </p>
-              </div>
-              <p className="text-xs text-muted-foreground mt-1">
-                A standard wallet, no screening. Turn it on later in a tap.
-              </p>
+            <button type="button" onClick={pickStarter} className={optionClass(starterSelected)}>
+              <span className="flex items-start gap-3">
+                <span className="w-[34px] h-[34px] rounded-xl shrink-0 flex items-center justify-center bg-foreground/6">
+                  <KeyRound className="h-[17px] w-[17px] text-muted-foreground" />
+                </span>
+                <span className="flex-1 min-w-0">
+                  <span className="text-[14.5px] font-bold tracking-tight">Just my key</span>
+                  <span className="block text-xs leading-relaxed text-muted-foreground mt-1">
+                    A standard wallet with no screening. Zhentan still relays
+                    your transactions gas-free.
+                  </span>
+                </span>
+                <Tick selected={starterSelected} />
+              </span>
             </button>
-
-            {pendingProfile === "starter" && (
-              <>
-                <p className="text-[11px] text-muted-foreground/80 leading-relaxed rounded-xl p-3.5 bg-foreground/4 border border-foreground/8">
-                  No screening — transactions execute with just your signature.
-                  Zhentan relays them gas-free but never co-signs.
-                </p>
-                <Button onClick={onContinue} disabled={!starterReady} className="w-full">
-                  {starterReady ? "Continue" : "Creating your vault..."}
-                  {starterReady && <ArrowRight className="ml-2 h-4 w-4" />}
-                </Button>
-              </>
-            )}
           </div>
+
+          <PrimaryCta cta={protectCta} />
         </>
       ) : (
-        /* ── Screen 2: add a backup key? ── */
+        /* ── 1b: add the override key ── */
         <>
-          <div className="w-14 h-14 rounded-2xl bg-gold/10 flex items-center justify-center mb-6">
-            <KeyRound className="w-7 h-7 text-gold" />
-          </div>
-
-          <h2 className="text-2xl font-bold text-center mb-2">Add a backup key?</h2>
-          <p className="text-sm text-muted-foreground text-center mb-6 max-w-xs">
-            A second key you control — your override. With it you can always move
-            funds yourself at app.safe.global, even if Zhentan is ever offline.
+          <h2 className="text-[23px] font-bold tracking-tight mb-2">Add your override key</h2>
+          <p className="text-[13.5px] leading-relaxed text-muted-foreground mb-[18px]">
+            A second wallet you control, so you can always move funds yourself
+            at <span className="text-foreground/75">app.safe.global</span> — even
+            if Zhentan is offline. It is never asked to sign during setup.
           </p>
 
-          <div className="w-full max-w-xs space-y-3">
-            {!externalWalletAddress ? (
-              <BackupAddressPicker onSelect={chooseBackup} />
-            ) : (
-              <div className="w-full flex items-center gap-3 rounded-2xl px-4 py-3 border border-safe/25 bg-safe/6">
-                <Check className="h-4 w-4 text-safe shrink-0" />
-                <p className="text-xs text-muted-foreground font-mono truncate flex-1">
+          {externalWalletAddress ? (
+            /* Saved override key */
+            <div className="flex items-center gap-2.5 p-3.5 rounded-2xl bg-safe/[0.07] border border-safe/20">
+              <span className="w-[30px] h-[30px] rounded-[10px] shrink-0 flex items-center justify-center bg-safe/14">
+                <Check className="h-[15px] w-[15px] text-safe" strokeWidth={2.6} />
+              </span>
+              <span className="flex-1 min-w-0">
+                <span className="block text-[13px] font-semibold">Override key set</span>
+                <span className="block font-mono text-[11px] text-muted-foreground mt-0.5 truncate">
                   {externalWalletAddress}
-                </p>
-                {!backupAddressLocked && (
-                  <button
-                    onClick={clearBackup}
-                    className="shrink-0 text-xs text-muted-foreground hover:text-foreground transition-colors"
-                  >
-                    Change
-                  </button>
-                )}
-              </div>
-            )}
-
-            {externalWalletAddress ? (
-              <Button onClick={onContinue} disabled={!protectedReady} className="w-full">
-                {protectedReady ? "Continue" : "Creating your vault..."}
-                {protectedReady && <ArrowRight className="ml-2 h-4 w-4" />}
-              </Button>
-            ) : (
-              <div className="space-y-2.5 pt-1">
-                <label className="flex items-start gap-2.5 rounded-xl p-3.5 bg-watch/[0.07] border border-watch/15 cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={guardedAgreed}
-                    onChange={(e) => setGuardedAgreed(e.target.checked)}
-                    className="mt-0.5 accent-gold"
-                  />
-                  <span className="text-[11px] text-watch/90 leading-relaxed">
-                    I understand that without a backup key, Zhentan must approve
-                    every transaction — and if its agent is ever offline, my
-                    funds wait until I add one. I can add a backup key anytime.
-                  </span>
-                </label>
+                </span>
+              </span>
+              {!backupAddressLocked && (
                 <button
-                  onClick={onContinue}
-                  disabled={!guardedReady}
-                  className="w-full text-xs text-muted-foreground hover:text-foreground py-2 transition-colors disabled:opacity-50 disabled:cursor-default"
+                  type="button"
+                  onClick={clearBackup}
+                  className="shrink-0 p-1 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
                 >
-                  {guardedReady
-                    ? "Continue without a backup key"
-                    : guardedAgreed
-                    ? "Creating your vault..."
-                    : "Continue without a backup key"}
+                  Change
                 </button>
-              </div>
-            )}
+              )}
+            </div>
+          ) : (
+            !skipped && (
+              <div>
+                {/* Segmented: connect / enter address */}
+                <div className="flex gap-1 p-1 rounded-[14px] bg-foreground/4 mb-3">
+                  <button type="button" onClick={() => { setMode("connect"); cand.clearError(); }} className={segClass(mode === "connect")}>
+                    Connect a wallet
+                  </button>
+                  <button type="button" onClick={() => setMode("address")} className={segClass(mode === "address")}>
+                    Enter an address
+                  </button>
+                </div>
 
+                {mode === "connect" ? (
+                  <button
+                    type="button"
+                    onClick={cand.connect}
+                    disabled={cand.connecting}
+                    className="w-full flex items-center gap-3 text-left p-3.5 rounded-2xl border border-foreground/8 bg-foreground/[0.035] hover:bg-foreground/6 hover:border-foreground/14 transition-all duration-200 disabled:opacity-60 disabled:cursor-default cursor-pointer"
+                  >
+                    <span className="w-8 h-8 rounded-[10px] shrink-0 flex items-center justify-center bg-foreground/6">
+                      {cand.connecting ? (
+                        <Loader2 className="h-4 w-4 text-muted-foreground animate-spin" />
+                      ) : (
+                        <Wallet className="h-4 w-4 text-muted-foreground" />
+                      )}
+                    </span>
+                    <span className="flex-1">
+                      <span className="block text-[13.5px] font-semibold">Connect a wallet</span>
+                      <span className="block text-[11.5px] text-muted-foreground mt-0.5">
+                        {cand.connecting ? "Opening your wallet…" : "Read-only — no signature asked"}
+                      </span>
+                    </span>
+                    <ChevronRight className="h-[15px] w-[15px] text-muted-foreground/80 shrink-0" />
+                  </button>
+                ) : (
+                  <div>
+                    <div className="flex gap-2">
+                      <input
+                        type="text"
+                        value={cand.input}
+                        onChange={(e) => cand.updateInput(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") cand.resolveInput();
+                        }}
+                        placeholder="0x address, name.eth or name.bnb"
+                        spellCheck={false}
+                        autoComplete="off"
+                        className="flex-1 min-w-0 bg-foreground/4 border border-foreground/10 rounded-[13px] px-3.5 py-[11px] font-mono text-[12.5px] text-foreground placeholder:font-sans placeholder:text-muted-foreground/50 focus:outline-none focus:border-gold/50"
+                      />
+                      <button
+                        type="button"
+                        onClick={cand.resolveInput}
+                        disabled={cand.resolving || !cand.input.trim()}
+                        className="shrink-0 px-[15px] rounded-[13px] border border-gold/30 text-gold text-xs font-semibold hover:bg-gold/10 transition-colors disabled:opacity-45 disabled:cursor-default cursor-pointer"
+                      >
+                        {cand.resolving ? "Checking…" : "Use"}
+                      </button>
+                    </div>
+                    {cand.error && (
+                      <p className="flex items-start gap-1.5 text-[11.5px] leading-relaxed text-danger mt-2">
+                        <AlertTriangle className="h-[13px] w-[13px] shrink-0 mt-0.5" />
+                        {cand.error}
+                      </p>
+                    )}
+                  </div>
+                )}
+
+                {/* Candidate preview — confirmed by the primary CTA below */}
+                <AnimatePresence>
+                  {cand.candidate && (
+                    <motion.div
+                      initial={{ opacity: 0, y: 6 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      exit={{ opacity: 0, y: -6 }}
+                      className="mt-3 p-3.5 rounded-2xl border border-gold/25 bg-gold/[0.06]"
+                    >
+                      <p className="text-[13px] font-semibold">
+                        {cand.candidate.label ?? "Pasted address"}
+                      </p>
+                      <p className="font-mono text-[11px] text-muted-foreground mt-1 break-all">
+                        {cand.candidate.address}
+                      </p>
+                      <div className="flex items-start gap-2.5 mt-2.5">
+                        <p className="flex-1 text-[11.5px] leading-relaxed text-muted-foreground/90">
+                          Confirm you control this wallet. It becomes a permanent
+                          owner of your vault and can&apos;t be swapped casually
+                          later.
+                        </p>
+                        <button
+                          type="button"
+                          onClick={cand.clearCandidate}
+                          className="shrink-0 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+                        >
+                          Clear
+                        </button>
+                      </div>
+                    </motion.div>
+                  )}
+                </AnimatePresence>
+              </div>
+            )
+          )}
+
+          {/* Skip warning panel — accepting it acknowledges the lockout risk */}
+          <AnimatePresence>
+            {skipPanel && (
+              <motion.div
+                initial={{ opacity: 0, y: 6 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -6 }}
+                className="mt-3 p-[15px] rounded-2xl bg-watch/[0.06] border border-watch/18"
+              >
+                <p className="flex items-center gap-2 text-[13px] font-semibold text-watch mb-1.5">
+                  <AlertTriangle className="h-3.5 w-3.5" />
+                  Continue without an override key?
+                </p>
+                <p className="text-xs leading-relaxed text-watch/85 mb-3">
+                  Zhentan must co-sign every transaction. If its agent is ever
+                  offline, your funds sit safe but wait. Adding a key later
+                  takes one tap in Settings.
+                </p>
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setSkipped(true);
+                      setSkipPanel(false);
+                      cand.clearCandidate();
+                    }}
+                    className="flex-1 py-2.5 rounded-xl border border-watch/35 text-watch text-xs font-semibold hover:bg-watch/10 transition-colors cursor-pointer"
+                  >
+                    Skip for now
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setSkipPanel(false);
+                      setSkipped(false);
+                    }}
+                    className="flex-1 py-2.5 rounded-xl bg-gold text-ink-900 text-xs font-bold hover:bg-gold/90 transition-colors cursor-pointer"
+                  >
+                    Add a key
+                  </button>
+                </div>
+              </motion.div>
+            )}
+          </AnimatePresence>
+
+          <PrimaryCta cta={backupCta} />
+
+          <div className="flex items-center justify-between mt-3">
             <button
-              onClick={backToAgent}
-              className="w-full inline-flex items-center justify-center gap-1.5 text-xs text-muted-foreground/60 hover:text-muted-foreground py-1.5 transition-colors"
+              type="button"
+              onClick={() => setScreen("protect")}
+              className="inline-flex items-center gap-1.5 py-1 text-xs text-muted-foreground/75 hover:text-foreground transition-colors cursor-pointer"
             >
-              <ArrowLeft className="h-3.5 w-3.5" />
+              <ArrowLeft className="h-[13px] w-[13px]" />
               Back
             </button>
+            {!externalWalletAddress && !skipPanel && !skipped && (
+              <button
+                type="button"
+                onClick={() => setSkipPanel(true)}
+                className="py-1 text-xs text-muted-foreground/75 hover:text-foreground transition-colors cursor-pointer"
+              >
+                I&apos;ll add this later
+              </button>
+            )}
           </div>
+
+          <p className="text-[11px] leading-relaxed text-muted-foreground/60 text-center mt-[18px]">
+            With an override key your vault is a 2-of-3 Safe — your key, your
+            override key, the screening agent. Any two move funds, so
+            you&apos;re never locked out and Zhentan alone can never move a
+            cent.
+          </p>
         </>
       )}
-
-      <p className="mt-6 text-[11px] text-muted-foreground/70 text-center leading-relaxed max-w-xs">
-        Full protection is a 2-of-3 Safe: your key, your backup key, and the
-        screening agent. Any two signatures move funds — you&apos;re never locked
-        out, and Zhentan alone can never move a cent.
-      </p>
     </motion.div>
   );
 }
 
-/* ─── Step 2: Choose Username ────────────────────────────────────── */
+/* ─── Step 2: Claim username ─────────────────────────────────────── */
 
 function UsernameStep({
   onSave,
@@ -265,6 +487,7 @@ function UsernameStep({
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const isValid = username.trim().length >= 3;
+  const available = isValid && !taken && !checking;
 
   const handleChange = (val: string) => {
     const clean = val.toLowerCase().replace(/[^a-z0-9_]/g, "");
@@ -276,8 +499,8 @@ function UsernameStep({
       setChecking(true);
       debounceRef.current = setTimeout(async () => {
         try {
-          const available = await api.users.checkUsername(clean);
-          setTaken(!available);
+          const ok = await api.users.checkUsername(clean);
+          setTaken(!ok);
         } catch {
           setTaken(false);
         } finally {
@@ -301,6 +524,17 @@ function UsernameStep({
     }
   };
 
+  const hint = error
+    ? error
+    : taken
+      ? "That username is taken."
+      : username.length > 0 && username.length < 3
+        ? "At least 3 characters."
+        : available
+          ? `Available — friends can pay you at @${username}`
+          : "";
+  const hintColor = error || taken ? "text-danger" : available ? "text-safe" : "text-muted-foreground/80";
+
   return (
     <motion.div
       key="username"
@@ -308,69 +542,66 @@ function UsernameStep({
       animate={{ opacity: 1, x: 0 }}
       exit={{ opacity: 0, x: -40 }}
       transition={{ type: "spring", bounce: 0.15 }}
-      className="flex flex-col items-center w-full"
+      className="w-full"
     >
-      <div className="w-14 h-14 rounded-2xl bg-gold/10 flex items-center justify-center mb-6">
-        <AtSign className="w-7 h-7 text-gold" />
-      </div>
-
-      <h2 className="text-2xl font-bold text-center mb-2">Choose your username</h2>
-      <p className="text-sm text-muted-foreground text-center mb-8 max-w-xs">
-        This is how others will find you on Zhentan. You can change it later.
+      <h2 className="text-[23px] font-bold tracking-tight mb-2">Claim your username</h2>
+      <p className="text-[13.5px] leading-relaxed text-muted-foreground mb-5">
+        Friends can send to <span className="font-mono text-foreground/75">@you</span> instead
+        of a 42-character address. Change it anytime.
       </p>
 
-      <div className="w-full max-w-xs space-y-4">
-        <div className="relative">
-          <span className="absolute left-4 top-1/2 -translate-y-1/2 text-muted-foreground text-sm">
-            @
+      <div className="relative">
+        <span className="absolute left-3.5 top-1/2 -translate-y-1/2 font-mono text-sm text-muted-foreground">
+          @
+        </span>
+        <input
+          type="text"
+          value={username}
+          onChange={(e) => handleChange(e.target.value)}
+          placeholder="alextan"
+          maxLength={20}
+          spellCheck={false}
+          className="w-full rounded-[15px] border border-foreground/10 bg-foreground/4 pl-[34px] pr-10 py-[13px] font-mono text-sm text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:border-gold/50"
+        />
+        {isValid && (
+          <span className="absolute right-3.5 top-1/2 -translate-y-1/2 flex">
+            {checking ? (
+              <Loader2 className="w-3.5 h-3.5 animate-spin text-muted-foreground/80" />
+            ) : taken ? (
+              <X className="w-3.5 h-3.5 text-danger" strokeWidth={3} />
+            ) : (
+              <Check className="w-3.5 h-3.5 text-safe" strokeWidth={3} />
+            )}
           </span>
-          <input
-            type="text"
-            value={username}
-            onChange={(e) => handleChange(e.target.value)}
-            placeholder="johndoe"
-            maxLength={20}
-            className="w-full rounded-2xl bg-foreground/6 pl-9 pr-10 py-3.5 text-sm text-foreground placeholder:text-muted-foreground/70 focus:outline-none focus:ring-2 focus:ring-gold/40 focus:bg-foreground/8 transition-all"
-          />
-          {isValid && (
-            <span className="absolute right-4 top-1/2 -translate-y-1/2">
-              {checking ? (
-                <Loader2 className="w-3.5 h-3.5 animate-spin text-muted-foreground/80" />
-              ) : taken ? (
-                <X className="w-3.5 h-3.5 text-danger" />
-              ) : (
-                <Check className="w-3.5 h-3.5 text-safe" />
-              )}
-            </span>
-          )}
-        </div>
-
-        {username.length > 0 && username.length < 3 && (
-          <p className="text-xs text-watch/80 pl-1">At least 3 characters</p>
         )}
-        {taken && <p className="text-xs text-danger pl-1">Username already taken</p>}
-        {error && <p className="text-xs text-danger pl-1">{error}</p>}
-
-        <Button onClick={handleSave} disabled={!isValid || saving || taken || checking} className="w-full">
-          {saving ? (
-            <><Loader2 className="w-4 h-4 animate-spin" />Saving...</>
-          ) : (
-            <>Continue <ArrowRight className="w-4 h-4" /></>
-          )}
-        </Button>
-
-        <button
-          onClick={onSkip}
-          className="w-full text-sm text-muted-foreground/50 hover:text-muted-foreground py-2 transition-colors"
-        >
-          Skip for now
-        </button>
       </div>
+      <p className={clsx("text-[11.5px] mt-2 min-h-4", hintColor)}>{hint}</p>
+
+      <Button onClick={handleSave} disabled={!available || saving} className="w-full mt-4">
+        {saving ? (
+          <>
+            <Loader2 className="w-4 h-4 animate-spin" />
+            Saving...
+          </>
+        ) : (
+          <>
+            Continue
+            <ArrowRight className="w-4 h-4" />
+          </>
+        )}
+      </Button>
+      <button
+        type="button"
+        onClick={onSkip}
+        className="w-full mt-2.5 py-1.5 text-xs text-muted-foreground/70 hover:text-foreground transition-colors cursor-pointer"
+      >
+        Skip for now
+      </button>
     </motion.div>
   );
 }
 
-/* ─── Step 2: Connect Telegram ───────────────────────────────────── */
+/* ─── Step 3: Telegram alerts ────────────────────────────────────── */
 
 const TelegramIcon = ({ className }: { className?: string }) => (
   <svg className={className} viewBox="0 0 24 24" fill="currentColor">
@@ -452,116 +683,109 @@ function ConnectStep({
       animate={{ opacity: 1, x: 0 }}
       exit={{ opacity: 0, x: -40 }}
       transition={{ type: "spring", bounce: 0.15 }}
-      className="flex flex-col items-center w-full"
+      className="w-full"
     >
-      <div className="w-14 h-14 rounded-2xl bg-gold/10 flex items-center justify-center mb-6">
-        <MessageCircle className="w-7 h-7 text-gold" />
-      </div>
-
-      <h2 className="text-2xl font-bold text-center mb-2">Connect Telegram</h2>
-      <p className="text-sm text-muted-foreground text-center mb-8 max-w-xs">
-        Get notified about transactions and manage your wallet from anywhere.
+      <h2 className="text-[23px] font-bold tracking-tight mb-2">Get alerts on Telegram</h2>
+      <p className="text-[13.5px] leading-relaxed text-muted-foreground mb-5">
+        Zhentan pings you when it screens a transaction, so you can approve or
+        reject from anywhere.
       </p>
 
-      <div className="w-full max-w-xs space-y-4">
-        <AnimatePresence mode="wait">
-          {!telegramLinked ? (
-            /* ── Not connected ── */
-            <motion.div
-              key="disconnected"
-              initial={{ opacity: 0, y: 6 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: -6 }}
-              transition={{ type: "spring", bounce: 0.1 }}
+      <AnimatePresence mode="wait">
+        {telegramLinked ? (
+          <motion.div
+            key="connected"
+            initial={{ opacity: 0, y: 6 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -6 }}
+            transition={{ type: "spring", bounce: 0.1 }}
+            className="flex items-center gap-3 p-3.5 rounded-2xl bg-safe/[0.07] border border-safe/20"
+          >
+            <span className="w-[34px] h-[34px] rounded-xl shrink-0 flex items-center justify-center bg-safe/14">
+              <TelegramIcon className="h-[17px] w-[17px] text-safe" />
+            </span>
+            <span className="flex-1 min-w-0">
+              <span className="flex items-center gap-2">
+                <span className="text-[13.5px] font-semibold">Telegram</span>
+                <span className="font-mono text-[9.5px] uppercase tracking-[0.1em] px-[7px] py-0.5 rounded-pill bg-safe/14 text-safe">
+                  Connected
+                </span>
+              </span>
+              <span className="block font-mono text-[11.5px] text-muted-foreground mt-1 truncate">
+                {tgUsername ? `@${tgUsername}` : "Account linked"}
+              </span>
+            </span>
+            <button
+              type="button"
+              onClick={handleDisconnect}
+              disabled={unlinking}
+              className="shrink-0 p-1 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer disabled:opacity-60"
             >
-              <button
-                onClick={() => { setLinking(true); linkTelegram(); }}
-                disabled={linking}
-                className="w-full flex items-center gap-4 rounded-2xl px-5 py-4 border border-foreground/8 bg-foreground/4 hover:bg-foreground/6 hover:border-foreground/12 transition-all duration-200 disabled:opacity-60 disabled:cursor-default"
-              >
-                <div className="w-10 h-10 rounded-xl bg-foreground/6 flex items-center justify-center shrink-0">
-                  {linking
-                    ? <Loader2 className="h-5 w-5 text-muted-foreground animate-spin" />
-                    : <TelegramIcon className="h-5 w-5 text-muted-foreground" />
-                  }
-                </div>
-                <div className="flex-1 text-left">
-                  <p className="text-sm font-semibold text-foreground">Connect Telegram</p>
-                  <p className="text-xs text-muted-foreground mt-0.5">
-                    {linking ? "Opening Telegram..." : "Review alerts & approve transactions"}
-                  </p>
-                </div>
-                <ArrowRight className="h-4 w-4 text-muted-foreground/80 shrink-0" />
-              </button>
-            </motion.div>
-          ) : (
-            /* ── Connected ── */
-            <motion.div
-              key="connected"
-              initial={{ opacity: 0, y: 6 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: -6 }}
-              transition={{ type: "spring", bounce: 0.1 }}
-            >
-              <div className="flex flex-row justify-between items-center gap-4 rounded-2xl px-5 py-4 border border-foreground/8 bg-foreground/4">
-                <div className="w-10 h-10 rounded-xl bg-foreground/6 flex items-center justify-center shrink-0">
-                  <TelegramIcon className="h-5 w-5 text-muted-foreground" />
-                </div>
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2">
-                    <p className="text-sm font-semibold text-foreground">Telegram</p>
-                    <span className="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-safe/15 text-safe">
-                      Connected
-                    </span>
-                  </div>
-                  <p className="text-xs text-muted-foreground mt-0.5 truncate">
-                    {tgUsername ? `@${tgUsername}` : "Account linked"}
-                  </p>
-                </div>
-                <button
-                onClick={handleDisconnect}
-                disabled={unlinking}
-                className="flex items-center justify-center gap-1.5 py-1.5 text-xs text-muted-foreground/80 hover:text-danger transition-colors"
-              >
-                {unlinking ? <Loader2 className="h-5 w-5 animate-spin" /> : <XIcon className="h-5 w-5" />}
-                
-              </button>
-              </div>
+              {unlinking ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : "Disconnect"}
+            </button>
+          </motion.div>
+        ) : (
+          <motion.button
+            key="disconnected"
+            initial={{ opacity: 0, y: 6 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -6 }}
+            transition={{ type: "spring", bounce: 0.1 }}
+            type="button"
+            onClick={() => {
+              setLinking(true);
+              linkTelegram();
+            }}
+            disabled={linking}
+            className="w-full flex items-center gap-3 text-left p-3.5 rounded-2xl border border-foreground/8 bg-foreground/[0.035] hover:bg-foreground/6 hover:border-foreground/14 transition-all duration-200 disabled:opacity-60 disabled:cursor-default cursor-pointer"
+          >
+            <span className="w-[34px] h-[34px] rounded-xl shrink-0 flex items-center justify-center bg-foreground/6">
+              {linking ? (
+                <Loader2 className="h-[17px] w-[17px] text-muted-foreground animate-spin" />
+              ) : (
+                <TelegramIcon className="h-[17px] w-[17px] text-muted-foreground" />
+              )}
+            </span>
+            <span className="flex-1">
+              <span className="block text-[13.5px] font-semibold">Connect Telegram</span>
+              <span className="block text-[11.5px] text-muted-foreground mt-0.5">
+                {linking ? "Opening Telegram…" : "Approve or reject from your chat"}
+              </span>
+            </span>
+            <ChevronRight className="h-[15px] w-[15px] text-muted-foreground/80 shrink-0" />
+          </motion.button>
+        )}
+      </AnimatePresence>
 
-              
-            </motion.div>
-          )}
-        </AnimatePresence>
-
-        <Button onClick={onFinish} disabled={!telegramLinked} className="w-full">
-          Continue
-          <ArrowRight className="w-4 h-4" />
-        </Button>
-
-        <button
-          onClick={onSkip}
-          className="w-full text-sm text-muted-foreground/50 hover:text-muted-foreground py-2 transition-colors"
-        >
-          Skip for now
-        </button>
-      </div>
+      <Button onClick={onFinish} className="w-full mt-4">
+        Continue
+        <ArrowRight className="w-4 h-4" />
+      </Button>
+      <button
+        type="button"
+        onClick={onSkip}
+        className="w-full mt-2.5 py-1.5 text-xs text-muted-foreground/70 hover:text-foreground transition-colors cursor-pointer"
+      >
+        Skip for now
+      </button>
     </motion.div>
   );
 }
 
-/* ─── Step 3: Done ───────────────────────────────────────────────── */
+/* ─── Step 4: Done ───────────────────────────────────────────────── */
 
 function DoneStep({
-  username,
-  socialName,
+  screeningOn,
+  backupSet,
+  tgLinked,
   onFinish,
 }: {
-  username: string | null;
-  socialName: string | null;
+  screeningOn: boolean;
+  backupSet: boolean;
+  tgLinked: boolean;
   onFinish: () => Promise<void>;
 }) {
   const [finishing, setFinishing] = useState(false);
-  const displayName = socialName?.trim() || username;
 
   const handleGo = async () => {
     if (finishing) return;
@@ -573,39 +797,82 @@ function DoneStep({
     }
   };
 
+  const doneLine = !screeningOn
+    ? "A standard wallet, ready to use. Turn on screening whenever you like."
+    : backupSet
+      ? "You're on a 2-of-3 Safe — fully protected and never locked out."
+      : "Screening is on. Add an override key any time in Settings.";
+
+  const rows = [
+    {
+      on: screeningOn,
+      text: screeningOn
+        ? "AI screening on — every transaction reviewed"
+        : "Screening off — you sign, Zhentan relays gas-free",
+    },
+    {
+      on: backupSet,
+      text: backupSet
+        ? "Override key set — move funds yourself anytime"
+        : "No override key yet — add one in Settings",
+    },
+    {
+      on: tgLinked,
+      text: tgLinked ? "Telegram alerts on" : "Telegram not connected",
+    },
+  ];
+
   return (
     <motion.div
       key="done"
       initial={{ opacity: 0, scale: 0.95 }}
       animate={{ opacity: 1, scale: 1 }}
       transition={{ type: "spring", bounce: 0.2 }}
-      className="flex flex-col items-center w-full"
+      className="w-full text-center"
     >
       <motion.div
         initial={{ scale: 0 }}
         animate={{ scale: 1 }}
         transition={{ delay: 0.15, type: "spring", bounce: 0.4 }}
-        className="w-16 h-16 rounded-full bg-gold flex items-center justify-center mb-6 shadow-[0_0_40px_rgba(196,148,40,0.3)]"
+        className="w-[60px] h-[60px] mx-auto mt-1.5 mb-5 rounded-pill bg-gold flex items-center justify-center shadow-[0_0_44px_rgba(196,148,40,0.35)]"
       >
-        <Check className="w-8 h-8 text-black" />
+        <Check className="w-7 h-7 text-ink-900" strokeWidth={3.2} />
       </motion.div>
 
-      <h2 className="text-2xl font-bold text-center mb-2">You're all set!</h2>
-      {displayName && (
-        <p className="text-sm text-muted-foreground text-center mb-2">
-          Welcome, <span className="text-gold font-semibold capitalize">{displayName}</span>
-        </p>
-      )}
-      <p className="text-xs text-muted-foreground/60 text-center max-w-xs mb-8">
-        Your AI-secured wallet is ready. Every transaction will be screened and
-        protected by Zhentan.
-      </p>
+      <h2 className="text-[23px] font-bold tracking-tight mb-2">Your vault is ready</h2>
+      <p className="text-[13.5px] leading-relaxed text-muted-foreground mb-5">{doneLine}</p>
 
-      <Button onClick={handleGo} disabled={finishing} className="w-full max-w-xs">
+      <div className="flex flex-col gap-px rounded-2xl overflow-hidden bg-foreground/6 text-left mb-5">
+        {rows.map((r) => (
+          <div key={r.text} className="flex items-center gap-2.5 px-3.5 py-3 bg-card">
+            <span
+              className={clsx(
+                "w-5 h-5 rounded-pill shrink-0 flex items-center justify-center",
+                r.on ? "bg-safe/14 text-safe" : "bg-foreground/6 text-muted-foreground/70"
+              )}
+            >
+              {r.on ? (
+                <Check className="h-3 w-3" strokeWidth={3} />
+              ) : (
+                <Minus className="h-3 w-3" strokeWidth={3} />
+              )}
+            </span>
+            <span className="flex-1 text-xs text-foreground/80">{r.text}</span>
+          </div>
+        ))}
+      </div>
+
+      <Button onClick={handleGo} disabled={finishing} className="w-full">
         {finishing ? (
-          <><Loader2 className="w-4 h-4 animate-spin" />Finishing...</>
+          <>
+            <Loader2 className="w-4 h-4 animate-spin" />
+            Finishing...
+          </>
         ) : (
-          <>Go to App <ArrowRight className="w-4 h-4" /></>
+          <>
+            Go to my wallet
+            <ArrowRight className="w-4 h-4" />
+          </>
         )}
       </Button>
     </motion.div>
@@ -616,13 +883,22 @@ function DoneStep({
 
 function OnboardingContent() {
   const router = useRouter();
-  const { safeAddress, safeConfig, safeLoading, wallet, user, commitSafe, recordOnboardingCompleted, refreshSafe } = useAuth();
+  const {
+    safeAddress,
+    safeConfig,
+    safeLoading,
+    wallet,
+    commitSafe,
+    recordOnboardingCompleted,
+    refreshSafe,
+    pendingProfile,
+    externalWalletAddress,
+    telegramUserId,
+  } = useAuth();
   const api = useApiClient();
 
   const [step, setStep] = useState(0);
   const [stepReady, setStepReady] = useState(false);
-  const [savedUsername, setSavedUsername] = useState<string | null>(null);
-  const totalSteps = 4;
 
   // Already onboarded (per the backend record) → forward to the app. Without
   // this, a completed user who lands on /onboarding (a stale deep-link, a
@@ -659,7 +935,6 @@ function OnboardingContent() {
     if (!safeAddress || !wallet?.address) throw new Error("Wallet not ready");
     await api.users.upsert({ safeAddress, username });
     markOnboardingUsernameSet(wallet.address);
-    setSavedUsername(username);
     setStep(2);
   };
 
@@ -690,8 +965,7 @@ function OnboardingContent() {
     // Transaction Service. Agent pays gas; /queue re-checks as a fallback,
     // so a failure here must not trap the user on this screen. The deploy also
     // backfills owners/derivation_version on the record — refetch once it
-    // lands so a session holding an incomplete row (which reads as legacy and
-    // e.g. suppresses the first-time tour) heals without a reload.
+    // lands so a session holding an incomplete row heals without a reload.
     if (safeConfig) {
       api.safe
         .deploy(safeConfig.owners, safeConfig.threshold)
@@ -701,9 +975,11 @@ function OnboardingContent() {
         });
     }
     markOnboardingTelegramDone(wallet.address);
+    // Queue the first-time tour for arrival on /home — TourLauncher consumes
+    // this marker; it never infers "new user" from account state.
+    queueTour("main");
     // The in-memory record still says onboarding_completed=false — refresh it
-    // so record-driven consumers (e.g. the first-time tour) see completion
-    // without waiting for the next full page load.
+    // so record-driven consumers see completion without a full page load.
     refreshSafe();
     router.replace("/home");
   };
@@ -712,16 +988,13 @@ function OnboardingContent() {
   if (!stepReady) return null;
 
   return (
-    <div className="min-h-screen hero-gradient text-foreground flex flex-col items-center justify-center px-4 relative">
-      {/* Background grid */}
-      <div className="absolute inset-0 grid-pattern opacity-40 pointer-events-none" />
-
+    <div className="min-h-screen hero-gradient text-foreground flex flex-col items-center justify-center px-5 py-14">
       {/* Logo */}
       <motion.div
         initial={{ opacity: 0, y: -12 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ type: "spring", bounce: 0.2 }}
-        className="absolute top-8 left-1/2 -translate-x-1/2"
+        className="mb-8"
       >
         <BrandMark size="xl" className="gap-3" glow priority />
       </motion.div>
@@ -731,15 +1004,10 @@ function OnboardingContent() {
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ delay: 0.15, type: "spring", bounce: 0.15 }}
-        className="w-full max-w-sm glass-card p-8 flex flex-col items-center"
+        className="w-full max-w-[436px] rounded-[26px] bg-card border border-border shadow-[0_34px_80px_-50px_rgba(0,0,0,0.9)] p-[30px] pb-[26px]"
       >
-        {/* Step indicator + skip-all button */}
-        <div className="w-full flex items-center justify-center mb-8">
-          <StepIndicator current={step} total={totalSteps} />
-          
-        </div>
+        <ProgressHeader step={step} />
 
-        {/* Step content */}
         <AnimatePresence mode="wait">
           {step === 0 && <ProtectionStep onContinue={handleBackupKeyDone} />}
           {step === 1 && (
@@ -757,8 +1025,9 @@ function OnboardingContent() {
           )}
           {step === 3 && (
             <DoneStep
-              username={savedUsername}
-              socialName={user?.name ?? null}
+              screeningOn={(safeConfig?.profile ?? pendingProfile) !== "starter"}
+              backupSet={!!externalWalletAddress}
+              tgLinked={!!telegramUserId}
               onFinish={handleFinish}
             />
           )}

--- a/client/src/app/onboarding/page.tsx
+++ b/client/src/app/onboarding/page.tsx
@@ -253,6 +253,12 @@ function ProtectionStep({ onContinue }: { onContinue: () => void }) {
           </div>
 
           <PrimaryCta cta={protectCta} />
+          {starterSelected && (
+            <p className="text-[11px] leading-relaxed text-muted-foreground/60 text-center mt-3">
+              Your vault address is minted on creation — adding protection
+              later never changes it.
+            </p>
+          )}
         </>
       ) : (
         /* ── 1b: add the override key ── */
@@ -436,6 +442,15 @@ function ProtectionStep({ onContinue }: { onContinue: () => void }) {
           </AnimatePresence>
 
           <PrimaryCta cta={backupCta} />
+
+          {/* Finality note: the CTA below mints the address / locks the key */}
+          {(cand.candidate || externalWalletAddress || skipped) && (
+            <p className="text-[11px] leading-relaxed text-muted-foreground/60 text-center mt-3">
+              {skipped && !cand.candidate && !externalWalletAddress
+                ? "Your vault address is minted on creation — adding an override key later never changes it."
+                : "Creating your vault makes this key a permanent owner — changing it later is an on-chain owner swap in Settings."}
+            </p>
+          )}
 
           <div className="flex items-center justify-between mt-3">
             <button

--- a/client/src/app/onboarding/page.tsx
+++ b/client/src/app/onboarding/page.tsx
@@ -110,6 +110,7 @@ function ProtectionStep({ onContinue }: { onContinue: () => void }) {
     setPendingProfile,
     safeAddress,
     safeLoading,
+    safeConfig,
   } = useAuth();
 
   // Two screens: "protect" (screening choice) then "backup" (override key).
@@ -127,12 +128,24 @@ function ProtectionStep({ onContinue }: { onContinue: () => void }) {
 
   const cand = useBackupCandidate();
 
-  const derived = !!safeAddress && !safeLoading;
+  // Readiness gates check the RESOLVED derivation (safeConfig.profile is
+  // classified from the derived owner set), never just the pending inputs:
+  // right after a choice changes, safeAddress/safeConfig still describe the
+  // PREVIOUS derivation for a render or two — and the auto-advance effect
+  // runs before the provider effect that flips safeLoading. Committing in
+  // that window persists a row for the stale address (the duplicate-row bug).
+  const derived = !!safeAddress && !safeLoading && !!safeConfig;
+  const resolvedProfile = safeConfig?.profile ?? null;
   const guardedSelected = pendingProfile === "guarded" || pendingProfile === "protected";
   const starterSelected = pendingProfile === "starter";
-  const starterReady = starterSelected && derived;
-  const protectedReady = pendingProfile === "protected" && !!externalWalletAddress && derived;
-  const guardedReady = pendingProfile === "guarded" && derived;
+  const starterReady = starterSelected && derived && resolvedProfile === "starter";
+  const protectedReady =
+    pendingProfile === "protected" &&
+    !!externalWalletAddress &&
+    derived &&
+    resolvedProfile === "protected";
+  const guardedReady =
+    pendingProfile === "guarded" && derived && resolvedProfile === "guarded";
 
   useEffect(() => {
     if (advancePending && protectedReady) {

--- a/client/src/components/BackupAddressPicker.tsx
+++ b/client/src/components/BackupAddressPicker.tsx
@@ -9,8 +9,13 @@ import { getAddress, isAddress } from "viem";
 import { useAuth } from "@/app/context/AuthContext";
 import { useApiClient } from "@/lib/api/client";
 
+export interface BackupCandidate {
+  address: string;
+  label?: string;
+}
+
 /**
- * Signature-free backup-key (owner #2) selection. Three ways in:
+ * Signature-free backup-key (owner #2) candidate selection. Three ways in:
  *   1. Connect a wallet — Privy connect modal, eth_requestAccounts only.
  *      No SIWE, no account linking, so the same hardware/backup wallet can
  *      serve any number of Zhentan accounts.
@@ -19,18 +24,12 @@ import { useApiClient } from "@/lib/api/client";
  *
  * The backup key never signs during setup (it's the override key used at
  * app.safe.global), so ownership is confirmed by the user, not a signature.
- * A preview + explicit confirm guards against typos: the chosen address is
- * baked into the Safe's derivation and can't be casually swapped later.
+ * The resolved candidate is held for an explicit confirm step (typo guard:
+ * the chosen address is baked into the Safe's derivation and can't be
+ * casually swapped later) — the layout around it decides how that confirm
+ * looks (the stacked picker's button, or onboarding's primary CTA).
  */
-export function BackupAddressPicker({
-  onSelect,
-  compact = false,
-}: {
-  /** Called with the checksummed address once the user confirms it. */
-  onSelect: (address: string) => void;
-  /** Tighter spacing for inline embeds (e.g. the upgrade banner). */
-  compact?: boolean;
-}) {
+export function useBackupCandidate() {
   const { wallet } = useAuth();
   const api = useApiClient();
 
@@ -39,7 +38,7 @@ export function BackupAddressPicker({
   const [connecting, setConnecting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   /** Resolved-but-unconfirmed candidate shown in the preview row. */
-  const [candidate, setCandidate] = useState<{ address: string; label?: string } | null>(null);
+  const [candidate, setCandidate] = useState<BackupCandidate | null>(null);
 
   const agentAddress = process.env.NEXT_PUBLIC_AGENT_ADDRESS;
 
@@ -73,7 +72,23 @@ export function BackupAddressPicker({
     onError: () => setConnecting(false),
   });
 
-  const handleResolve = async () => {
+  const connect = () => {
+    setError(null);
+    setConnecting(true);
+    try {
+      connectWallet();
+    } catch {
+      setConnecting(false);
+    }
+  };
+
+  const updateInput = (value: string) => {
+    setInput(value);
+    setError(null);
+    setCandidate(null);
+  };
+
+  const resolveInput = async () => {
     const value = input.trim();
     if (!value) return;
     setError(null);
@@ -113,19 +128,45 @@ export function BackupAddressPicker({
     }
   };
 
+  const clearCandidate = () => setCandidate(null);
+  const clearError = () => setError(null);
+
+  return {
+    input,
+    updateInput,
+    resolving,
+    connecting,
+    error,
+    candidate,
+    connect,
+    resolveInput,
+    clearCandidate,
+    clearError,
+  };
+}
+
+/**
+ * Stacked backup-key picker (connect row + or-divider + address input) with
+ * its own confirm button — used by the upgrade dialog. Onboarding renders
+ * the segmented layout on the same useBackupCandidate logic.
+ */
+export function BackupAddressPicker({
+  onSelect,
+  compact = false,
+}: {
+  /** Called with the checksummed address once the user confirms it. */
+  onSelect: (address: string) => void;
+  /** Tighter spacing for inline embeds (e.g. the upgrade banner). */
+  compact?: boolean;
+}) {
+  const { input, updateInput, resolving, connecting, error, candidate, connect, resolveInput } =
+    useBackupCandidate();
+
   return (
     <div className={compact ? "space-y-2.5" : "space-y-3"}>
       {/* Option 1: connect (no signature) */}
       <button
-        onClick={() => {
-          setError(null);
-          setConnecting(true);
-          try {
-            connectWallet();
-          } catch {
-            setConnecting(false);
-          }
-        }}
+        onClick={connect}
         disabled={connecting}
         className="w-full flex items-center gap-3 rounded-xl px-4 py-3 border border-foreground/8 bg-foreground/4 hover:bg-foreground/6 hover:border-foreground/12 transition-all duration-200 disabled:opacity-60 disabled:cursor-default"
       >
@@ -154,13 +195,9 @@ export function BackupAddressPicker({
         <input
           type="text"
           value={input}
-          onChange={(e) => {
-            setInput(e.target.value);
-            setError(null);
-            setCandidate(null);
-          }}
+          onChange={(e) => updateInput(e.target.value)}
           onKeyDown={(e) => {
-            if (e.key === "Enter") handleResolve();
+            if (e.key === "Enter") resolveInput();
           }}
           placeholder="0x address, name.eth or name.bnb"
           spellCheck={false}
@@ -168,7 +205,7 @@ export function BackupAddressPicker({
           className="flex-1 min-w-0 bg-foreground/6 border border-border rounded-md px-3 py-2 text-sm font-mono text-foreground placeholder:font-sans placeholder:text-muted-foreground/50 focus:outline-none focus:border-gold/50"
         />
         <button
-          onClick={handleResolve}
+          onClick={resolveInput}
           disabled={resolving || !input.trim()}
           className="shrink-0 px-3.5 py-2 rounded-md border border-gold/30 text-gold text-xs font-semibold hover:bg-gold/10 transition-colors disabled:opacity-50 disabled:cursor-default"
         >

--- a/client/src/components/TransactionDetailDialog.tsx
+++ b/client/src/components/TransactionDetailDialog.tsx
@@ -457,9 +457,8 @@ export function TransactionDetailDialog({ tx: txProp, open, onClose }: Transacti
 
   // Whether this is a zhentan-tracked tx (has our metadata)
   const isZhentanTx = tx.source !== "zerion-only";
-  // Whether counterparty address is meaningful for this op — never for wallet
-  // events, whose "counterparty" is the Safe itself.
-  const showCounterparty = !tx.txKind && !!tx.to && op !== "execute" && op !== "approve";
+  // Whether counterparty address is meaningful for this op
+  const showCounterparty = !!tx.to && op !== "execute" && op !== "approve";
   const counterpartyLabel =
     op === "receive" ? "From" : op === "send" ? "To" : "Interacted with";
 
@@ -529,35 +528,6 @@ export function TransactionDetailDialog({ tx: txProp, open, onClose }: Transacti
             </div>
           )}
 
-          {/* Wallet events: the vault and its key setup, not transfer fields */}
-          {tx.txKind && (
-            <div className="flex justify-between gap-2 sm:gap-4">
-              <dt className="text-muted-foreground/80 shrink-0">Vault</dt>
-              <dd
-                className="min-w-0 max-w-[50%] sm:max-w-[200px] truncate"
-                title={tx.safeAddress}
-              >
-                <a
-                  href={`${BSC_EXPLORER_URL}/address/${tx.safeAddress}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="group inline-flex items-center gap-2 font-mono text-foreground hover:text-foreground transition-colors underline-offset-4 hover:underline truncate"
-                >
-                  <ExternalLink className="h-3.5 w-3.5 shrink-0 text-muted-foreground/80 group-hover:text-foreground" />
-                  <span className="truncate">{truncateAddress(tx.safeAddress, 10)}</span>
-                </a>
-              </dd>
-            </div>
-          )}
-          {tx.txKind && (tx.ownerAddresses?.length ?? 0) > 0 && (
-            <div className="flex justify-between gap-2 sm:gap-4">
-              <dt className="text-muted-foreground/80 shrink-0">Keys</dt>
-              <dd className="text-foreground/80">
-                {tx.ownerAddresses.length} owners · {tx.threshold} required
-              </dd>
-            </div>
-          )}
-
           {/* Trade: explicit swap pair */}
           {op === "trade" && tx.tradeReceived && tx.amount && tx.token && (
             <div className="flex justify-between gap-2 sm:gap-4">
@@ -597,18 +567,16 @@ export function TransactionDetailDialog({ tx: txProp, open, onClose }: Transacti
             </div>
           )}
 
-          {/* Proposed — zhentan txs only. Creation rows are synthesized from
-              the deploy receipt (proposed = executed), so one date suffices. */}
-          {isZhentanTx && tx.txKind !== "creation" && (
+          {/* Proposed — zhentan txs only */}
+          {isZhentanTx && (
             <div className="flex justify-between gap-2 sm:gap-4">
               <dt className="text-muted-foreground/80 shrink-0">Proposed</dt>
               <dd className="text-foreground/80 truncate min-w-0">{formatDate(tx.proposedAt)}</dd>
             </div>
           )}
 
-          {/* Signatures — zhentan txs only. Not for creation: the deployment
-              is sent by the agent EOA, no Safe signatures exist. */}
-          {isZhentanTx && tx.txKind !== "creation" && (
+          {/* Signatures — zhentan txs only */}
+          {isZhentanTx && (
             <div className="flex justify-between gap-2 sm:gap-4">
               <dt className="text-muted-foreground/80 shrink-0">Signatures</dt>
               <dd className="text-foreground/80">

--- a/client/src/components/TransactionDetailDialog.tsx
+++ b/client/src/components/TransactionDetailDialog.tsx
@@ -25,6 +25,12 @@ import {
   ChevronDown,
   ChevronUp,
   ShieldAlert,
+  ShieldOff,
+  Sparkles,
+  Settings2,
+  KeyRound,
+  RefreshCw,
+  Users,
   type LucideIcon,
 } from "lucide-react";
 import { BSC_EXPLORER_URL } from "@/lib/constants";
@@ -56,7 +62,46 @@ const FALLBACK_CONFIG: OpConfig = {
   Icon: ArrowUpRight, label: "Transaction", sign: "", iconColor: "text-muted-foreground",
 };
 
-function getConfig(tx: TransactionWithStatus): OpConfig {
+// ── Wallet events (txKind rows) — one icon + explainer per server label ──────
+// Labels are the server's hardcoded contract (server/src/lib/safe/txKind.ts +
+// the synthesized creation row); unknown labels fall back by kind.
+
+const KIND_ICONS: Record<string, LucideIcon> = {
+  "Safe account created": Sparkles,
+  "Protection activated": ShieldCheck,
+  "Screening agent enabled": ShieldCheck,
+  "Backup key added": KeyRound,
+  "Backup key changed": RefreshCw,
+  "Screening agent removed": ShieldOff,
+  "Owners changed": Users,
+  "Wallet configuration": Settings2,
+};
+
+const KIND_DESCRIPTIONS: Record<string, string> = {
+  "Safe account created": "Your vault was deployed on-chain at its permanent address",
+  "Protection activated": "Backup key and screening agent added as owners of your vault",
+  "Screening agent enabled": "The screening agent was added as an owner — screening is on",
+  "Backup key added": "A key you control was added as an owner — your override at app.safe.global",
+  "Backup key changed": "Your backup key was swapped for a new one at the same address",
+  "Screening agent removed": "The agent was removed as an owner — a stock Safe from here on",
+  "Owners changed": "The owner set of your vault changed",
+  "Wallet configuration": "A configuration call on your vault — no funds moved",
+};
+
+function kindConfig(tx: TransactionWithStatus): OpConfig & { description?: string } {
+  const label =
+    tx.kindLabel ?? (tx.txKind === "creation" ? "Safe account created" : "Wallet configuration");
+  return {
+    Icon: KIND_ICONS[label] ?? (tx.txKind === "creation" ? Sparkles : Settings2),
+    label,
+    sign: "",
+    iconColor: "text-gold",
+    description: KIND_DESCRIPTIONS[label],
+  };
+}
+
+function getConfig(tx: TransactionWithStatus): OpConfig & { description?: string } {
+  if (tx.txKind) return kindConfig(tx);
   const op = tx.operationType ?? (tx.direction === "receive" ? "receive" : "send");
   return OP_CONFIG[op] ?? FALLBACK_CONFIG;
 }
@@ -93,10 +138,36 @@ function TokenAvatar({ iconUrl, symbol, size = 40 }: { iconUrl?: string | null; 
 
 // ── Hero amount card ──────────────────────────────────────────────────────────
 
-function HeroAmount({ tx, config }: { tx: TransactionWithStatus; config: OpConfig }) {
+function HeroAmount({
+  tx,
+  config,
+}: {
+  tx: TransactionWithStatus;
+  config: OpConfig & { description?: string };
+}) {
   const { Icon, label, sign, iconColor } = config;
   const op = tx.operationType ?? (tx.direction === "receive" ? "receive" : "send");
   const usd = formatUsd(tx.valueUSD);
+
+  // Wallet event (creation / config): gold event tile + label + explainer —
+  // these rows move no funds, so no token avatar or amount.
+  if (tx.txKind) {
+    return (
+      <div className="rounded-2xl bg-foreground/6 p-4 flex items-center gap-3">
+        <div className="w-10 h-10 rounded-2xl bg-gold/10 flex items-center justify-center shrink-0 text-gold">
+          <Icon className="h-5 w-5" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-base font-semibold text-foreground">{label}</p>
+          {config.description && (
+            <p className="text-xs text-muted-foreground/80 mt-0.5 leading-relaxed">
+              {config.description}
+            </p>
+          )}
+        </div>
+      </div>
+    );
+  }
 
   // Trade: dual-token layout — [sent] → [received]
   if (op === "trade" && tx.tradeReceived) {
@@ -386,8 +457,9 @@ export function TransactionDetailDialog({ tx: txProp, open, onClose }: Transacti
 
   // Whether this is a zhentan-tracked tx (has our metadata)
   const isZhentanTx = tx.source !== "zerion-only";
-  // Whether counterparty address is meaningful for this op
-  const showCounterparty = !!tx.to && op !== "execute" && op !== "approve";
+  // Whether counterparty address is meaningful for this op — never for wallet
+  // events, whose "counterparty" is the Safe itself.
+  const showCounterparty = !tx.txKind && !!tx.to && op !== "execute" && op !== "approve";
   const counterpartyLabel =
     op === "receive" ? "From" : op === "send" ? "To" : "Interacted with";
 
@@ -457,6 +529,35 @@ export function TransactionDetailDialog({ tx: txProp, open, onClose }: Transacti
             </div>
           )}
 
+          {/* Wallet events: the vault and its key setup, not transfer fields */}
+          {tx.txKind && (
+            <div className="flex justify-between gap-2 sm:gap-4">
+              <dt className="text-muted-foreground/80 shrink-0">Vault</dt>
+              <dd
+                className="min-w-0 max-w-[50%] sm:max-w-[200px] truncate"
+                title={tx.safeAddress}
+              >
+                <a
+                  href={`${BSC_EXPLORER_URL}/address/${tx.safeAddress}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="group inline-flex items-center gap-2 font-mono text-foreground hover:text-foreground transition-colors underline-offset-4 hover:underline truncate"
+                >
+                  <ExternalLink className="h-3.5 w-3.5 shrink-0 text-muted-foreground/80 group-hover:text-foreground" />
+                  <span className="truncate">{truncateAddress(tx.safeAddress, 10)}</span>
+                </a>
+              </dd>
+            </div>
+          )}
+          {tx.txKind && (tx.ownerAddresses?.length ?? 0) > 0 && (
+            <div className="flex justify-between gap-2 sm:gap-4">
+              <dt className="text-muted-foreground/80 shrink-0">Keys</dt>
+              <dd className="text-foreground/80">
+                {tx.ownerAddresses.length} owners · {tx.threshold} required
+              </dd>
+            </div>
+          )}
+
           {/* Trade: explicit swap pair */}
           {op === "trade" && tx.tradeReceived && tx.amount && tx.token && (
             <div className="flex justify-between gap-2 sm:gap-4">
@@ -496,16 +597,18 @@ export function TransactionDetailDialog({ tx: txProp, open, onClose }: Transacti
             </div>
           )}
 
-          {/* Proposed — zhentan txs only */}
-          {isZhentanTx && (
+          {/* Proposed — zhentan txs only. Creation rows are synthesized from
+              the deploy receipt (proposed = executed), so one date suffices. */}
+          {isZhentanTx && tx.txKind !== "creation" && (
             <div className="flex justify-between gap-2 sm:gap-4">
               <dt className="text-muted-foreground/80 shrink-0">Proposed</dt>
               <dd className="text-foreground/80 truncate min-w-0">{formatDate(tx.proposedAt)}</dd>
             </div>
           )}
 
-          {/* Signatures — zhentan txs only */}
-          {isZhentanTx && (
+          {/* Signatures — zhentan txs only. Not for creation: the deployment
+              is sent by the agent EOA, no Safe signatures exist. */}
+          {isZhentanTx && tx.txKind !== "creation" && (
             <div className="flex justify-between gap-2 sm:gap-4">
               <dt className="text-muted-foreground/80 shrink-0">Signatures</dt>
               <dd className="text-foreground/80">

--- a/client/src/components/UpgradeBanner.tsx
+++ b/client/src/components/UpgradeBanner.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
-import { AlertTriangle, ShieldCheck } from "lucide-react";
+import { AlertTriangle, KeyRound, ShieldCheck } from "lucide-react";
 
 import { useSafeTransitions } from "@/lib/useSafeUpgrade";
 import { UpgradeDialog } from "@/components/UpgradeDialog";
@@ -13,8 +13,17 @@ import { UpgradeDialog } from "@/components/UpgradeDialog";
  *   guarded → prominent amber WARNING — the agent is on but there's no backup
  *             key, so the user can't reach the threshold alone (lockout risk).
  * Renders nothing for protected/detached wallets.
+ *
+ * Variants: "banner" is the standalone card (home page); "row" renders as a
+ * divider-topped row inside the settings Protection card.
  */
-export function UpgradeBanner({ className }: { className?: string }) {
+export function UpgradeBanner({
+  className,
+  variant = "banner",
+}: {
+  className?: string;
+  variant?: "banner" | "row";
+}) {
   const { profile } = useSafeTransitions();
   const [open, setOpen] = useState(false);
 
@@ -37,7 +46,47 @@ export function UpgradeBanner({ className }: { className?: string }) {
             exit={{ opacity: 0, height: 0 }}
             className={className}
           >
-            {isGuarded ? (
+            {variant === "row" ? (
+              /* ── Settings Protection-card row ── */
+              isGuarded ? (
+                <div className="flex items-center gap-3.5 p-[18px] border-t border-border bg-watch/5">
+                  <div className="w-9 h-9 rounded-xl bg-watch/10 flex items-center justify-center shrink-0">
+                    <KeyRound className="h-[17px] w-[17px] text-watch" />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-semibold text-foreground">Add a backup key</p>
+                    <p className="text-xs text-muted-foreground/85 mt-1 leading-relaxed">
+                      Zhentan must approve every transaction. If the agent goes
+                      offline, your funds wait until you add a key you control.
+                    </p>
+                  </div>
+                  <button
+                    onClick={() => setOpen(true)}
+                    className="shrink-0 px-3.5 py-2 rounded-xl bg-gold text-ink-900 text-xs font-semibold hover:bg-gold/90 transition-colors cursor-pointer"
+                  >
+                    Add key
+                  </button>
+                </div>
+              ) : (
+                <div className="flex items-center gap-3.5 p-[18px] border-t border-border">
+                  <div className="w-9 h-9 rounded-xl bg-gold/10 flex items-center justify-center shrink-0">
+                    <ShieldCheck className="h-[17px] w-[17px] text-gold" />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-semibold text-foreground">Activate Zhentan protection</p>
+                    <p className="text-xs text-muted-foreground/85 mt-1 leading-relaxed">
+                      Add AI screening — and a backup key you control.
+                    </p>
+                  </div>
+                  <button
+                    onClick={() => setOpen(true)}
+                    className="shrink-0 px-3.5 py-2 rounded-xl bg-gold text-ink-900 text-xs font-semibold hover:bg-gold/90 transition-colors cursor-pointer"
+                  >
+                    Activate
+                  </button>
+                </div>
+              )
+            ) : isGuarded ? (
               /* ── Prominent lockout warning: agent on, no backup key ── */
               <div className="rounded-xl border border-watch/30 bg-watch/[0.08] overflow-hidden">
                 <div className="flex items-center gap-3 px-4 py-3.5">

--- a/client/src/components/tour/TourLauncher.tsx
+++ b/client/src/components/tour/TourLauncher.tsx
@@ -1,70 +1,69 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useState } from "react";
 import { usePathname } from "next/navigation";
 
 import { useAuth } from "@/app/context/AuthContext";
 import { useTour } from "./TourProvider";
-import { hasSeenTour, mainTour, upgradeTour } from "@/lib/tours";
+import {
+  TOUR_QUEUED_EVENT,
+  clearPendingTour,
+  hasSeenTour,
+  mainTour,
+  readPendingTour,
+  upgradeTour,
+} from "@/lib/tours";
 
 /**
- * Auto-fires the guided tours, once per Safe per device:
- *
- * - First-time (v2 accounts): on the first landing on /home after onboarding
- *   completes — requests → agent → settings.
- * - Legacy upgraded (v1 accounts that became protected): the settings-only
- *   walkthrough, fired right after the upgrade's owner mirror flips the
- *   profile. It waits for any open dialog (the upgrade wizard's success
- *   screen) to close before starting.
+ * Fires QUEUED guided tours. The flow where a milestone happens queues its
+ * tour via queueTour() — onboarding finish → "main", a transition that adds
+ * the backup key → "upgrade" — and this launcher only consumes the marker.
+ * It never infers "new user" from account state, so a new device or cleared
+ * storage doesn't replay a tour; the per-Safe seen-flags act as suppressors
+ * and Settings → Product tour is the on-demand replay.
  */
 export function TourLauncher() {
-  const { safeAddress, safeConfig, recordOnboardingCompleted } = useAuth();
+  const { safeAddress } = useAuth();
   const { start, active } = useTour();
   const pathname = usePathname();
-  const firedRef = useRef(false);
+  // Bumped when a flow queues a tour mid-session, so the effect re-checks.
+  const [queueTick, setQueueTick] = useState(0);
 
   useEffect(() => {
-    if (active || firedRef.current || !safeAddress || !safeConfig) return;
+    const onQueued = () => setQueueTick((t) => t + 1);
+    window.addEventListener(TOUR_QUEUED_EVENT, onQueued);
+    return () => window.removeEventListener(TOUR_QUEUED_EVENT, onQueued);
+  }, []);
 
-    const isLegacy = (safeConfig.derivationVersion ?? 1) === 1;
+  useEffect(() => {
+    if (active || !safeAddress) return;
+    const pending = readPendingTour();
+    if (!pending) return;
+    // The main tour starts on /home, where its anchors live — hold the
+    // marker until the user lands there.
+    if (pending === "main" && pathname !== "/home") return;
+    if (hasSeenTour(pending, safeAddress)) {
+      clearPendingTour();
+      return;
+    }
+
     let timer: ReturnType<typeof setTimeout> | undefined;
     let attempts = 0;
 
-    // Delay past the page's entry animations; retry while a dialog is open.
-    const schedule = (fire: () => void) => {
-      const tick = () => {
-        if (firedRef.current) return;
-        if (document.querySelector('[role="dialog"]') && attempts++ < 20) {
-          timer = setTimeout(tick, 1500);
-          return;
-        }
-        firedRef.current = true;
-        fire();
-      };
-      timer = setTimeout(tick, 900);
-    };
-
-    // The record flag lags right after onboarding (the completion POST beats
-    // the record refetch to /home) — the cookie is stamped synchronously at
-    // finish, so first-time users get the tour on arrival, not after reload.
-    const onboardingComplete =
-      recordOnboardingCompleted === true ||
-      document.cookie.includes("onboarding_complete=1");
-
-    if (isLegacy) {
-      if (safeConfig.profile === "protected" && !hasSeenTour("upgrade", safeAddress)) {
-        schedule(() => start(upgradeTour(safeAddress)));
+    // Delay past the page's entry animations; retry while a dialog is open
+    // (e.g. the upgrade wizard's success screen).
+    const tick = () => {
+      if (document.querySelector('[role="dialog"]') && attempts++ < 20) {
+        timer = setTimeout(tick, 1500);
+        return;
       }
-    } else if (
-      onboardingComplete &&
-      pathname === "/home" &&
-      !hasSeenTour("main", safeAddress)
-    ) {
-      schedule(() => start(mainTour(safeAddress)));
-    }
+      clearPendingTour();
+      start(pending === "main" ? mainTour(safeAddress) : upgradeTour(safeAddress));
+    };
+    timer = setTimeout(tick, 900);
 
     return () => clearTimeout(timer);
-  }, [active, safeAddress, safeConfig, recordOnboardingCompleted, pathname, start]);
+  }, [active, safeAddress, pathname, start, queueTick]);
 
   return null;
 }

--- a/client/src/lib/constants.ts
+++ b/client/src/lib/constants.ts
@@ -44,6 +44,17 @@ export const SAFE_ABI = [
     outputs: [],
   },
   {
+    name: "swapOwner",
+    type: "function" as const,
+    stateMutability: "nonpayable" as const,
+    inputs: [
+      { name: "prevOwner", type: "address" as const },
+      { name: "oldOwner", type: "address" as const },
+      { name: "newOwner", type: "address" as const },
+    ],
+    outputs: [],
+  },
+  {
     name: "getOwners",
     type: "function" as const,
     stateMutability: "view" as const,

--- a/client/src/lib/safe/transitions.ts
+++ b/client/src/lib/safe/transitions.ts
@@ -16,6 +16,7 @@ import type { SafeProposalContext } from "@/types";
  *   starter → protected   MultiSend[addOwner(backup, 1), addOwner(agent, 2)]
  *   guarded → protected   addOwnerWithThreshold(backup, 2)
  *   protected → detached  removeOwner(prevOwner, agent, 2)
+ *   backup key swap       swapOwner(prevOwner, oldBackup, newBackup)
  *
  * From starter (threshold 1) the user's own signature authorizes the
  * transition and the agent merely relays; at threshold 2 the agent co-signs.
@@ -80,6 +81,33 @@ export function detachAgentCalls(
         abi: SAFE_ABI,
         functionName: "removeOwner",
         args: [prevOwner, agent, 2n],
+      }),
+    },
+  ];
+}
+
+/**
+ * Backup-key swap (profile stays protected): replace the old backup owner
+ * with a new one. Linked-list op like detach — `owners` must be the LIVE
+ * on-chain order.
+ */
+export function swapBackupCalls(
+  safeAddress: Address,
+  owners: string[],
+  oldBackup: Address,
+  newBackup: Address
+): SafeCall[] {
+  const idx = owners.findIndex((o) => o.toLowerCase() === oldBackup.toLowerCase());
+  if (idx === -1) throw new Error("Current backup key is not an owner of this Safe");
+  const prevOwner = (idx === 0 ? SENTINEL_OWNER : owners[idx - 1]) as Address;
+  return [
+    {
+      to: safeAddress,
+      value: 0n,
+      data: encodeFunctionData({
+        abi: SAFE_ABI,
+        functionName: "swapOwner",
+        args: [prevOwner, oldBackup, newBackup],
       }),
     },
   ];

--- a/client/src/lib/tours.ts
+++ b/client/src/lib/tours.ts
@@ -32,6 +32,46 @@ export interface TourDefinition {
   onClose?: () => void;
 }
 
+// ── Pending-tour marker (session-scoped) ────────────────────────────────────
+// Tours are QUEUED by the flow where their milestone happens (onboarding
+// finish → "main"; a transition that adds the backup key → "upgrade") and
+// consumed by TourLauncher. sessionStorage survives the onboarding → /home
+// layout remount but dies with the tab — so a new device or cleared storage
+// never replays a tour from account state alone; Settings → Product tour is
+// the on-demand path.
+
+export type TourKey = "main" | "upgrade";
+
+const PENDING_KEY = "zhentan_tour_pending";
+/** Fired by queueTour so an already-mounted TourLauncher re-checks the marker. */
+export const TOUR_QUEUED_EVENT = "zhentan:tour-queued";
+
+export function queueTour(key: TourKey) {
+  try {
+    sessionStorage.setItem(PENDING_KEY, key);
+    window.dispatchEvent(new Event(TOUR_QUEUED_EVENT));
+  } catch {
+    // no storage → no auto-fire; the Settings replay still works
+  }
+}
+
+export function readPendingTour(): TourKey | null {
+  try {
+    const v = sessionStorage.getItem(PENDING_KEY);
+    return v === "main" || v === "upgrade" ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+export function clearPendingTour() {
+  try {
+    sessionStorage.removeItem(PENDING_KEY);
+  } catch {
+    // best-effort
+  }
+}
+
 // ── Seen-flags (device-local, deliberately NOT wiped on logout — replaying
 // the tour on every re-login would read as a bug; flags are per-Safe). ──────
 

--- a/client/src/lib/useSafeUpgrade.ts
+++ b/client/src/lib/useSafeUpgrade.ts
@@ -13,6 +13,7 @@ import {
   proposeTransition,
 } from "@/lib/safe/transitions";
 import type { WalletState } from "@/lib/safe/profiles";
+import { queueTour } from "@/lib/tours";
 
 export interface SafeTransitionsState {
   /** Current wallet state (starter/guarded/protected/detached/unknown). */
@@ -111,6 +112,9 @@ export function useSafeTransitions(): SafeTransitionsState {
         ),
       { registerBackup: true }
     );
+    // Wallet just became protected — queue the settings walkthrough
+    // (TourLauncher waits for the wizard's success dialog to close).
+    queueTour("upgrade");
   }, [run, safeAddress, externalWalletAddress, agentAddress]);
 
   const enableAgentOnly = useCallback(async () => {
@@ -130,6 +134,9 @@ export function useSafeTransitions(): SafeTransitionsState {
       () => addBackupCalls(safeAddress as Address, externalWalletAddress as Address),
       { registerBackup: true }
     );
+    // Wallet just became protected — queue the settings walkthrough
+    // (this is the legacy upgrade path as well as the v2 add-backup).
+    queueTour("upgrade");
   }, [run, safeAddress, externalWalletAddress]);
 
   const detach = useCallback(async () => {

--- a/client/src/lib/useSafeUpgrade.ts
+++ b/client/src/lib/useSafeUpgrade.ts
@@ -10,6 +10,7 @@ import {
   enableAgentCalls,
   addBackupCalls,
   detachAgentCalls,
+  swapBackupCalls,
   proposeTransition,
 } from "@/lib/safe/transitions";
 import type { WalletState } from "@/lib/safe/profiles";
@@ -30,6 +31,8 @@ export interface SafeTransitionsState {
   enableAgentOnly: () => Promise<void>;
   /** guarded → protected (add backup key; the legacy upgrade). */
   addBackup: () => Promise<void>;
+  /** Replace the backup key with a new one (profile stays protected). */
+  swapBackup: (newBackup: string) => Promise<void>;
   /** protected → detached (remove the agent — the exit). */
   detach: () => Promise<void>;
 }
@@ -47,6 +50,7 @@ export function useSafeTransitions(): SafeTransitionsState {
     getOwnerAccount,
     identityToken,
     refreshSafe,
+    wallet,
   } = useAuth();
   const api = useApiClient();
 
@@ -139,6 +143,46 @@ export function useSafeTransitions(): SafeTransitionsState {
     queueTour("upgrade");
   }, [run, safeAddress, externalWalletAddress]);
 
+  const swapBackup = useCallback(
+    async (newBackup: string) => {
+      if (!safeAddress || !safeConfig || !agentAddress) return;
+      const agent = agentAddress.toLowerCase();
+      const signer = wallet?.address?.toLowerCase() ?? "";
+      // The backup slot is the user owner that is neither agent nor signer.
+      const oldBackup = safeConfig.owners.find(
+        (o) => o.toLowerCase() !== agent && o.toLowerCase() !== signer
+      );
+      if (!oldBackup) {
+        setError("This wallet has no backup key to swap");
+        throw new Error("This wallet has no backup key to swap");
+      }
+      if (oldBackup.toLowerCase() === newBackup.toLowerCase()) {
+        setError("That's already your backup key");
+        throw new Error("That's already your backup key");
+      }
+      // Register the NEW key first — the server validates swap calldata
+      // against the registered backup. Best-effort restore on failure so the
+      // record can't drift from the on-chain owner set.
+      await api.users.upsert({ safeAddress, externalWalletAddress: newBackup });
+      try {
+        await run("Change backup key", () =>
+          swapBackupCalls(
+            safeAddress as Address,
+            safeConfig.owners,
+            oldBackup as Address,
+            newBackup as Address
+          )
+        );
+      } catch (err) {
+        await api.users
+          .upsert({ safeAddress, externalWalletAddress: oldBackup })
+          .catch(() => {});
+        throw err;
+      }
+    },
+    [run, safeAddress, safeConfig, agentAddress, wallet?.address, api]
+  );
+
   const detach = useCallback(async () => {
     if (!agentAddress || !safeAddress || !safeConfig) return;
     await run("Detach Zhentan", () =>
@@ -155,6 +199,7 @@ export function useSafeTransitions(): SafeTransitionsState {
     activateProtection,
     enableAgentOnly,
     addBackup,
+    swapBackup,
     detach,
   };
 }

--- a/server/src/lib/constants.ts
+++ b/server/src/lib/constants.ts
@@ -37,6 +37,17 @@ export const SAFE_ABI = [
     outputs: [],
   },
   {
+    name: "swapOwner",
+    type: "function" as const,
+    stateMutability: "nonpayable" as const,
+    inputs: [
+      { name: "prevOwner", type: "address" as const },
+      { name: "oldOwner", type: "address" as const },
+      { name: "newOwner", type: "address" as const },
+    ],
+    outputs: [],
+  },
+  {
     name: "getOwners",
     type: "function" as const,
     stateMutability: "view" as const,

--- a/server/src/lib/safe/txKind.ts
+++ b/server/src/lib/safe/txKind.ts
@@ -75,8 +75,9 @@ export function classifyTxKind(
     const removed = calls
       .filter((c) => c.functionName === "removeOwner")
       .map((c) => String(c.args[1]).toLowerCase());
+    const swapped = calls.some((c) => c.functionName === "swapOwner");
 
-    if (added.length || removed.length) {
+    if (added.length || removed.length || swapped) {
       const addsAgent = agent !== "" && added.includes(agent);
       const addsBackup = added.some((a) => a !== agent);
       let kindLabel: string;
@@ -84,6 +85,9 @@ export function classifyTxKind(
       else if (addsAgent) kindLabel = "Screening agent enabled";
       else if (addsBackup) kindLabel = "Backup key added";
       else if (agent !== "" && removed.includes(agent)) kindLabel = "Screening agent removed";
+      // Validation only permits swapping the backup slot, so a swap IS a
+      // backup-key change.
+      else if (swapped) kindLabel = "Backup key changed";
       else kindLabel = "Owners changed";
       return { txKind: "config", kindLabel };
     }

--- a/server/src/lib/supabase/db.ts
+++ b/server/src/lib/supabase/db.ts
@@ -1245,10 +1245,18 @@ export async function getUserDetails(safeAddress: string): Promise<UserDetailsRo
 }
 
 export async function getUserBySignerAddress(signerAddress: string): Promise<UserDetailsRow | null> {
+  // Deterministic pick if a signer ever maps to multiple rows (e.g. an
+  // orphaned row from an interrupted onboarding): prefer the completed
+  // account, then the newest. `.maybeSingle()` without the limit ERRORS on
+  // multiple matches — and a swallowed error here reads as "no record",
+  // bouncing a returning user into onboarding.
   const { data } = await supabase
     .from("user_details")
     .select("*")
     .ilike("signer_address", signerAddress)
+    .order("onboarding_completed", { ascending: false, nullsFirst: false })
+    .order("created_at", { ascending: false })
+    .limit(1)
     .maybeSingle();
   return data ?? null;
 }

--- a/server/src/routes/queue.ts
+++ b/server/src/routes/queue.ts
@@ -159,14 +159,16 @@ async function validateSafeTxProposal(pendingTx: PendingTransaction): Promise<vo
  *   starter → protected   MultiSend[addOwner(backup, 1), addOwner(agent, 2)]
  *   guarded → protected   addOwnerWithThreshold(backup, 2)   (legacy upgrade)
  *   protected → detached  removeOwner(prev, agent, 2)        (exit)
+ *   backup key swap       swapOwner(prev, oldBackup, newBackup)
  *
  * Every added owner must be the agent or the REGISTERED backup key; the
  * simulated end state must classify to a managed profile (or detached, for
- * the exit) different from the current one.
+ * the exit). The profile must change — except for a backup-key swap, which
+ * legitimately keeps the wallet protected while replacing an owner.
  */
 async function validateTransitionTx(
   pendingTx: PendingTransaction & { calldata?: string }
-): Promise<{ endState: WalletState; endThreshold: number }> {
+): Promise<{ endState: WalletState; endThreshold: number; endOwners: string[] }> {
   const { safeAddress } = pendingTx;
   // For SafeTx proposals, validate the SIGNED payload (its hash was already
   // recomputed and signature-verified) — not the loose display fields.
@@ -207,6 +209,7 @@ async function validateTransitionTx(
   // Simulate the end state call by call.
   const owners = currentOwners.map((o) => o.toLowerCase());
   let threshold = currentThreshold;
+  let swapped = false;
 
   for (const call of innerCalls) {
     if (!isAddressEqual(call.to as Address, safeAddress as Address)) {
@@ -238,6 +241,29 @@ async function validateTransitionTx(
       if (idx === -1) throw new Error("Agent is not an owner of this Safe");
       owners.splice(idx, 1);
       threshold = Number(t);
+    } else if (decoded.functionName === "swapOwner") {
+      const [, oldOwner, newOwner] = decoded.args as readonly [Address, Address, Address];
+      const oldAddr = oldOwner.toLowerCase();
+      const newAddr = newOwner.toLowerCase();
+      // Only the backup slot may be swapped — never the agent, never the
+      // account signer.
+      if (oldAddr === agent.toLowerCase()) {
+        throw new Error("Transition may not swap out the agent");
+      }
+      if (record.signer_address && oldAddr === record.signer_address.toLowerCase()) {
+        throw new Error("Transition may not swap out the account signer");
+      }
+      const isRegisteredBackup =
+        !!record.external_wallet_address &&
+        newAddr === record.external_wallet_address.toLowerCase();
+      if (!isRegisteredBackup || newAddr === agent.toLowerCase()) {
+        throw new Error("Swap may only install the registered backup key as owner");
+      }
+      const idx = owners.indexOf(oldAddr);
+      if (idx === -1) throw new Error(`${oldOwner} is not an owner of this Safe`);
+      if (owners.includes(newAddr)) throw new Error(`${newOwner} is already an owner`);
+      owners[idx] = newAddr;
+      swapped = true;
     } else {
       throw new Error(`Unsupported transition call: ${decoded.functionName}`);
     }
@@ -247,13 +273,13 @@ async function validateTransitionTx(
   if (endState !== "starter" && endState !== "guarded" && endState !== "protected" && endState !== "detached") {
     throw new Error(`Transition ends in an unmanaged state (${endState})`);
   }
-  if (endState === currentState) {
+  if (endState === currentState && !swapped) {
     throw new Error("Transition does not change the wallet profile");
   }
   // The simulated end state IS the post-execution truth (the tx is validated
   // hard and executed atomically) — return it so finishTransition can persist
-  // a deterministic threshold instead of racing an RPC read.
-  return { endState, endThreshold: threshold };
+  // a deterministic threshold and owner set instead of racing an RPC read.
+  return { endState, endThreshold: threshold, endOwners: owners };
 }
 
 /**
@@ -269,15 +295,16 @@ async function validateTransitionTx(
  */
 async function finishTransition(
   safeAddress: string,
-  target: { endState: WalletState; endThreshold: number }
+  target: { endState: WalletState; endThreshold: number; endOwners: string[] }
 ): Promise<void> {
-  const agent = getAgentAddress();
+  // Match the SIMULATED owner set, not just the classification — a swap keeps
+  // the profile identical before and after, so classification alone can't
+  // tell a lagging replica from the executed swap.
+  const want = new Set(target.endOwners.map((o) => o.toLowerCase()));
+  const matches = (list: string[]) =>
+    list.length === want.size && list.every((o) => want.has(o.toLowerCase()));
   let owners = await readSafeOwners(safeAddress);
-  for (
-    let i = 0;
-    i < 6 && classifyProfile(owners, target.endThreshold, agent) !== target.endState;
-    i++
-  ) {
+  for (let i = 0; i < 6 && !matches(owners); i++) {
     await new Promise((r) => setTimeout(r, 1200));
     owners = await readSafeOwners(safeAddress);
   }
@@ -307,7 +334,9 @@ export function createQueueRouter(): IRouter {
       const isUpgrade = pendingTx.upgrade === true || pendingTx.transition === true;
       // The transition's simulated end state (owners+threshold), captured at
       // validation and reused to persist a deterministic post-execution profile.
-      let transitionTarget: { endState: WalletState; endThreshold: number } | undefined;
+      let transitionTarget:
+        | { endState: WalletState; endThreshold: number; endOwners: string[] }
+        | undefined;
 
       if (isSafeTx) {
         try {


### PR DESCRIPTION
Closes #64

Implements the updated claude.ai/design mocks (`Zhentan App.dc.html` settings screen, `Zhentan Onboarding.dc.html`) in three commits, one per concern.

## 1. Grouped settings page (`7155a32`)

- `settings/page.tsx`: every section is now an eyebrow + hairline header over a single `bg-card` rounded-2xl card of uniform rows (36px icon tile · title/description · action · dividers), via small local `SectionHeader`/`SettingsRow` helpers. Section order per design: **Protection → Wallet → Advanced → App → Upgrade → Danger zone**.
- Protection card: Guard toggle row (logic untouched) + flattened Telegram/activation row (whole row still opens the ActivationDialog) + the backup-key nudge as an amber row.
- Wallet card gains a static **Network** row; App becomes a card (explorer + product tour); Danger zone gets the red-bordered card with icon tile.
- `UpgradeBanner` gains `variant="row"` for the Protection card; the home page banner is unchanged. All gating, hooks, and `data-tour` anchors preserved. Scroll container matches the requests page (`scrollbar-hide`), full width like other pages.

## 2. Milestone-triggered tours (`e696620`)

Follow-up to #62 — tours no longer auto-fire from inferred account state (which replayed them on every new device / storage wipe):

- `tours.ts`: session-scoped `zhentan_tour_pending` marker (`queueTour`/`readPendingTour`/`clearPendingTour`) + a window event so a mounted launcher notices mid-session queues.
- `TourLauncher` is a pure consumer: holds the main tour until `/home`, skips-and-clears if already seen, keeps the dialog-wait retry. No more cookie sniffing, record-flag races, or `derivationVersion ?? 1` legacy inference. The one-shot latch is gone, so one session can fire both milestones' tours.
- Queue points: onboarding finish → `"main"`; `activateProtection`/`addBackup` transitions → `"upgrade"` (`enableAgentOnly` deliberately not — the upgrade tour copy assumes three keys).
- Per-Safe seen-flags remain as suppressors; Settings → Replay unchanged.

## 3. Redesigned onboarding (`ebca03a`)

- New card shell (436px, rounded-26, dash progress header — protect + override key share step 1), selectable protection choice cards, override-key screen with **Connect a wallet / Enter an address** segmented control, candidate preview, and the "Your vault is ready" summary screen driven by real state (`safeConfig.profile`, `externalWalletAddress`, `telegramUserId`).
- `BackupAddressPicker`: resolve/validate logic extracted into an exported `useBackupCandidate` hook, shared by onboarding's segmented layout and the upgrade dialog's unchanged stacked picker.
- Logic adaptations (design → reality):
  - Guarded consent checkbox → skip-warning panel; accepting it is the lockout acknowledgment.
  - "Use this key & create my vault" merges confirm+continue with a readiness gate — auto-advances when the protected derivation lands.
  - Telegram Continue always enabled (linking optional).
  - A pre-existing backup key on the override screen now classifies the wallet protected instead of stranding the continue gate.
- `commitSafe()` timing, step restore, username availability checks, Telegram upserts, and `handleFinish` (including #63's deploy → `refreshSafe()` heal, reconciled during rebase) all preserved.

## Testing

- `tsc --noEmit` clean after rebase onto current main.
- Suggested manual pass: fresh signup through each protection path (guarded+key / guarded skip / starter), confirming the readiness gates and the main tour firing once on `/home`; a guarded→protected upgrade firing the settings tour; settings page visual pass on desktop + mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)