### PR TITLE
perf: stop Safe Transaction Service polling from burning the API rate limit

### DIFF
--- a/client/src/lib/pollExecution.ts
+++ b/client/src/lib/pollExecution.ts
@@ -7,10 +7,16 @@ import type { TransactionWithStatus } from "@/types";
  * Polls the backend until the agent resolves a screened proposal —
  * returns the tx hash on execution, throws on rejection or timeout.
  * Shared by the WalletConnect and Swap flows (screening-on path).
+ *
+ * Polls the SINGLE-tx endpoint, not the list: the list read reconciles every
+ * unresolved row against the Safe Transaction Service, so a 3s list poll
+ * multiplies into rate-limit-burning service calls. The single read is a
+ * plain DB fetch; external (Safe-app) executions still fold in via the
+ * safeSync worker within its 60s sweep.
  */
 export async function pollForExecution(
   txId: string,
-  safeAddress: string,
+  _safeAddress: string,
   identityToken: string | null
 ): Promise<string> {
   const maxAttempts = 60; // ~3 minutes at 3s intervals
@@ -19,13 +25,10 @@ export async function pollForExecution(
   for (let i = 0; i < maxAttempts; i++) {
     await new Promise((r) => setTimeout(r, interval));
     try {
-      const res = await apiFetch(
-        `/transactions?safeAddress=${encodeURIComponent(safeAddress)}`,
-        identityToken
-      );
+      const res = await apiFetch(`/transactions/${encodeURIComponent(txId)}`, identityToken);
       if (!res.ok) continue;
-      const data = await res.json();
-      const tx = (data.transactions as TransactionWithStatus[])?.find((t) => t.id === txId);
+      const data = (await res.json()) as { transaction?: TransactionWithStatus };
+      const tx = data.transaction;
       if (tx?.txHash) return tx.txHash;
       if (tx?.rejected) throw new Error(tx.rejectReason || "Transaction rejected by agent");
     } catch (err) {

--- a/server/src/lib/safe/reconcile.ts
+++ b/server/src/lib/safe/reconcile.ts
@@ -41,6 +41,27 @@ function isOwnSupersede(tx: { rejected?: boolean; rejectReason?: string }): bool
   return !!tx.rejected && !!tx.rejectReason?.startsWith("Superseded:");
 }
 
+// Per-row cooldown on the Transaction Service lookup. Reconcile runs from
+// every GET /transactions list read AND the safeSync worker — without this,
+// N open tabs polling at 8s multiply into N×rows service calls a minute,
+// which is what exhausts the Safe API rate limit. Outcomes only change
+// on-chain, so one service check per row per window is plenty; within the
+// window we report `unresolved` and the row simply renders as-is.
+const SERVICE_CHECK_COOLDOWN_MS = 30_000;
+const lastServiceCheck = new Map<string, number>();
+
+function underCooldown(txId: string): boolean {
+  const last = lastServiceCheck.get(txId) ?? 0;
+  if (Date.now() - last < SERVICE_CHECK_COOLDOWN_MS) return true;
+  lastServiceCheck.set(txId, Date.now());
+  return false;
+}
+
+/** Forget resolved rows so the cooldown map only tracks live ones. */
+function clearCooldown(txId: string): void {
+  lastServiceCheck.delete(txId);
+}
+
 /**
  * Reconciles a single SafeTx proposal against service / on-chain truth.
  *
@@ -59,6 +80,7 @@ export async function reconcileSafeTx(
   // concurrent reconcile is never double-written or double-notified.
   const fresh = await getTransaction(tx.id);
   if (fresh?.executedAt) {
+    clearCooldown(tx.id);
     return {
       status: "executed",
       txHash: fresh.txHash ?? "",
@@ -68,9 +90,16 @@ export async function reconcileSafeTx(
   }
   // A user-initiated rejection is final. Our own "Superseded:" marking falls
   // through to be re-verified below (and healed if it actually executed).
-  if (fresh?.rejected && !isOwnSupersede(fresh)) return { status: "superseded" };
+  if (fresh?.rejected && !isOwnSupersede(fresh)) {
+    clearCooldown(tx.id);
+    return { status: "superseded" };
+  }
 
   if (tx.safeNonce === undefined) return { status: "unresolved" };
+
+  // Checked against the service recently — nothing can have changed that the
+  // DB reads above wouldn't already reflect. Skip the service round-trip.
+  if (underCooldown(tx.id)) return { status: "unresolved" };
 
   // Authoritative: which safeTxHash did the service index as EXECUTED at OUR
   // nonce? We read by nonce and compare hashes rather than inferring from a
@@ -93,6 +122,7 @@ export async function reconcileSafeTx(
       // Actual executor — the user's backup key for a Safe-UI override.
       const executedBy = winner.executor ?? tx.proposedBy;
       await finishExecution(tx, winner.transactionHash, success, executedBy);
+      clearCooldown(tx.id);
       return { status: "executed", txHash: winner.transactionHash, success, executedBy };
     }
     // A DIFFERENT hash occupied our nonce → genuinely superseded (a rejection,
@@ -109,6 +139,7 @@ export async function reconcileSafeTx(
       rejectedAt: new Date().toISOString(),
       rejectReason: SUPERSEDE_REASON,
     }).catch((err) => console.error("syncLinkedRequest (superseded) failed:", err));
+    clearCooldown(tx.id);
     return { status: "superseded" };
   }
 

--- a/server/src/lib/safe/reconcile.ts
+++ b/server/src/lib/safe/reconcile.ts
@@ -41,6 +41,17 @@ function isOwnSupersede(tx: { rejected?: boolean; rejectReason?: string }): bool
   return !!tx.rejected && !!tx.rejectReason?.startsWith("Superseded:");
 }
 
+// A supersede verdict can only be premature while the service indexer lags —
+// a window of seconds. Re-verify for an hour after the marking, then treat it
+// as final: without the bound, every dead "Superseded:" row is re-checked
+// against the service on every list read, forever.
+const SUPERSEDE_REVERIFY_WINDOW_MS = 60 * 60 * 1000;
+
+function supersedeIsFinal(tx: { rejectedAt?: string }): boolean {
+  const markedAt = new Date(tx.rejectedAt ?? NaN).getTime();
+  return !(Date.now() - markedAt < SUPERSEDE_REVERIFY_WINDOW_MS);
+}
+
 // Per-row cooldown on the Transaction Service lookup. Reconcile runs from
 // every GET /transactions list read AND the safeSync worker — without this,
 // N open tabs polling at 8s multiply into N×rows service calls a minute,
@@ -89,8 +100,9 @@ export async function reconcileSafeTx(
     };
   }
   // A user-initiated rejection is final. Our own "Superseded:" marking falls
-  // through to be re-verified below (and healed if it actually executed).
-  if (fresh?.rejected && !isOwnSupersede(fresh)) {
+  // through to be re-verified below (and healed if it actually executed) —
+  // but only within the re-verify window; after that it's final too.
+  if (fresh?.rejected && (!isOwnSupersede(fresh) || supersedeIsFinal(fresh))) {
     clearCooldown(tx.id);
     return { status: "superseded" };
   }

--- a/server/src/workers/safeSync.ts
+++ b/server/src/workers/safeSync.ts
@@ -14,6 +14,15 @@ import { reconcileSafeTx } from "../lib/safe/reconcile.js";
 
 const SYNC_INTERVAL_MS = 60_000;
 
+// Age-based backoff: a row unresolved for over a day (an abandoned queued
+// tx, a wallet whose agent never ran) is checked hourly instead of every
+// tick. Without this, every stale row costs one Safe-service call per
+// minute forever — a week-old orphan alone burns ~10k requests of the API
+// rate budget.
+const STALE_AFTER_MS = 24 * 60 * 60 * 1000;
+const STALE_CHECK_INTERVAL_MS = 60 * 60 * 1000;
+const nextStaleCheckAt = new Map<string, number>();
+
 async function getUnresolvedSafeTxRows(): Promise<TransactionRow[]> {
   const { data, error } = await supabase
     .from("transactions")
@@ -44,7 +53,17 @@ async function tick(): Promise<void> {
     console.error("safeSync: failed to list unresolved rows:", err);
     return;
   }
+  // Prune backoff entries for rows that resolved since the last tick.
+  const liveIds = new Set(rows.map((r) => r.id));
+  for (const id of nextStaleCheckAt.keys()) {
+    if (!liveIds.has(id)) nextStaleCheckAt.delete(id);
+  }
   for (const row of rows) {
+    const age = Date.now() - new Date(row.proposed_at).getTime();
+    if (Number.isFinite(age) && age > STALE_AFTER_MS) {
+      if (Date.now() < (nextStaleCheckAt.get(row.id) ?? 0)) continue;
+      nextStaleCheckAt.set(row.id, Date.now() + STALE_CHECK_INTERVAL_MS);
+    }
     try {
       await syncOne(row);
     } catch (err) {


### PR DESCRIPTION
## Problem

The Safe API key hit its rate limit. Investigation showed the budget was being consumed almost entirely by unresolved-row reconciliation, multiplied across surfaces:

- Every `GET /transactions` list read reconciles each unresolved SafeTx row against the Transaction Service — with tabs polling every 8s (30s idle), that's N tabs × rows service calls per poll.
- The WalletConnect screening wait polled that same list every 3s (~20 list calls/min → 20 × rows service calls).
- The `safeSync` worker swept every unresolved row every 60s, forever — a single week-old abandoned row burned ~10k requests on its own.
- Rows Zhentan itself marked `"Superseded:"` are re-verified on every list read (the heal path for premature verdicts) with no expiry — 13 dead test rows made every tab open cost 13 service calls even with zero unresolved rows.

## Changes

**`server/src/lib/safe/reconcile.ts`**
- Per-row 30s cooldown on the Transaction Service lookup, shared by both callers (list reads + worker); within the window reconcile answers from the DB reads alone. Cleared the moment a row resolves. Collapses tab-count × poll-rate multiplication to ≤2 service calls per row per minute, total.
- The `"Superseded:"` re-verify heal window is now bounded to **one hour** after the marking — a supersede verdict can only be premature while the service indexer lags (seconds), so re-checking dead rows forever was pure waste.

**`server/src/workers/safeSync.ts`**
- Rows unresolved for more than 24h are swept hourly instead of every minute (backoff map pruned as rows resolve).

**`client/src/lib/pollExecution.ts`**
- The WalletConnect wait now polls `GET /transactions/:id` (a plain DB read, zero service calls) instead of the reconciling list endpoint. Safe-app override executions still fold in via safeSync's 60s sweep.

## Resulting steady state

| Scenario | Before | After |
|---|---|---|
| Idle, no unresolved rows | up to 13/min (superseded re-verify) | 0 |
| 1 pending tx, any number of tabs | ~8–26/min | ≤2/min |
| WalletConnect screening wait | +20×rows/min | 0 |
| Stale abandoned row | 1/min forever | 1/hour |

## Notes

- Behavior trade-offs: a backup-key execution from the Safe app may take up to ~60s (safeSync sweep) to fold into a WC wait instead of ~3s; a `confirming` badge can briefly read `pending` between cooldown windows. Both cosmetic.
- These commits also currently sit on #65 (where the incident was debugged); once this merges, the identical patches dedupe cleanly there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)