### PR TITLE
feat: kind-based transaction pipeline — decoder, risk strategies, agent-proposed swaps

### DIFF
--- a/agent/SKILL.md
+++ b/agent/SKILL.md
@@ -84,9 +84,9 @@ in the app.
 **Swaps**: for "swap 10 USDC for WBNB" call `queue_request` with
 `kind: "swap"`, `fromToken`/`toToken` (symbols), and `amount` = the sell
 amount. Do not set `to`, `token`, or any invoice field — swaps have no
-recipient and never carry invoice metadata. Score swap risk on amount vs
-limits and how unusual the pair is for this owner (recipient factors don't
-apply).
+recipient and never carry invoice metadata. The server scores swaps itself
+(amount, velocity, route); as with transfers, add `riskScore`/`riskNotes`
+only for contextual red flags.
 
 1. If the recipient is a name ("alice.eth", "@koshik", "alice.bnb"), call
    `resolve_recipient(name)` and **show the owner the resolved address** before queueing.
@@ -97,30 +97,24 @@ apply).
    - transfers: `description` — the instruction in one sentence
    - invoices: `invoiceNumber`, `issueDate`, `dueDate`, `billedFrom`/`billedTo`,
      `services` `[{description, qty, rate, total}]`
-3. **Always score the request before queueing — `riskScore` (0–100) and `riskNotes`
-   are required on every `queue_request`, for both transfers and invoices.** Unlike
-   live transactions (which the server scores automatically), a request is scored by
-   **you**: call `get_screening_status(safe, includePatterns: true)` and apply the
-   **Risk scoring reference** below — unknown vs known recipient, amount vs the
-   recipient's history, hour-of-day, and any single-tx / daily / custom limits. Set
-   `riskNotes` to one line justifying the score (e.g. "Unknown recipient, amount 4×
-   their average"). Never queue a request without a score.
+3. **Do NOT score behavioral factors — the server does.** Every request is
+   scored server-side by the same deterministic rules engine that screens live
+   transactions (recipient history, amount vs patterns, velocity, time-of-day,
+   custom rules). Hand-applying those rules drifts — you might call a
+   well-known recipient "unknown". Set `riskScore` + `riskNotes` **only** when
+   you see a **contextual red flag the server cannot**: a suspicious or
+   altered invoice, a social-engineering smell in the instruction, a resolved
+   name that doesn't match its address, urgency pressure. Your score can only
+   raise the server's, never lower it. For routine requests, omit both.
 4. `queue_request(...)` → confirm: "Request for [amount] [token] queued — approve it
    in your Zhentan dashboard."
 
-## Risk scoring reference
-
-| Factor | Score |
-|--------|-------|
-| Unknown recipient | +40 |
-| Amount > 3× recipient average | +25 |
-| Outside allowed hours (UTC) | +20 |
-| Exceeds single-tx limit | +30 |
-| Would exceed daily volume | +20 |
-| Custom rule triggered | varies |
+## Risk verdicts (server-computed)
 
 Verdicts: **APPROVE** (<40) · **REVIEW** (40–70) · **BLOCK** (>70).
-Thresholds are per-Safe — change them with `update_screening_settings`.
+Thresholds are per-Safe — change them with `update_screening_settings`. Use
+`get_screening_status(safe)` when the owner asks about their settings or
+patterns — not to score requests.
 
 ## Rules management
 

--- a/agent/SKILL.md
+++ b/agent/SKILL.md
@@ -52,6 +52,7 @@ with `get_user_profile` when a tool needs a `safe` parameter.
 | "enable/disable screening", "update limits" | `update_screening_settings` (get the Safe via `get_user_profile`) |
 | "screening status" | `get_screening_status` |
 | "send/pay X to Y" or an invoice | see **Payment requests** below |
+| "swap X for Y" | `queue_request` with `kind: "swap"` — see **Payment requests** below |
 | "list requests / invoices" | `list_requests(callerId)` |
 | "who am I" / "my wallet" | `get_user_profile(chatId)` |
 | "list/create/update/delete rule" | `list_rules` / `create_rule` / `update_rule` / `delete_rule` |
@@ -73,10 +74,19 @@ rewrite or shorten an id.
 - A rejected transaction is final. If the owner then wants to pay that recipient,
   queue a **new** payment request instead.
 
-## Payment requests (invoices & transfer instructions)
+## Payment requests (invoices, transfers & swaps)
 
-A request is any incoming payment ask. It is **queued to the dashboard for the
-owner to approve** — queueing never moves funds.
+A request is any incoming payment or swap ask. It is **queued to the dashboard
+for the owner to approve** — queueing never moves funds. The server builds the
+transaction as a draft where it can; the owner completes it with one signature
+in the app.
+
+**Swaps**: for "swap 10 USDC for WBNB" call `queue_request` with
+`kind: "swap"`, `fromToken`/`toToken` (symbols), and `amount` = the sell
+amount. Do not set `to`, `token`, or any invoice field — swaps have no
+recipient and never carry invoice metadata. Score swap risk on amount vs
+limits and how unusual the pair is for this owner (recipient factors don't
+apply).
 
 1. If the recipient is a name ("alice.eth", "@koshik", "alice.bnb"), call
    `resolve_recipient(name)` and **show the owner the resolved address** before queueing.

--- a/client/src/app/(app)/requests/page.tsx
+++ b/client/src/app/(app)/requests/page.tsx
@@ -77,13 +77,14 @@ function RequestsPageContent() {
       if (!user || !wallet) throw new Error("Please log in first");
       if (!safeAddress) throw new Error("Wallet not ready");
 
-      // Auto-approve path: the agent already built + pre-signed this tx (1-of-2).
-      // Fetch it, add the user's signature over the same safeTxHash, and the
-      // relayer executes — no fresh proposal, no re-screening.
+      // Draft path: the agent already built this tx (transfer or swap) as a
+      // draft. Finalize assigns the Safe nonce + hash NOW (deferred so a
+      // dismissed draft never parks a nonce), then the user signs that final
+      // payload and the relayer executes — no fresh proposal, no re-screening.
       if (request.txId) {
-        const { transaction } = await api.transactions.get(request.txId);
+        const { transaction } = await api.transactions.finalize(request.txId);
         if (!transaction.safeTx || !transaction.safeAddress) {
-          throw new Error("Pre-signed transaction is unavailable");
+          throw new Error("Prepared transaction is unavailable");
         }
         const account = await getOwnerAccount();
         if (!account) throw new Error("Wallet not ready for signing");
@@ -97,7 +98,15 @@ function RequestsPageContent() {
         return { txId: request.txId };
       }
 
-      // No pre-sign → the user proposes a fresh tx and it goes through screening.
+      // Swap requests settle only through an agent-built draft — there is no
+      // client-side swap builder to fall back to.
+      if (request.kind === "swap") {
+        throw new Error(
+          "This swap couldn't be prepared (no route or unknown token). Ask Zhentan to queue it again."
+        );
+      }
+
+      // No draft → the user proposes a fresh tx and it goes through screening.
       const token = resolveToken(request.token);
       if (!token?.address) {
         throw new Error(`Unsupported token: ${request.token}`);

--- a/client/src/lib/api/transactions.ts
+++ b/client/src/lib/api/transactions.ts
@@ -40,9 +40,25 @@ export function transactionsApi(req: ApiFetchFn) {
     },
 
     /**
-     * Complete an agent-proposed (pre-signed, 1-of-2) tx: submit the user's
-     * signature over its safeTxHash; the server verifies it, stores it, and the
-     * relayer executes. Used by the auto-approve request flow.
+     * Finalize an agent-proposed DRAFT: the server assigns the Safe nonce and
+     * computes the EIP-712 hash so the user can sign. Deferred to this moment
+     * so a dismissed draft never parks a nonce. Idempotent — returns the
+     * transaction with its final safeTx/safeTxHash either way.
+     */
+    async finalize(id: string): Promise<{ transaction: TransactionWithStatus }> {
+      const res = await req(`/transactions/${encodeURIComponent(id)}/finalize`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+      if (!res.ok) throw new Error(await res.text());
+      return res.json();
+    },
+
+    /**
+     * Complete an agent-proposed tx: submit the user's signature over its
+     * safeTxHash; the server verifies it, stores it, and the relayer executes
+     * (the agent co-signs at execution — it screened the request when it
+     * built the draft). Used by the request draft flow after finalize().
      */
     async sign(
       id: string,

--- a/client/src/lib/proposeSwap.ts
+++ b/client/src/lib/proposeSwap.ts
@@ -90,6 +90,9 @@ export async function proposeSwap({
     amount: sellAmount,
     token: `${fromToken.symbol} → ${toToken.symbol}`,
     tokenAddress: fromToken.address ?? NATIVE_TOKEN_ADDRESS,
+    // The buy token is the analysis target server-side (deep-analyze scans
+    // what the user ends up holding, not what they already own).
+    toTokenAddress: toToken.address ?? undefined,
     tokenIconUrl: fromToken.iconUrl ?? null,
     ...(amountUSD && { amountUSD }),
     ...(screeningDisabled && { screeningDisabled: true }),

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -60,6 +60,13 @@ export interface PendingTransaction {
   tokenAddress: string;
   /** Token icon URL for display in activity (e.g. from Zerion). Stored when proposing. */
   tokenIconUrl?: string | null;
+  /** Swap rows: the token being bought (the analysis target server-side). */
+  toTokenAddress?: string;
+  /**
+   * Agent-proposed row awaiting the user's decision. Drafts have no nonce or
+   * safeTxHash yet — call /transactions/:id/finalize before signing.
+   */
+  draft?: boolean;
   /** When true, server skips risk analysis; client triggers execute. */
   screeningDisabled?: boolean;
   proposedBy: string;
@@ -311,6 +318,12 @@ export type RequestStatus = "queued" | "approved" | "executed" | "rejected";
 export type RequestType = "invoice" | "transfer";
 
 /**
+ * How a request settles on-chain, orthogonal to `type` (presentation — an
+ * invoice is a transfer with billing metadata). Absent means "transfer".
+ */
+export type RequestKind = "transfer" | "swap";
+
+/**
  * An incoming payment request routed through the agent — either a parsed
  * invoice or a general transfer instruction. Invoice-specific fields are
  * undefined for non-invoice requests.
@@ -318,9 +331,16 @@ export type RequestType = "invoice" | "transfer";
 export interface QueuedRequest {
   id: string;
   type: RequestType;
+  kind?: RequestKind;
   to: string;
   amount: string;
   token: string;
+  /** Swap requests: sell-token symbol. */
+  fromToken?: string;
+  /** Swap requests: buy-token symbol. */
+  toToken?: string;
+  /** Swap requests: slippage as a fraction (0.005 = 0.5%). */
+  slippage?: number;
   /** Free-text instruction/summary from the agent (e.g. the user's original ask). */
   description?: string;
   invoiceNumber?: string;

--- a/mcp/src/tools/requests.ts
+++ b/mcp/src/tools/requests.ts
@@ -26,16 +26,30 @@ export function registerRequestTools(server: McpServer) {
   server.registerTool(
     "queue_request",
     {
-      title: "Queue a payment request",
+      title: "Queue a payment or swap request",
       description:
-        "Queue an incoming payment request (a parsed invoice or a general transfer instruction) to the user's " +
+        "Queue an incoming request (a parsed invoice, a transfer instruction, or a token swap) to the user's " +
         "Zhentan dashboard for approval. This does NOT move funds — the user approves it in the app. " +
-        "Use when the user forwards an invoice or asks to send/pay someone.",
+        "Use when the user forwards an invoice, asks to send/pay someone, or asks to swap tokens. " +
+        'For swaps set kind: "swap" with fromToken/toToken (symbols) and amount = sell amount; ' +
+        "to/token are not used and invoice fields are invalid.",
       inputSchema: {
-        type: z.enum(["invoice", "transfer"]).describe('"invoice" for invoice documents, "transfer" for send/pay instructions'),
-        to: ADDRESS.describe("Recipient wallet address"),
-        amount: z.string().regex(/^\d+(\.\d+)?$/, "amount must be a positive decimal string"),
-        token: z.string().min(1).describe('Token symbol, e.g. "USDC"'),
+        type: z.enum(["invoice", "transfer"]).optional().describe('"invoice" for invoice documents, "transfer" for send/pay instructions. Omit for swaps.'),
+        kind: z
+          .enum(["transfer", "swap"])
+          .optional()
+          .describe('How the request settles on-chain. Default "transfer" (invoices are always transfers); "swap" for token swaps.'),
+        to: ADDRESS.optional().describe("Recipient wallet address (required unless kind is swap)"),
+        amount: z.string().regex(/^\d+(\.\d+)?$/, "amount must be a positive decimal string").describe("Transfer amount, or the SELL amount for swaps"),
+        token: z.string().min(1).optional().describe('Token symbol, e.g. "USDC" (required unless kind is swap)'),
+        fromToken: z.string().min(1).optional().describe('Swaps only: sell-token symbol, e.g. "USDC"'),
+        toToken: z.string().min(1).optional().describe('Swaps only: buy-token symbol, e.g. "WBNB"'),
+        slippage: z
+          .number()
+          .min(0.0001)
+          .max(0.5)
+          .optional()
+          .describe("Swaps only: slippage as a fraction (0.005 = 0.5%). Default 0.005."),
         callerId: CALLER_ID.describe("Required — resolves which user's Safe owns this request"),
         description: z.string().max(500).optional().describe("For transfers: the user's instruction in one sentence"),
         invoiceNumber: z.string().optional(),

--- a/mcp/src/tools/requests.ts
+++ b/mcp/src/tools/requests.ts
@@ -65,15 +65,17 @@ export function registerRequestTools(server: McpServer) {
           .max(100)
           .optional()
           .describe(
-            "Always set this. Your 0–100 risk assessment of the request — score it yourself " +
-              "(the server does not): unknown vs known recipient, amount vs the recipient's history, " +
-              "hour-of-day, and single-tx/daily/custom limits.",
+            "CONTEXTUAL risk only (0–100), and only when you see a red flag the server cannot: " +
+              "a suspicious invoice, a social-engineering smell, a resolved name that doesn't match its address. " +
+              "The server already scores recipient history, amounts, velocity and time-of-day deterministically — " +
+              "do NOT re-derive those factors. Your score can only raise the server's, never lower it. " +
+              "Omit entirely for routine requests.",
           ),
         riskNotes: z
           .string()
           .max(500)
           .optional()
-          .describe("Always set this. One line justifying the riskScore."),
+          .describe("One line naming the contextual red flag. Required when riskScore is set."),
       },
     },
     async (args) => {

--- a/server/src/lib/constants.ts
+++ b/server/src/lib/constants.ts
@@ -108,6 +108,41 @@ export const ERC20_TRANSFER_ABI = [
   },
 ] as const;
 
+export const ERC20_APPROVE_ABI = [
+  {
+    name: "approve",
+    type: "function" as const,
+    stateMutability: "nonpayable" as const,
+    inputs: [
+      { name: "spender", type: "address" as const },
+      { name: "amount", type: "uint256" as const },
+    ],
+    outputs: [{ type: "bool" as const }],
+  },
+] as const;
+
+export const MULTISEND_ABI = [
+  {
+    name: "multiSend",
+    type: "function" as const,
+    stateMutability: "payable" as const,
+    inputs: [{ name: "transactions", type: "bytes" as const }],
+    outputs: [],
+  },
+] as const;
+
+/**
+ * DEX routers the kind decoder recognizes as swap targets. A call to any
+ * other contract classifies as "dapp-call" and is scored accordingly —
+ * membership here is a classification aid, not a security boundary.
+ */
+export const KNOWN_ROUTERS: Record<string, string> = {
+  // PancakeSwap Smart Router (BSC)
+  "0x13f4ea83d0bd40e75c8222255bc855a974568dd4": "PancakeSwap",
+  // LI.FI Diamond (canonical cross-chain router, same address on BSC)
+  "0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae": "LI.FI",
+};
+
 export function getPimlicoRpcUrl(apiKey: string): string {
   return `https://api.pimlico.io/v2/binance/rpc?apikey=${apiKey}`;
 }

--- a/server/src/lib/safe/agentPropose.ts
+++ b/server/src/lib/safe/agentPropose.ts
@@ -1,115 +1,96 @@
 /**
- * Agent-initiated proposal for low-risk requests (the "auto-approve" path).
+ * Agent-initiated proposals (the request → transaction half of the pipeline).
  *
- * When a request scores APPROVE, the agent builds the transfer SafeTx and adds
- * ITS co-signature up front — the tx lands at 1-of-2, pre-screened. The user
- * then completes it with a single signature and the relayer executes, or
- * rejects it. This inverts the normal ordering (agent signs first), which is
- * only sound because the agent DID screen it — consistent with "the agent never
- * signs what it didn't screen". The user's signature is still mandatory to
- * reach the threshold, so the agent can never move funds alone.
+ * The agent builds the SafeTx for a queued request — any kind in the builder
+ * registry (transfer, swap) — and stores it as a DRAFT: a normal row the user
+ * completes with one signature. Drafts carry the full call payload but NO
+ * nonce, hash, or signature of any party:
  *
- * An agent-proposed tx is identified by `userSignature` being null (a
- * user-proposed tx always carries it) — no schema change needed.
+ *   - The nonce is assigned and the EIP-712 hash computed only when the user
+ *     finalizes to sign (POST /transactions/:id/finalize). A dismissed draft
+ *     therefore never parks a Safe nonce and needs no on-chain rejection.
+ *   - The agent's signature happens at execution time like every screened
+ *     transaction (/execute signs fresh) — consistent with "the agent never
+ *     signs what it didn't screen", and the user's signature is still
+ *     mandatory to reach the threshold, so the agent can never move funds
+ *     alone.
+ *   - Drafts are never mirrored to the Transaction Service (a mirror needs a
+ *     nonce). Visibility in app.safe.global starts once the user signs.
+ *
+ * An agent-proposed row is identified by `draft: true` (plus `userSignature`
+ * being null — a user-proposed tx always carries it).
  */
-import { encodeFunctionData, parseUnits, type Address, type Hex } from "viem";
 import { randomUUID } from "crypto";
 
-import { ERC20_TRANSFER_ABI, NATIVE_TOKEN_ADDRESS } from "../constants.js";
-import { fetchTokenPositions } from "../zerion.js";
-import {
-  getNextSafeNonce,
-  computeSafeTxHash,
-  getProtocolKit,
-  proposeToService,
-} from "./service.js";
+import { KIND_BUILDERS, buildSafeTxFromCalls, type BuiltCalls } from "./builders.js";
 import { isSafeDeployed } from "./deploy.js";
 import { getAgentAddress } from "./relayer.js";
 import { getUserDetails, createTransaction } from "../supabase/index.js";
-import type { PendingTransaction, SafeTxData } from "../../types.js";
-
-/** Resolve a token symbol → { address, decimals } from the Safe's holdings. */
-async function resolveToken(
-  safeAddress: string,
-  symbol: string
-): Promise<{ address: string; decimals: number } | null> {
-  if (symbol.toUpperCase() === "BNB") {
-    return { address: NATIVE_TOKEN_ADDRESS, decimals: 18 };
-  }
-  try {
-    const { tokens } = await fetchTokenPositions(safeAddress);
-    const t = tokens.find(
-      (x) => x.address && x.symbol?.toUpperCase() === symbol.toUpperCase()
-    );
-    if (t?.address) return { address: t.address, decimals: t.decimals };
-  } catch {
-    /* fall through */
-  }
-  return null;
-}
+import type { PendingTransaction, RequestKind } from "../../types.js";
 
 export interface AgentProposeInput {
+  kind: RequestKind;
   safeAddress: string;
-  to: string;
-  amount: string; // human-readable
-  token: string; // symbol
+  /** transfer: recipient address. Ignored for swaps (display shows the router). */
+  to?: string;
+  /** transfer: human-readable amount. */
+  amount?: string;
+  /** transfer: token symbol. */
+  token?: string;
+  /** swap: sell-token symbol. */
+  fromToken?: string;
+  /** swap: buy-token symbol. */
+  toToken?: string;
+  /** swap: human-readable sell amount. */
+  sellAmount?: string;
+  /** swap: slippage fraction (0.005 = 0.5%). */
+  slippage?: number;
   riskScore: number;
+  riskVerdict?: "APPROVE" | "REVIEW" | "BLOCK";
   riskReasons: string[];
 }
 
 /**
- * Builds + agent-signs a transfer SafeTx for an APPROVE request and stores it as
- * a pending (1-of-2) transaction, mirrored to the Transaction Service. Returns
- * the tx id, or null when it can't pre-sign (undeployed Safe, unknown embedded
- * owner, unresolvable token, or a build error) — the request then just stays
- * queued with its risk score.
+ * Builds a draft SafeTx for a request and stores it as a pending row awaiting
+ * the user's signature. Returns the tx id, or null when the draft can't be
+ * built (undeployed Safe, unknown embedded owner, unresolvable token, no
+ * swap route, or a build error) — the request then just stays queued with its
+ * risk score.
  */
 export async function agentProposeFromRequest(
   input: AgentProposeInput
 ): Promise<string | null> {
-  const { safeAddress, to, amount, token, riskScore, riskReasons } = input;
+  const { kind, safeAddress, riskScore, riskVerdict, riskReasons } = input;
   try {
     const record = await getUserDetails(safeAddress);
     const embedded = record?.signer_address;
     if (!embedded) return null; // no known user owner to co-sign later
     if (!record?.safe_deployed && !(await isSafeDeployed(safeAddress))) return null;
 
-    const tk = await resolveToken(safeAddress, token);
-    if (!tk) return null;
+    let built: BuiltCalls | null = null;
+    if (kind === "swap") {
+      if (!input.fromToken || !input.toToken || !input.sellAmount) return null;
+      built = await KIND_BUILDERS.swap({
+        safeAddress,
+        fromToken: input.fromToken,
+        toToken: input.toToken,
+        sellAmount: input.sellAmount,
+        slippage: input.slippage,
+      });
+    } else {
+      if (!input.to || !input.amount || !input.token) return null;
+      built = await KIND_BUILDERS.transfer({
+        safeAddress,
+        to: input.to,
+        amount: input.amount,
+        token: input.token,
+      });
+    }
+    if (!built) return null;
 
-    const amountWei = parseUnits(amount, tk.decimals);
-    const isNative = tk.address.toLowerCase() === NATIVE_TOKEN_ADDRESS.toLowerCase();
-    const call = isNative
-      ? { to: to as Address, value: amountWei, data: "0x" as Hex }
-      : {
-          to: tk.address as Address,
-          value: 0n,
-          data: encodeFunctionData({
-            abi: ERC20_TRANSFER_ABI,
-            functionName: "transfer",
-            args: [to as Address, amountWei],
-          }),
-        };
-
-    const nonce = await getNextSafeNonce(safeAddress);
-    const safeTx: SafeTxData = {
-      to: call.to,
-      value: call.value.toString(),
-      data: call.data,
-      operation: 0,
-      safeTxGas: "0",
-      baseGas: "0",
-      gasPrice: "0",
-      gasToken: NATIVE_TOKEN_ADDRESS,
-      refundReceiver: NATIVE_TOKEN_ADDRESS,
-      nonce,
-    };
-    const safeTxHash = computeSafeTxHash(safeAddress, safeTx);
-
-    // Agent's pre-signature — it screened this as APPROVE, so signing is
-    // consistent with the invariant. The user's signature is still required.
-    const protocolKit = await getProtocolKit(safeAddress);
-    const agentSig = await protocolKit.signHash(safeTxHash);
+    // Placeholder nonce — replaced at finalize time; the stored hash-less
+    // draft can't be signed or executed until then.
+    const safeTx = buildSafeTxFromCalls(built.calls, 0);
 
     const owners =
       record.safe_owners?.length
@@ -120,41 +101,25 @@ export async function agentProposeFromRequest(
     const tx: PendingTransaction = {
       id: txId,
       txType: "safetx",
-      to,
-      amount,
-      token,
-      tokenAddress: isNative ? NATIVE_TOKEN_ADDRESS : tk.address,
-      proposedBy: embedded, // the eventual user co-signer (owner #1)
-      // userSignature left undefined → marks this agent-proposed, awaiting user
+      draft: true,
+      to: built.display.to,
+      amount: built.display.amount,
+      token: built.display.token,
+      tokenAddress: built.display.tokenAddress,
+      ...(built.display.toTokenAddress && { toTokenAddress: built.display.toTokenAddress }),
+      proposedBy: embedded, // the eventual user signer (owner #1)
+      // userSignature left undefined → awaiting the user
       signatures: [],
       ownerAddresses: owners,
       threshold: record.safe_threshold ?? 2,
       safeAddress,
       safeTx,
-      safeTxHash,
-      safeNonce: nonce,
       riskScore,
-      riskVerdict: "APPROVE",
+      riskVerdict: riskVerdict ?? "APPROVE",
       riskReasons,
       proposedAt: new Date().toISOString(),
     };
     await createTransaction(tx);
-
-    // Mirror at 1-of-2 (agent as proposer + its signature) so it also shows in
-    // app.safe.global. Best-effort — local assembly executes regardless.
-    try {
-      await proposeToService({
-        safeAddress,
-        safeTx,
-        safeTxHash,
-        senderAddress: getAgentAddress(),
-        senderSignature: agentSig.data,
-        origin: "Zhentan (agent pre-approved)",
-      });
-    } catch (err) {
-      console.error("agentPropose: service mirror failed (continuing):", err);
-    }
-
     return txId;
   } catch (err) {
     console.error("agentPropose failed (request stays queued):", err);

--- a/server/src/lib/safe/agentPropose.ts
+++ b/server/src/lib/safe/agentPropose.ts
@@ -125,13 +125,14 @@ export async function agentProposeFromRequest(
     };
     await createTransaction(tx);
 
-    // Transfers finalize at creation: their calldata can't go stale, and the
-    // eager nonce + agent-signed 1/2 mirror makes the pending request visible
-    // in app.safe.global immediately (parity with the pre-draft flow). Swaps
-    // stay lazy — finalize re-quotes them when the user approves. Best-effort:
+    // APPROVE-scored drafts (any kind) finalize at creation: the eager nonce
+    // + agent-signed 1/2 mirror makes the pending request visible in
+    // app.safe.global immediately (parity with the pre-draft flow). Swap
+    // quotes are refreshed again at approval — see finalizeDraft. REVIEW-band
+    // swaps stay lazy so a dismissed one never parks a nonce. Best-effort:
     // a failure here leaves a lazy draft the approve flow finalizes instead.
-    if (kind === "transfer") {
-      await finalizeDraft(tx).catch((err) =>
+    if ((riskVerdict ?? "APPROVE") === "APPROVE") {
+      await finalizeDraft(tx, { freshQuote: false }).catch((err) =>
         console.error("agentPropose: eager finalize failed (draft stays lazy):", err)
       );
     }

--- a/server/src/lib/safe/agentPropose.ts
+++ b/server/src/lib/safe/agentPropose.ts
@@ -3,26 +3,30 @@
  *
  * The agent builds the SafeTx for a queued request — any kind in the builder
  * registry (transfer, swap) — and stores it as a DRAFT: a normal row the user
- * completes with one signature. Drafts carry the full call payload but NO
- * nonce, hash, or signature of any party:
+ * completes with one signature. A draft is born with the full call payload
+ * but no nonce, hash, or signature; finalizeDraft() is what makes it signable
+ * (nonce + hash + agent-signed 1/2 mirror to the Transaction Service).
  *
- *   - The nonce is assigned and the EIP-712 hash computed only when the user
- *     finalizes to sign (POST /transactions/:id/finalize). A dismissed draft
- *     therefore never parks a Safe nonce and needs no on-chain rejection.
- *   - The agent's signature happens at execution time like every screened
- *     transaction (/execute signs fresh) — consistent with "the agent never
- *     signs what it didn't screen", and the user's signature is still
- *     mandatory to reach the threshold, so the agent can never move funds
- *     alone.
- *   - Drafts are never mirrored to the Transaction Service (a mirror needs a
- *     nonce). Visibility in app.safe.global starts once the user signs.
+ * WHEN a draft finalizes is per-kind:
+ *   - TRANSFERS finalize eagerly right here — their calldata can't go stale,
+ *     and the mirror makes the pending request visible in app.safe.global
+ *     immediately. Dismissing one parks its nonce until superseded (the
+ *     pre-draft flow behaved the same way).
+ *   - SWAPS finalize lazily when the user approves — the quote (route +
+ *     min-out) is rebuilt fresh at that moment; a queue-time quote reverts
+ *     on-chain (GS013) by the time the user signs. A dismissed swap draft
+ *     never parks a nonce.
  *
- * An agent-proposed row is identified by `draft: true` (plus `userSignature`
- * being null — a user-proposed tx always carries it).
+ * The agent's execution signature happens at /execute like every screened
+ * transaction; the user's signature is always mandatory to reach the
+ * threshold, so the agent can never move funds alone. An agent-proposed row
+ * is identified by `userSignature` being null (a user-proposed tx always
+ * carries it).
  */
 import { randomUUID } from "crypto";
 
 import { KIND_BUILDERS, buildSafeTxFromCalls, type BuiltCalls } from "./builders.js";
+import { finalizeDraft } from "./finalizeDraft.js";
 import { isSafeDeployed } from "./deploy.js";
 import { getAgentAddress } from "./relayer.js";
 import { getUserDetails, createTransaction } from "../supabase/index.js";
@@ -120,6 +124,18 @@ export async function agentProposeFromRequest(
       proposedAt: new Date().toISOString(),
     };
     await createTransaction(tx);
+
+    // Transfers finalize at creation: their calldata can't go stale, and the
+    // eager nonce + agent-signed 1/2 mirror makes the pending request visible
+    // in app.safe.global immediately (parity with the pre-draft flow). Swaps
+    // stay lazy — finalize re-quotes them when the user approves. Best-effort:
+    // a failure here leaves a lazy draft the approve flow finalizes instead.
+    if (kind === "transfer") {
+      await finalizeDraft(tx).catch((err) =>
+        console.error("agentPropose: eager finalize failed (draft stays lazy):", err)
+      );
+    }
+
     return txId;
   } catch (err) {
     console.error("agentPropose failed (request stays queued):", err);

--- a/server/src/lib/safe/builders.ts
+++ b/server/src/lib/safe/builders.ts
@@ -27,6 +27,7 @@ import {
 } from "../constants.js";
 import { getPancakeSwapQuote } from "../pancakeswap.js";
 import { fetchTokenPositions } from "../zerion.js";
+import { findFallbackAddressBySymbol } from "../token-fallbacks.js";
 import type { RequestKind, SafeTxData } from "../../types.js";
 
 export interface SafeCall {
@@ -112,11 +113,17 @@ async function buildTransferCalls(params: TransferBuildParams): Promise<BuiltCal
 
 async function buildSwapCalls(params: SwapBuildParams): Promise<BuiltCalls | null> {
   const { safeAddress, fromToken, toToken, sellAmount } = params;
-  const [from, to] = await Promise.all([
+  // Sell token must come from the Safe's holdings (you can't sell what you
+  // don't hold, and parseUnits needs its trusted decimals). The BUY token
+  // usually isn't held yet — fall back to the known-token table; only its
+  // ADDRESS is needed here (the quoter reads decimals/symbol on-chain).
+  const [from, toHeld] = await Promise.all([
     resolveTokenBySymbol(safeAddress, fromToken),
     resolveTokenBySymbol(safeAddress, toToken),
   ]);
-  if (!from || !to) return null;
+  const toAddress = toHeld?.address ?? findFallbackAddressBySymbol(toToken);
+  if (!from || !toAddress) return null;
+  const to = { address: toAddress };
 
   const sellAmountWei = parseUnits(sellAmount, from.decimals);
   const quote = await getPancakeSwapQuote({

--- a/server/src/lib/safe/builders.ts
+++ b/server/src/lib/safe/builders.ts
@@ -1,0 +1,225 @@
+/**
+ * Builder registry for agent-initiated transactions.
+ *
+ * Each settlement kind is one entry: `build(params) → { calls, display }`.
+ * The shared buildSafeTx below (server port of the client builder in
+ * client/src/lib/safe/safeTx.ts — keep the encodings in lockstep) turns the
+ * calls into a standard SafeTx: single call → plain CALL, several calls →
+ * MultiSendCallOnly batch. Adding a new agent-initiable kind = one entry
+ * here + a decoder case in kind.ts + a risk strategy in risk.ts.
+ */
+import {
+  encodeFunctionData,
+  encodePacked,
+  concatHex,
+  parseUnits,
+  size,
+  type Address,
+  type Hex,
+} from "viem";
+
+import {
+  ERC20_TRANSFER_ABI,
+  ERC20_APPROVE_ABI,
+  MULTISEND_ABI,
+  MULTISEND_CALL_ONLY,
+  NATIVE_TOKEN_ADDRESS,
+} from "../constants.js";
+import { getPancakeSwapQuote } from "../pancakeswap.js";
+import { fetchTokenPositions } from "../zerion.js";
+import type { RequestKind, SafeTxData } from "../../types.js";
+
+export interface SafeCall {
+  to: Address;
+  value: bigint;
+  data: Hex;
+}
+
+/** Display fields the queued row is stamped with (what the user sees). */
+export interface BuiltCalls {
+  calls: SafeCall[];
+  display: {
+    to: string;
+    amount: string;
+    token: string;
+    tokenAddress: string;
+    toTokenAddress?: string;
+  };
+}
+
+export interface TransferBuildParams {
+  safeAddress: string;
+  to: string;
+  amount: string; // human-readable
+  token: string; // symbol
+}
+
+export interface SwapBuildParams {
+  safeAddress: string;
+  fromToken: string; // symbol
+  toToken: string; // symbol
+  sellAmount: string; // human-readable
+  /** Fraction, e.g. 0.005 = 0.5%. */
+  slippage?: number;
+}
+
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000" as const;
+const DEFAULT_SLIPPAGE = 0.005;
+
+/** Resolve a token symbol → { address, decimals } from the Safe's holdings. */
+export async function resolveTokenBySymbol(
+  safeAddress: string,
+  symbol: string
+): Promise<{ address: string; decimals: number } | null> {
+  if (symbol.toUpperCase() === "BNB") {
+    return { address: NATIVE_TOKEN_ADDRESS, decimals: 18 };
+  }
+  try {
+    const { tokens } = await fetchTokenPositions(safeAddress);
+    const t = tokens.find(
+      (x) => x.address && x.symbol?.toUpperCase() === symbol.toUpperCase()
+    );
+    if (t?.address) return { address: t.address, decimals: t.decimals };
+  } catch {
+    /* fall through */
+  }
+  return null;
+}
+
+async function buildTransferCalls(params: TransferBuildParams): Promise<BuiltCalls | null> {
+  const { safeAddress, to, amount, token } = params;
+  const tk = await resolveTokenBySymbol(safeAddress, token);
+  if (!tk) return null;
+
+  const amountWei = parseUnits(amount, tk.decimals);
+  const isNative = tk.address.toLowerCase() === NATIVE_TOKEN_ADDRESS.toLowerCase();
+  const call: SafeCall = isNative
+    ? { to: to as Address, value: amountWei, data: "0x" as Hex }
+    : {
+        to: tk.address as Address,
+        value: 0n,
+        data: encodeFunctionData({
+          abi: ERC20_TRANSFER_ABI,
+          functionName: "transfer",
+          args: [to as Address, amountWei],
+        }),
+      };
+  return {
+    calls: [call],
+    display: { to, amount, token, tokenAddress: tk.address },
+  };
+}
+
+async function buildSwapCalls(params: SwapBuildParams): Promise<BuiltCalls | null> {
+  const { safeAddress, fromToken, toToken, sellAmount } = params;
+  const [from, to] = await Promise.all([
+    resolveTokenBySymbol(safeAddress, fromToken),
+    resolveTokenBySymbol(safeAddress, toToken),
+  ]);
+  if (!from || !to) return null;
+
+  const sellAmountWei = parseUnits(sellAmount, from.decimals);
+  const quote = await getPancakeSwapQuote({
+    fromToken: from.address,
+    toToken: to.address,
+    amount: sellAmountWei.toString(),
+    fromAddress: safeAddress,
+    slippage: params.slippage ?? DEFAULT_SLIPPAGE,
+  });
+  if (!quote) return null;
+
+  const isNativeSell =
+    from.address.toLowerCase() === NATIVE_TOKEN_ADDRESS.toLowerCase();
+  const calls: SafeCall[] = [];
+  if (!isNativeSell) {
+    // Exact-amount approval only — the agent never asks the user to sign an
+    // unlimited approval (the risk engine flags those).
+    calls.push({
+      to: from.address as Address,
+      value: 0n,
+      data: encodeFunctionData({
+        abi: ERC20_APPROVE_ABI,
+        functionName: "approve",
+        args: [quote.approvalAddress as Address, sellAmountWei],
+      }),
+    });
+  }
+  calls.push({
+    to: quote.transaction.to as Address,
+    value: BigInt(quote.transaction.value || "0"),
+    data: quote.transaction.data as Hex,
+  });
+
+  return {
+    calls,
+    display: {
+      to: quote.transaction.to,
+      amount: sellAmount,
+      token: `${fromToken.toUpperCase()} → ${toToken.toUpperCase()}`,
+      tokenAddress: from.address,
+      toTokenAddress: to.address,
+    },
+  };
+}
+
+/** One entry per agent-initiable kind. */
+export const KIND_BUILDERS: {
+  transfer: (p: TransferBuildParams) => Promise<BuiltCalls | null>;
+  swap: (p: SwapBuildParams) => Promise<BuiltCalls | null>;
+} = {
+  transfer: buildTransferCalls,
+  swap: buildSwapCalls,
+};
+
+export function isAgentInitiableKind(kind: string): kind is RequestKind {
+  return kind in KIND_BUILDERS;
+}
+
+/**
+ * Server port of the client's buildSafeTx: single call → operation 0,
+ * several → packed MultiSendCallOnly batch (operation 1). Gas fields zero —
+ * the relayer (agent EOA) pays.
+ */
+export function buildSafeTxFromCalls(calls: SafeCall[], nonce: number): SafeTxData {
+  if (calls.length === 0) throw new Error("buildSafeTxFromCalls requires at least one call");
+
+  if (calls.length === 1) {
+    const { to, value, data } = calls[0];
+    return {
+      to,
+      value: value.toString(),
+      data,
+      operation: 0,
+      safeTxGas: "0",
+      baseGas: "0",
+      gasPrice: "0",
+      gasToken: ZERO_ADDRESS,
+      refundReceiver: ZERO_ADDRESS,
+      nonce,
+    };
+  }
+
+  // MultiSend packed encoding per tx: operation(1) | to(20) | value(32) | dataLength(32) | data
+  const packed = calls.map((c) =>
+    encodePacked(
+      ["uint8", "address", "uint256", "uint256", "bytes"],
+      [0, c.to, c.value, BigInt(size(c.data)), c.data]
+    )
+  );
+  return {
+    to: MULTISEND_CALL_ONLY,
+    value: "0",
+    data: encodeFunctionData({
+      abi: MULTISEND_ABI,
+      functionName: "multiSend",
+      args: [concatHex(packed)],
+    }),
+    operation: 1,
+    safeTxGas: "0",
+    baseGas: "0",
+    gasPrice: "0",
+    gasToken: ZERO_ADDRESS,
+    refundReceiver: ZERO_ADDRESS,
+    nonce,
+  };
+}

--- a/server/src/lib/safe/builders.ts
+++ b/server/src/lib/safe/builders.ts
@@ -25,7 +25,6 @@ import {
   MULTISEND_CALL_ONLY,
   NATIVE_TOKEN_ADDRESS,
 } from "../constants.js";
-import { getPancakeSwapQuote } from "../pancakeswap.js";
 import { fetchTokenPositions } from "../zerion.js";
 import { findFallbackAddressBySymbol } from "../token-fallbacks.js";
 import type { RequestKind, SafeTxData } from "../../types.js";
@@ -65,7 +64,47 @@ export interface SwapBuildParams {
 }
 
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000" as const;
-const DEFAULT_SLIPPAGE = 0.005;
+
+interface ServerSwapQuote {
+  transaction: { to: string; value: string; data: string };
+  approvalAddress: string;
+}
+
+/**
+ * Quote through the server's own /swap endpoint — the same LI.FI-first,
+ * PancakeSwap-fallback flow the client swap UI uses, including the slippage
+ * ladder that auto-escalates from 5% for thin pools. Agent-built swaps must
+ * ride the identical proven path: a direct PancakeSwap quote at tight
+ * slippage builds calldata that reverts on exactly the pairs users actually
+ * trade (fee-on-transfer / low-liquidity tokens).
+ */
+async function fetchServerSwapQuote(params: {
+  fromTokenAddress: string;
+  toTokenAddress: string;
+  amountWei: bigint;
+  safeAddress: string;
+  slippage?: number;
+}): Promise<ServerSwapQuote | null> {
+  const port = Number(process.env.PORT) || 3001;
+  const qs = new URLSearchParams({
+    fromToken: params.fromTokenAddress,
+    toToken: params.toTokenAddress,
+    amount: params.amountWei.toString(),
+    fromAddress: params.safeAddress,
+  });
+  if (params.slippage != null) qs.set("slippage", String(params.slippage));
+  const agentSecret = process.env.AGENT_SECRET;
+  try {
+    const res = await fetch(`http://localhost:${port}/swap?${qs.toString()}`, {
+      headers: { ...(agentSecret && { Authorization: `Bearer ${agentSecret}` }) },
+    });
+    if (!res.ok) return null;
+    const body = (await res.json()) as { quote?: ServerSwapQuote };
+    return body.quote ?? null;
+  } catch {
+    return null;
+  }
+}
 
 /** Resolve a token symbol → { address, decimals } from the Safe's holdings. */
 export async function resolveTokenBySymbol(
@@ -126,12 +165,12 @@ async function buildSwapCalls(params: SwapBuildParams): Promise<BuiltCalls | nul
   const to = { address: toAddress };
 
   const sellAmountWei = parseUnits(sellAmount, from.decimals);
-  const quote = await getPancakeSwapQuote({
-    fromToken: from.address,
-    toToken: to.address,
-    amount: sellAmountWei.toString(),
-    fromAddress: safeAddress,
-    slippage: params.slippage ?? DEFAULT_SLIPPAGE,
+  const quote = await fetchServerSwapQuote({
+    fromTokenAddress: from.address,
+    toTokenAddress: to.address,
+    amountWei: sellAmountWei,
+    safeAddress,
+    slippage: params.slippage,
   });
   if (!quote) return null;
 

--- a/server/src/lib/safe/finalizeDraft.ts
+++ b/server/src/lib/safe/finalizeDraft.ts
@@ -1,0 +1,98 @@
+/**
+ * Finalization of agent-proposed draft transactions — the moment a draft
+ * becomes signable: nonce assigned, EIP-712 hash computed, and the proposal
+ * mirrored to the Safe Transaction Service at 1/2 with the agent's signature
+ * (it screened the draft, so signing is consistent with the invariant).
+ *
+ * Called from two places:
+ *   - agentPropose, immediately after creating a TRANSFER draft — transfer
+ *     calldata can't go stale, so finalizing eagerly makes the pending
+ *     request visible in app.safe.global right away (parity with the
+ *     pre-draft flow). The cost: dismissing an already-finalized transfer
+ *     parks its nonce until superseded, as it always did before drafts.
+ *   - POST /transactions/:id/finalize, when the user approves — the lazy
+ *     path SWAPS stay on: their quote (route + min-out) is rebuilt fresh
+ *     here, because a quote built at queue time reverts on-chain (GS013) by
+ *     the time the user signs.
+ */
+import {
+  computeSafeTxHash,
+  getNextSafeNonce,
+  getProtocolKit,
+  proposeToService,
+} from "./service.js";
+import { getAgentAddress } from "./relayer.js";
+import { KIND_BUILDERS, buildSafeTxFromCalls } from "./builders.js";
+import { getRequestByTxId, updateTransaction } from "../supabase/index.js";
+import type { PendingTransaction } from "../../types.js";
+
+/** Swap re-quote failed — the caller should tell the user to re-queue. */
+export class SwapRefreshError extends Error {}
+
+export async function finalizeDraft(tx: PendingTransaction): Promise<PendingTransaction> {
+  // Already finalized (or a user proposal, which is born finalized).
+  if (tx.safeTxHash) return tx;
+  if (!tx.safeTx) throw new Error("Draft has no safeTx payload");
+
+  // Swap drafts re-quote NOW: their calldata was built when the agent queued
+  // the request, and a stale min-out reverts on-chain. Nothing is signed
+  // yet, so rebuilding is free; the user signs the fresh payload.
+  let safeTxBase = tx.safeTx;
+  let display: { to?: string; toTokenAddress?: string } = {};
+  const linkedRequest = await getRequestByTxId(tx.id).catch(() => null);
+  if (linkedRequest?.kind === "swap" && linkedRequest.fromToken && linkedRequest.toToken) {
+    const rebuilt = await KIND_BUILDERS.swap({
+      safeAddress: tx.safeAddress,
+      fromToken: linkedRequest.fromToken,
+      toToken: linkedRequest.toToken,
+      sellAmount: linkedRequest.amount,
+      slippage: linkedRequest.slippage,
+    });
+    if (!rebuilt) {
+      throw new SwapRefreshError(
+        "Swap route could not be refreshed — ask Zhentan to queue the swap again"
+      );
+    }
+    safeTxBase = buildSafeTxFromCalls(rebuilt.calls, 0);
+    display = { to: rebuilt.display.to, toTokenAddress: rebuilt.display.toTokenAddress };
+  }
+
+  const nonce = await getNextSafeNonce(tx.safeAddress);
+  const safeTx = { ...safeTxBase, nonce };
+  const safeTxHash = computeSafeTxHash(tx.safeAddress, safeTx);
+  await updateTransaction(tx.id, {
+    safeTx,
+    safeTxHash,
+    safeNonce: nonce,
+    ...(display.to && { to: display.to }),
+    ...(display.toTokenAddress && { toTokenAddress: display.toTokenAddress }),
+  });
+
+  // Mirror to the Transaction Service at 1/2 so the tx is visible in
+  // app.safe.global. Best-effort: a service outage must not block the flow —
+  // execution assembles signatures locally.
+  try {
+    const protocolKit = await getProtocolKit(tx.safeAddress);
+    const agentSig = await protocolKit.signHash(safeTxHash);
+    await proposeToService({
+      safeAddress: tx.safeAddress,
+      safeTx,
+      safeTxHash,
+      senderAddress: getAgentAddress(),
+      senderSignature: agentSig.data,
+      origin: "Zhentan (agent draft)",
+    });
+  } catch (err) {
+    console.error("Draft finalize: service mirror failed (continuing):", err);
+  }
+
+  return {
+    ...tx,
+    ...(display.to && { to: display.to }),
+    ...(display.toTokenAddress && { toTokenAddress: display.toTokenAddress }),
+    safeTx,
+    safeTxHash,
+    safeNonce: nonce,
+    draft: undefined,
+  };
+}

--- a/server/src/lib/safe/finalizeDraft.ts
+++ b/server/src/lib/safe/finalizeDraft.ts
@@ -5,15 +5,19 @@
  * (it screened the draft, so signing is consistent with the invariant).
  *
  * Called from two places:
- *   - agentPropose, immediately after creating a TRANSFER draft — transfer
- *     calldata can't go stale, so finalizing eagerly makes the pending
- *     request visible in app.safe.global right away (parity with the
- *     pre-draft flow). The cost: dismissing an already-finalized transfer
- *     parks its nonce until superseded, as it always did before drafts.
- *   - POST /transactions/:id/finalize, when the user approves — the lazy
- *     path SWAPS stay on: their quote (route + min-out) is rebuilt fresh
- *     here, because a quote built at queue time reverts on-chain (GS013) by
- *     the time the user signs.
+ *   - agentPropose, immediately after creating an APPROVE-scored draft of
+ *     ANY kind (freshQuote: false — the payload was built seconds ago).
+ *     Eager finalization makes the pending request visible in
+ *     app.safe.global right away, parity with the pre-draft flow. The cost:
+ *     dismissing an already-finalized draft parks its nonce until
+ *     superseded, as it always did before drafts. REVIEW-band swaps skip
+ *     this and stay lazy.
+ *   - POST /transactions/:id/finalize, when the user approves (freshQuote
+ *     defaults true) — SWAP calldata is rebuilt with a fresh quote here,
+ *     because a queue-time quote's min-out reverts on-chain (GS013) by
+ *     signing time. An eager-finalized swap is re-proposed at the SAME
+ *     nonce, superseding its stale service proposal; the user always signs
+ *     the fresh hash.
  */
 import {
   computeSafeTxHash,
@@ -21,6 +25,7 @@ import {
   getProtocolKit,
   proposeToService,
 } from "./service.js";
+import { readSafeNonce } from "./onchain.js";
 import { getAgentAddress } from "./relayer.js";
 import { KIND_BUILDERS, buildSafeTxFromCalls } from "./builders.js";
 import { getRequestByTxId, updateTransaction } from "../supabase/index.js";
@@ -29,24 +34,43 @@ import type { PendingTransaction } from "../../types.js";
 /** Swap re-quote failed — the caller should tell the user to re-queue. */
 export class SwapRefreshError extends Error {}
 
-export async function finalizeDraft(tx: PendingTransaction): Promise<PendingTransaction> {
-  // Already finalized (or a user proposal, which is born finalized).
-  if (tx.safeTxHash) return tx;
+export async function finalizeDraft(
+  tx: PendingTransaction,
+  opts?: {
+    /**
+     * Rebuild swap calldata with a fresh quote (approval-time semantics,
+     * the default). Creation-time callers pass false — the quote was built
+     * seconds ago. A signed transaction is never touched either way.
+     */
+    freshQuote?: boolean;
+  }
+): Promise<PendingTransaction> {
+  const freshQuote = opts?.freshQuote ?? true;
+  // A signed payload is immutable — and a user proposal is born signed.
+  if (tx.userSignature) return tx;
   if (!tx.safeTx) throw new Error("Draft has no safeTx payload");
 
-  // Swap drafts re-quote NOW: their calldata was built when the agent queued
-  // the request, and a stale min-out reverts on-chain. Nothing is signed
-  // yet, so rebuilding is free; the user signs the fresh payload.
+  const linkedRequest = await getRequestByTxId(tx.id).catch(() => null);
+  const swapRequest =
+    linkedRequest?.kind === "swap" && linkedRequest.fromToken && linkedRequest.toToken
+      ? linkedRequest
+      : null;
+
+  // Already finalized and there is nothing to refresh → done. (An
+  // eager-finalized SWAP does get refreshed at approval: its queue-time
+  // quote is stale by now, and re-proposing the fresh payload at the SAME
+  // nonce supersedes the stale service proposal.)
+  if (tx.safeTxHash && (!freshQuote || !swapRequest)) return tx;
+
   let safeTxBase = tx.safeTx;
   let display: { to?: string; toTokenAddress?: string } = {};
-  const linkedRequest = await getRequestByTxId(tx.id).catch(() => null);
-  if (linkedRequest?.kind === "swap" && linkedRequest.fromToken && linkedRequest.toToken) {
+  if (swapRequest && freshQuote) {
     const rebuilt = await KIND_BUILDERS.swap({
       safeAddress: tx.safeAddress,
-      fromToken: linkedRequest.fromToken,
-      toToken: linkedRequest.toToken,
-      sellAmount: linkedRequest.amount,
-      slippage: linkedRequest.slippage,
+      fromToken: swapRequest.fromToken!,
+      toToken: swapRequest.toToken!,
+      sellAmount: swapRequest.amount,
+      slippage: swapRequest.slippage,
     });
     if (!rebuilt) {
       throw new SwapRefreshError(
@@ -57,7 +81,17 @@ export async function finalizeDraft(tx: PendingTransaction): Promise<PendingTran
     display = { to: rebuilt.display.to, toTokenAddress: rebuilt.display.toTokenAddress };
   }
 
-  const nonce = await getNextSafeNonce(tx.safeAddress);
+  // Reuse an already-assigned nonce so the refreshed payload replaces the
+  // stale proposal at the same queue slot — unless the chain has moved past
+  // it while the draft sat (then the slot is gone; take the next free one).
+  let nonce: number;
+  if (tx.safeNonce !== undefined) {
+    const onChainNonce = await readSafeNonce(tx.safeAddress);
+    nonce =
+      tx.safeNonce >= onChainNonce ? tx.safeNonce : await getNextSafeNonce(tx.safeAddress);
+  } else {
+    nonce = await getNextSafeNonce(tx.safeAddress);
+  }
   const safeTx = { ...safeTxBase, nonce };
   const safeTxHash = computeSafeTxHash(tx.safeAddress, safeTx);
   await updateTransaction(tx.id, {

--- a/server/src/lib/safe/kind.ts
+++ b/server/src/lib/safe/kind.ts
@@ -1,0 +1,249 @@
+/**
+ * Kind decoder — classifies any SafeTx payload from its CALLDATA (never from
+ * client-supplied display fields) into a settlement kind. One decode, shared
+ * by risk analysis, deep-analyze, pattern learning and request validation, so
+ * every consumer agrees on what a transaction actually does.
+ *
+ * Extending to a new kind = one case here + one builder entry in builders.ts
+ * + one strategy branch in risk.ts.
+ */
+import {
+  decodeFunctionData,
+  isAddressEqual,
+  maxUint256,
+  type Address,
+  type Hex,
+} from "viem";
+import { decodeMultiSendData } from "@safe-global/protocol-kit";
+
+import {
+  ERC20_TRANSFER_ABI,
+  ERC20_APPROVE_ABI,
+  MULTISEND_CALL_ONLY,
+  KNOWN_ROUTERS,
+} from "../constants.js";
+import type { PendingTransaction, SafeTxData } from "../../types.js";
+
+export interface DecodedCall {
+  to: string;
+  value: bigint;
+  data: Hex;
+}
+
+export type DecodedKind =
+  | {
+      kind: "transfer";
+      recipient: string;
+      /** null = native BNB */
+      tokenAddress: string | null;
+      amountWei: bigint;
+    }
+  | {
+      kind: "swap";
+      router: string;
+      /** Router label from the allowlist, null when the router is unknown. */
+      routerName: string | null;
+      /** null = selling native BNB (value-bearing router call). */
+      sellTokenAddress: string | null;
+      sellAmountWei: bigint;
+      approval: {
+        tokenAddress: string;
+        spender: string;
+        amountWei: bigint;
+        infinite: boolean;
+      } | null;
+    }
+  | {
+      kind: "approval";
+      tokenAddress: string;
+      spender: string;
+      amountWei: bigint;
+      infinite: boolean;
+    }
+  | { kind: "config" }
+  | { kind: "dapp-call"; target: string; selector: string | null }
+  | { kind: "unknown" };
+
+/** Treat approvals at or above half of uint256 max as effectively infinite. */
+const INFINITE_THRESHOLD = maxUint256 / 2n;
+
+function tryDecodeErc20(
+  call: DecodedCall
+): { fn: "transfer" | "approve"; arg0: string; amount: bigint } | null {
+  try {
+    const t = decodeFunctionData({ abi: ERC20_TRANSFER_ABI, data: call.data });
+    const [to, amount] = t.args as readonly [Address, bigint];
+    return { fn: "transfer", arg0: to, amount };
+  } catch {
+    /* not transfer */
+  }
+  try {
+    const a = decodeFunctionData({ abi: ERC20_APPROVE_ABI, data: call.data });
+    const [spender, amount] = a.args as readonly [Address, bigint];
+    return { fn: "approve", arg0: spender, amount };
+  } catch {
+    /* not approve */
+  }
+  return null;
+}
+
+function routerName(address: string): string | null {
+  return KNOWN_ROUTERS[address.toLowerCase()] ?? null;
+}
+
+/** Unwrap a SafeTx into its constituent calls (MultiSend batches flatten). */
+export function unwrapCalls(safeTx: SafeTxData): DecodedCall[] {
+  if (
+    safeTx.operation === 1 &&
+    isAddressEqual(safeTx.to as Address, MULTISEND_CALL_ONLY as Address)
+  ) {
+    try {
+      return decodeMultiSendData(safeTx.data as Hex).map((t) => ({
+        to: t.to,
+        value: BigInt(t.value),
+        data: t.data as Hex,
+      }));
+    } catch {
+      // Fall through — treat as a single opaque call.
+    }
+  }
+  return [
+    { to: safeTx.to, value: BigInt(safeTx.value), data: safeTx.data as Hex },
+  ];
+}
+
+/**
+ * Classify a SafeTx. `safeAddress` distinguishes config self-calls; rows
+ * without a safeTx payload (legacy 4337) return "unknown" and callers fall
+ * back to transfer-shaped behavior.
+ */
+export function decodeSafeTxKind(
+  safeTx: SafeTxData | undefined,
+  safeAddress: string
+): DecodedKind {
+  if (!safeTx) return { kind: "unknown" };
+
+  const calls = unwrapCalls(safeTx);
+  if (calls.length === 0) return { kind: "unknown" };
+
+  // Owner/config management: every call targets the Safe itself (the
+  // wallet-profile transitions; validated separately by validateTransitionTx).
+  if (calls.every((c) => isAddressEqual(c.to as Address, safeAddress as Address))) {
+    return { kind: "config" };
+  }
+
+  // Single call: native transfer / ERC20 transfer / approval / router / dapp.
+  if (calls.length === 1) {
+    const call = calls[0];
+    if (call.data === "0x" || call.data === "0x00") {
+      return {
+        kind: "transfer",
+        recipient: call.to,
+        tokenAddress: null,
+        amountWei: call.value,
+      };
+    }
+    const name = routerName(call.to);
+    if (name !== null) {
+      // Single router call: selling native BNB (value-bearing) or a token
+      // approved in an earlier tx — either way the sell token isn't in this
+      // payload, so it stays null.
+      return {
+        kind: "swap",
+        router: call.to,
+        routerName: name,
+        sellTokenAddress: null,
+        sellAmountWei: call.value,
+        approval: null,
+      };
+    }
+    const erc20 = tryDecodeErc20(call);
+    if (erc20?.fn === "transfer") {
+      return {
+        kind: "transfer",
+        recipient: erc20.arg0,
+        tokenAddress: call.to,
+        amountWei: erc20.amount,
+      };
+    }
+    if (erc20?.fn === "approve") {
+      return {
+        kind: "approval",
+        tokenAddress: call.to,
+        spender: erc20.arg0,
+        amountWei: erc20.amount,
+        infinite: erc20.amount >= INFINITE_THRESHOLD,
+      };
+    }
+    return {
+      kind: "dapp-call",
+      target: call.to,
+      selector: call.data.length >= 10 ? call.data.slice(0, 10) : null,
+    };
+  }
+
+  // Batch: the canonical swap shape is [ERC20 approve, router call] — an
+  // approval whose spender is the router target of a later call.
+  const approvals = calls
+    .map((c) => ({ call: c, erc20: tryDecodeErc20(c) }))
+    .filter((x) => x.erc20?.fn === "approve");
+  const routerCall = calls.find((c) => routerName(c.to) !== null);
+  if (routerCall) {
+    const matching = approvals.find(
+      (a) => a.erc20 && isAddressEqual(a.erc20.arg0 as Address, routerCall.to as Address)
+    );
+    return {
+      kind: "swap",
+      router: routerCall.to,
+      routerName: routerName(routerCall.to),
+      sellTokenAddress: matching ? matching.call.to : null,
+      sellAmountWei: matching ? matching.erc20!.amount : routerCall.value,
+      approval: matching
+        ? {
+            tokenAddress: matching.call.to,
+            spender: matching.erc20!.arg0,
+            amountWei: matching.erc20!.amount,
+            infinite: matching.erc20!.amount >= INFINITE_THRESHOLD,
+          }
+        : null,
+    };
+  }
+
+  // A batch that is entirely ERC20/native transfers is still a transfer for
+  // risk purposes only when it has ONE recipient; otherwise it's a dapp-call
+  // (multi-recipient batches need their own kind before relaxing this).
+  const transfers = calls.map((c) =>
+    c.data === "0x"
+      ? { recipient: c.to, tokenAddress: null as string | null, amountWei: c.value }
+      : (() => {
+          const t = tryDecodeErc20(c);
+          return t?.fn === "transfer"
+            ? { recipient: t.arg0, tokenAddress: c.to as string | null, amountWei: t.amount }
+            : null;
+        })()
+  );
+  if (transfers.every((t) => t !== null)) {
+    const recipients = new Set(transfers.map((t) => t!.recipient.toLowerCase()));
+    if (recipients.size === 1) {
+      const first = transfers[0]!;
+      return {
+        kind: "transfer",
+        recipient: first.recipient,
+        tokenAddress: first.tokenAddress,
+        amountWei: first.amountWei,
+      };
+    }
+  }
+
+  const first = calls.find((c) => c.data !== "0x") ?? calls[0];
+  return {
+    kind: "dapp-call",
+    target: first.to,
+    selector: first.data.length >= 10 ? first.data.slice(0, 10) : null,
+  };
+}
+
+/** Convenience: decode from a stored transaction row. */
+export function decodeTxKind(tx: PendingTransaction): DecodedKind {
+  return decodeSafeTxKind(tx.safeTx, tx.safeAddress);
+}

--- a/server/src/lib/supabase/db.ts
+++ b/server/src/lib/supabase/db.ts
@@ -3,6 +3,7 @@
  * Replaces the readFileSync / writeFileSync pattern across all routes.
  */
 import { supabase } from "./client.js";
+import { decodeTxKind } from "../safe/kind.js";
 import type {
   TransactionRow,
   UserDetailsRow,
@@ -46,6 +47,12 @@ export function rowToTx(row: TransactionRow): PendingTransaction {
     safeTxHash: row.safe_tx_hash ?? undefined,
     safeTx: (row.safe_tx as unknown as PendingTransaction["safeTx"]) ?? undefined,
     safeNonce: row.safe_nonce ?? undefined,
+    // Derived, never stored: only agent-proposed drafts lack a hash — every
+    // user proposal is required to carry one (validateSafeTxProposal), so
+    // this can't drift from the row's actual state. Finalizing (assigning
+    // the nonce + hash) is exactly what ends draft-ness.
+    draft: row.tx_type === "safetx" && !row.safe_tx_hash ? true : undefined,
+    toTokenAddress: row.to_token_address ?? undefined,
     userSignature: row.user_signature ?? undefined,
     userSignatures: row.user_signatures ?? undefined,
     rejectionSignature: row.rejection_signature ?? undefined,
@@ -107,6 +114,7 @@ function txToRow(tx: PendingTransaction): TransactionRow {
     tx_hash: tx.txHash ?? null,
     success: tx.success ?? null,
     screening_disabled: tx.screeningDisabled ?? false,
+    to_token_address: tx.toTokenAddress ?? null,
   };
 }
 
@@ -114,10 +122,14 @@ function rowToRequest(row: RequestRow): QueuedRequest {
   return {
     id: row.id,
     type: row.request_type === "transfer" ? "transfer" : "invoice",
+    kind: row.kind === "swap" ? "swap" : "transfer",
     safeAddress: row.safe_address ?? undefined,
     to: row.to_address ?? "",
     amount: row.amount ?? "",
     token: row.token ?? "",
+    fromToken: row.from_token ?? undefined,
+    toToken: row.to_token ?? undefined,
+    slippage: row.slippage ?? undefined,
     description: row.description ?? undefined,
     invoiceNumber: row.invoice_number ?? undefined,
     issueDate: row.issue_date ?? undefined,
@@ -142,10 +154,14 @@ function requestToRow(req: QueuedRequest): RequestRow {
   return {
     id: req.id,
     request_type: req.type ?? "invoice",
+    kind: req.kind ?? "transfer",
     safe_address: req.safeAddress?.toLowerCase() ?? null,
     to_address: req.to ?? null,
     amount: req.amount ?? null,
     token: req.token ?? null,
+    from_token: req.fromToken ?? null,
+    to_token: req.toToken ?? null,
+    slippage: req.slippage ?? null,
     description: req.description ?? null,
     invoice_number: req.invoiceNumber ?? null,
     issue_date: req.issueDate ?? null,
@@ -986,8 +1002,17 @@ export async function updatePatternsAfterExecution(
   const dayOfWeek = now.getUTCDay();
   const today = now.toISOString().split("T")[0];
 
+  // Swaps and approvals have no payment recipient — `tx.to` is a router or
+  // token contract, and learning it as a recipient would corrupt the trust
+  // profile the risk engine scores real payments against. Token, time,
+  // velocity and daily patterns still learn from every kind.
+  const decoded = decodeTxKind(tx);
+  const hasRecipient = decoded.kind !== "swap" && decoded.kind !== "approval";
+
   await Promise.all([
-    _updateRecipientProfile(safe, tx.to.toLowerCase(), amount, hourUtc, dayOfWeek, now),
+    ...(hasRecipient
+      ? [_updateRecipientProfile(safe, tx.to.toLowerCase(), amount, hourUtc, dayOfWeek, now)]
+      : []),
     _updateTimePattern(safe, hourUtc, dayOfWeek, amount),
     _updateTokenPattern(safe, tx),
     incrementVelocityWindow(safe, "hourly", amount),

--- a/server/src/lib/supabase/db.ts
+++ b/server/src/lib/supabase/db.ts
@@ -245,6 +245,7 @@ export async function updateTransaction(
     riskReasons: "risk_reasons",
     screeningDisabled: "screening_disabled",
     amountUSD: "amount_usd",
+    toTokenAddress: "to_token_address",
   };
 
   const row: Partial<TransactionRow> = {};

--- a/server/src/lib/supabase/types.ts
+++ b/server/src/lib/supabase/types.ts
@@ -46,6 +46,8 @@ export interface TransactionRow {
   user_signatures: { signer: string; data: string }[] | null;
   rejection_signature: string | null;
   confirmations: unknown[] | null;
+  /** Swap rows: the token being bought (analysis target). */
+  to_token_address: string | null;
 }
 
 export interface UserDetailsRow {
@@ -86,10 +88,15 @@ export interface UserSettingsRow {
 export interface RequestRow {
   id: string;
   request_type: string | null;
+  /** Settlement kind: 'transfer' (default) | 'swap'. */
+  kind: string | null;
   safe_address: string | null;
   to_address: string | null;
   amount: string | null;
   token: string | null;
+  from_token: string | null;
+  to_token: string | null;
+  slippage: number | null;
   description: string | null;
   invoice_number: string | null;
   issue_date: string | null;

--- a/server/src/lib/token-fallbacks.ts
+++ b/server/src/lib/token-fallbacks.ts
@@ -133,3 +133,15 @@ export function getTokenFallback(address: string | null | undefined): TokenFallb
   if (!address) return undefined;
   return TOKEN_FALLBACKS[address.toLowerCase()];
 }
+
+/** Reverse lookup: token symbol → contract address (lowercase key of the
+ *  table). Lets the swap builder resolve a BUY token the Safe doesn't hold
+ *  yet — its decimals and metadata are then read on-chain by the quoter.
+ */
+export function findFallbackAddressBySymbol(symbol: string): string | undefined {
+  const sym = symbol.trim().toUpperCase();
+  for (const [address, meta] of Object.entries(TOKEN_FALLBACKS)) {
+    if (meta.symbol.toUpperCase() === sym) return address;
+  }
+  return undefined;
+}

--- a/server/src/risk.ts
+++ b/server/src/risk.ts
@@ -1,4 +1,5 @@
 import type { PendingTransaction } from "./types.js";
+import type { DecodedKind } from "./lib/safe/kind.js";
 
 // ─────────────────────────────────────────────────────────────
 // PatternsFile — assembled by getPatternsForSafe() in db.ts
@@ -129,7 +130,8 @@ export interface RiskResult {
 
 export function analyzeRisk(
   tx: PendingTransaction,
-  patterns: PatternsFile
+  patterns: PatternsFile,
+  decoded?: DecodedKind
 ): RiskResult {
   let riskScore = 0;
   const reasons: string[] = [];
@@ -142,10 +144,49 @@ export function analyzeRisk(
   const dayOfWeek = now.getUTCDay(); // 0=Sun
   const today = now.toISOString().split("T")[0];
 
-  const recipient = patterns.recipients[tx.to.toLowerCase()];
+  // ── 0. Kind-specific scoring ──────────────────────────────
+  // Swaps and standalone approvals have no payment recipient: `tx.to` is a
+  // DEX router or token contract, so recipient trust/history is skipped for
+  // them (it would score the router as an "unknown recipient" and pollute
+  // the verdict). Amount limits, velocity and time checks below still apply.
+  const isSwap = decoded?.kind === "swap";
+  const isApproval = decoded?.kind === "approval";
+
+  if (decoded?.kind === "swap") {
+    if (decoded.routerName === null) {
+      riskScore += 50;
+      reasons.push(`Swap routed through an unrecognized router (${decoded.router})`);
+    } else {
+      reasons.push(`Swap via ${decoded.routerName}`);
+    }
+    if (decoded.approval) {
+      if (decoded.approval.infinite) {
+        riskScore += 30;
+        reasons.push("Swap grants an UNLIMITED token approval to the router");
+      } else if (decoded.approval.amountWei > decoded.sellAmountWei) {
+        riskScore += 15;
+        reasons.push("Swap approves more than the sell amount");
+      }
+    }
+  }
+
+  if (decoded?.kind === "approval") {
+    if (decoded.infinite) {
+      riskScore += 40;
+      reasons.push(`UNLIMITED approval granted to ${decoded.spender}`);
+    } else {
+      riskScore += 15;
+      reasons.push(`Token approval granted to ${decoded.spender}`);
+    }
+  }
+
+  const recipient =
+    isSwap || isApproval ? undefined : patterns.recipients[tx.to.toLowerCase()];
 
   // ── 1. Recipient trust level ──────────────────────────────
-  if (!recipient) {
+  if (isSwap || isApproval) {
+    // No payment recipient — scored by kind above.
+  } else if (!recipient) {
     // First-time recipient — apply the user's configured action
     const action = limits.unknownRecipientAction;
     if (action === "block") {

--- a/server/src/routes/analyze.ts
+++ b/server/src/routes/analyze.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response, type IRouter } from "express";
 import { getTransaction, getLastInReviewTransaction, getRecipientProfile } from "../lib/supabase/index.js";
 import { getSafeAddressFromCallerId } from "../lib/caller.js";
+import { decodeTxKind } from "../lib/safe/kind.js";
 
 const BSC_CHAIN_ID = "56";
 
@@ -175,16 +176,27 @@ export function createAnalyzeRouter(): IRouter {
         return;
       }
 
-      // Fetch recipient profile from DB
-      const profile = tx.safeAddress
-        ? await getRecipientProfile(tx.to.toLowerCase(), tx.safeAddress)
-        : null;
+      // Classify from calldata so each kind scans its actual risk surface:
+      // transfers scan the recipient + sent token; swaps scan the router and
+      // the token being BOUGHT (what the user ends up holding) — the sell
+      // token is already theirs.
+      const decoded = decodeTxKind(tx);
+      const isSwap = decoded.kind === "swap";
 
-      const tokenAddr = (tx.tokenAddress || "").toLowerCase();
+      // Fetch recipient profile from DB (payment kinds only — a router is
+      // not a recipient)
+      const profile =
+        tx.safeAddress && !isSwap && decoded.kind !== "approval"
+          ? await getRecipientProfile(tx.to.toLowerCase(), tx.safeAddress)
+          : null;
+
+      // Swaps: prefer the buy token (stored at proposal time); fall back to
+      // the sell token so pre-refactor rows still get a token scan.
+      const tokenAddr = (
+        (isSwap ? tx.toTokenAddress || tx.tokenAddress : tx.tokenAddress) || ""
+      ).toLowerCase();
       const isKnownStable = KNOWN_STABLECOINS.has(tokenAddr);
 
-      console.log("tokenAddr", tokenAddr);
-      console.log("isKnownStable", isKnownStable);
       // Run external API checks in parallel
       const [addressSecurity, tokenSecurity, honeypot] = await Promise.all([
         checkAddressSecurity(tx.to),
@@ -195,11 +207,31 @@ export function createAnalyzeRouter(): IRouter {
       const allFlags: string[] = [];
       const addrFlags = (addressSecurity as { flags?: string[] }).flags;
       if (addrFlags) allFlags.push(...addrFlags);
-      if (!profile) allFlags.push("Unknown recipient (not in patterns)");
+      if (isSwap) {
+        if (decoded.routerName === null) {
+          allFlags.push(`Unrecognized swap router: ${decoded.router}`);
+        }
+        if (decoded.approval?.infinite) {
+          allFlags.push("Unlimited token approval granted to the router");
+        }
+      } else if (decoded.kind === "approval") {
+        if (decoded.infinite) allFlags.push("Unlimited token approval");
+      } else if (!profile) {
+        allFlags.push("Unknown recipient (not in patterns)");
+      }
 
       res.json({
         txId: id,
         callerId,
+        kind: decoded.kind,
+        ...(isSwap && {
+          swap: {
+            router: decoded.router,
+            routerName: decoded.routerName,
+            analyzedToken: tokenAddr || null,
+            analyzedTokenIs: tx.toTokenAddress ? "buy-token" : "sell-token",
+          },
+        }),
         to: tx.to,
         amount: tx.amount,
         token: tx.token,

--- a/server/src/routes/queue.ts
+++ b/server/src/routes/queue.ts
@@ -16,6 +16,7 @@ import { notify } from "../notifications/index.js";
 import { SAFE_ABI, MULTISEND_CALL_ONLY } from "../lib/constants.js";
 import { decodeMultiSendData } from "@safe-global/protocol-kit";
 import { classifyProfile, type WalletState } from "../lib/safe/profiles.js";
+import { decodeSafeTxKind } from "../lib/safe/kind.js";
 import {
   computeSafeTxHash,
   recoverSafeTxSigner,
@@ -498,7 +499,12 @@ export function createQueueRouter(): IRouter {
       let risk;
       try {
         const patterns = await getPatternsForSafe(pendingTx.safeAddress ?? "");
-        risk = analyzeRisk(pendingTx, patterns);
+        // Classify from the SIGNED calldata so swaps/approvals are scored by
+        // their own strategy instead of as a "transfer to the router".
+        const decoded = isSafeTx
+          ? decodeSafeTxKind(pendingTx.safeTx, pendingTx.safeAddress)
+          : undefined;
+        risk = analyzeRisk(pendingTx, patterns, decoded);
       } catch (err) {
         const msg = err instanceof Error ? err.message : "Unknown error";
         console.error("Risk analysis failed:", msg);

--- a/server/src/routes/requests.ts
+++ b/server/src/routes/requests.ts
@@ -1,9 +1,10 @@
 import { Router, Request, Response, type IRouter } from "express";
-import type { RequestStatus, RequestType, QueuedRequest, PendingTransaction } from "../types.js";
-import { getRequests, getRequest, createRequest, updateRequest, updateTransaction, getPatternsForSafe } from "../lib/supabase/index.js";
+import type { RequestStatus, RequestType, RequestKind, QueuedRequest, PendingTransaction } from "../types.js";
+import { getRequests, getRequest, createRequest, updateRequest, updateTransaction, getTransaction, getPatternsForSafe } from "../lib/supabase/index.js";
 import { getSafeAddressFromCallerId } from "../lib/caller.js";
 import { analyzeRisk } from "../risk.js";
 import { agentProposeFromRequest } from "../lib/safe/agentPropose.js";
+import type { DecodedKind } from "../lib/safe/kind.js";
 import { randomUUID } from "crypto";
 
 const VALID_STATUSES: RequestStatus[] = [
@@ -14,6 +15,7 @@ const VALID_STATUSES: RequestStatus[] = [
 ];
 
 const VALID_TYPES: RequestType[] = ["invoice", "transfer"];
+const VALID_KINDS: RequestKind[] = ["transfer", "swap"];
 
 /**
  * Requests — incoming payment asks routed through the agent: parsed invoices
@@ -27,15 +29,36 @@ export function createRequestsRouter(): IRouter {
   router.post("/", async (req: Request, res: Response) => {
     try {
       const body = req.body ?? {};
-      const { type, to, amount, token, description, invoiceNumber, issueDate, dueDate, billedFrom, billedTo, services, riskScore, riskNotes, sourceChannel } = body;
+      const { type, kind, to, amount, token, fromToken, toToken, slippage, description, invoiceNumber, issueDate, dueDate, billedFrom, billedTo, services, riskScore, riskNotes, sourceChannel } = body;
 
-      if (!to || !amount || !token) {
-        res.status(400).json({ error: "Missing required fields: to, amount, token" });
+      if (kind !== undefined && !VALID_KINDS.includes(kind)) {
+        res.status(400).json({ error: `Invalid kind: ${kind}. Valid: ${VALID_KINDS.join(", ")}` });
         return;
       }
+      const requestKind: RequestKind = kind ?? "transfer";
 
       if (type !== undefined && !VALID_TYPES.includes(type)) {
         res.status(400).json({ error: `Invalid type: ${type}. Valid: ${VALID_TYPES.join(", ")}` });
+        return;
+      }
+
+      // `kind` is settlement, `type` is presentation: an invoice is always a
+      // transfer with billing metadata — there is no such thing as paying an
+      // invoice with a swap.
+      if (requestKind === "swap") {
+        const hasInvoiceMeta = Boolean(
+          type === "invoice" || invoiceNumber || billedFrom || billedTo || (services && services.length) || dueDate
+        );
+        if (hasInvoiceMeta) {
+          res.status(400).json({ error: "Swap requests cannot carry invoice fields — invoices settle as transfers" });
+          return;
+        }
+        if (!fromToken || !toToken || !amount) {
+          res.status(400).json({ error: "Swap requests require fromToken, toToken, amount (sell amount)" });
+          return;
+        }
+      } else if (!to || !amount || !token) {
+        res.status(400).json({ error: "Missing required fields: to, amount, token" });
         return;
       }
 
@@ -71,11 +94,25 @@ export function createRequestsRouter(): IRouter {
         try {
           const patterns = await getPatternsForSafe(safeAddress);
           const synthTx = {
-            to,
+            to: to ?? "",
             amount: String(amount),
-            token,
+            token: token ?? fromToken,
           } as unknown as PendingTransaction;
-          const risk = analyzeRisk(synthTx, patterns);
+          // Swap fallback scoring matches what the swap builder produces by
+          // construction: PancakeSwap route, exact-amount approval — so only
+          // the amount/velocity/time factors contribute.
+          const syntheticDecoded: DecodedKind | undefined =
+            requestKind === "swap"
+              ? {
+                  kind: "swap",
+                  router: "",
+                  routerName: "PancakeSwap",
+                  sellTokenAddress: null,
+                  sellAmountWei: 0n,
+                  approval: null,
+                }
+              : undefined;
+          const risk = analyzeRisk(synthTx, patterns, syntheticDecoded);
           finalRiskScore = risk.riskScore;
           if (!finalRiskNotes) {
             finalRiskNotes = `${risk.verdict}: ${risk.reasons.join("; ")}`;
@@ -88,38 +125,65 @@ export function createRequestsRouter(): IRouter {
         }
       }
 
-      // Auto-approve path: when the request scores APPROVE against the user's
-      // threshold, the agent pre-builds + pre-signs the transfer (1-of-2), so
-      // the user just signs to execute. Anything else stays a plain queued
-      // request carrying its risk score for the user to review. Best-effort —
-      // if the pre-sign can't be built, the request still queues normally.
-      let presignedTxId: string | undefined;
+      // Draft path: the agent builds the SafeTx as a DRAFT row (no nonce, no
+      // signatures — see agentPropose.ts) the user completes with one
+      // signature. Transfers get a draft only when the score clears the
+      // user's APPROVE threshold (riskier ones fall back to the client's own
+      // propose flow, which re-screens). Swaps get a draft whenever the score
+      // is below the BLOCK threshold — the client has no swap builder to fall
+      // back to, and the user still explicitly signs. Best-effort: if the
+      // draft can't be built, the request queues normally.
+      let draftTxId: string | undefined;
       try {
         const patterns = await getPatternsForSafe(safeAddress);
-        const approveThreshold = patterns.globalLimits.riskThresholdApprove;
-        const approvable = finalRiskScore != null && finalRiskScore < approveThreshold;
-        if (approvable) {
-          presignedTxId =
+        const { riskThresholdApprove, riskThresholdBlock } = patterns.globalLimits;
+        const score = finalRiskScore ?? 100;
+        const shouldDraft =
+          requestKind === "swap" ? score < riskThresholdBlock : score < riskThresholdApprove;
+        if (shouldDraft) {
+          draftTxId =
             (await agentProposeFromRequest({
+              kind: requestKind,
               safeAddress,
               to,
               amount: String(amount),
               token,
-              riskScore: finalRiskScore!,
+              fromToken,
+              toToken,
+              sellAmount: String(amount),
+              slippage: slippage != null ? Number(slippage) : undefined,
+              riskScore: finalRiskScore ?? 0,
+              riskVerdict:
+                score < riskThresholdApprove ? "APPROVE" : "REVIEW",
               riskReasons: finalRiskNotes ? [finalRiskNotes] : [],
             })) ?? undefined;
         }
       } catch (err) {
-        console.error("Request pre-sign check failed (queuing normally):", err);
+        console.error("Request draft build failed (queuing normally):", err);
       }
+
+      // Swap display fields: the draft knows the router + label; a draft-less
+      // swap request (build failed) shows the pair label with no recipient.
+      const draftTx = draftTxId ? await getTransaction(draftTxId).catch(() => null) : null;
+      const displayTo = requestKind === "swap" ? draftTx?.to ?? "" : to;
+      const displayToken =
+        requestKind === "swap"
+          ? draftTx?.token ?? `${String(fromToken).toUpperCase()} → ${String(toToken).toUpperCase()}`
+          : token;
 
       const request: QueuedRequest = {
         id: `req-${randomUUID().slice(0, 8)}`,
         type: requestType,
+        kind: requestKind,
         safeAddress,
-        to,
+        to: displayTo,
         amount: String(amount),
-        token,
+        token: displayToken,
+        ...(requestKind === "swap" && {
+          fromToken: String(fromToken),
+          toToken: String(toToken),
+          ...(slippage != null && { slippage: Number(slippage) }),
+        }),
         description: description ?? undefined,
         invoiceNumber: invoiceNumber ?? undefined,
         issueDate: issueDate ?? undefined,
@@ -131,23 +195,24 @@ export function createRequestsRouter(): IRouter {
         riskNotes: finalRiskNotes,
         sourceChannel: sourceChannel ?? "unknown",
         queuedAt: new Date().toISOString(),
-        // A pre-signed tx id on a still-queued request signals the client to
-        // show "Zhentan signed — sign to execute" instead of "approve to pay".
+        // A draft tx id on a still-queued request signals the client to show
+        // "Zhentan prepared this — sign to execute" instead of "approve to pay".
         status: "queued",
-        txId: presignedTxId,
+        txId: draftTxId,
       };
 
       console.log(`Queueing request ${request.id} for Safe ${safeAddress}:`, {
         type: request.type,
+        kind: request.kind,
         to: request.to,
         amount: request.amount,
         token: request.token,
         riskScore: request.riskScore,
         riskNotes: request.riskNotes,
-        presignedTxId: request.txId,
+        draftTxId: request.txId,
       });
       await createRequest(request);
-      res.status(201).json({ status: "queued", id: request.id, type: request.type, to: request.to, amount: request.amount, token: request.token, ...(presignedTxId && { txId: presignedTxId, presigned: true }) });
+      res.status(201).json({ status: "queued", id: request.id, type: request.type, kind: request.kind, to: request.to, amount: request.amount, token: request.token, ...(draftTxId && { txId: draftTxId, presigned: true }) });
     } catch (err) {
       const message = err instanceof Error ? err.message : "Unknown error";
       res.status(500).json({ error: message });

--- a/server/src/routes/requests.ts
+++ b/server/src/routes/requests.ts
@@ -99,14 +99,15 @@ export function createRequestsRouter(): IRouter {
             token: token ?? fromToken,
           } as unknown as PendingTransaction;
           // Swap fallback scoring matches what the swap builder produces by
-          // construction: PancakeSwap route, exact-amount approval — so only
-          // the amount/velocity/time factors contribute.
+          // construction: a known router (LI.FI first, PancakeSwap fallback)
+          // and an exact-amount approval — so only the amount/velocity/time
+          // factors contribute.
           const syntheticDecoded: DecodedKind | undefined =
             requestKind === "swap"
               ? {
                   kind: "swap",
                   router: "",
-                  routerName: "PancakeSwap",
+                  routerName: "LI.FI / PancakeSwap",
                   sellTokenAddress: null,
                   sellAmountWei: 0n,
                   approval: null,

--- a/server/src/routes/requests.ts
+++ b/server/src/routes/requests.ts
@@ -81,49 +81,56 @@ export function createRequestsRouter(): IRouter {
       const hasInvoiceFields = Boolean(invoiceNumber || billedFrom || billedTo || (services && services.length) || dueDate);
       const requestType: RequestType = type ?? (hasInvoiceFields ? "invoice" : "transfer");
 
-      // Risk: the agent's own assessment wins. Only when it omits a score do we
-      // fall back to the same rules engine that scores live transactions, so a
-      // request never ends up without a score for the dashboard.
-      let finalRiskScore: number | undefined =
+      // Risk: the server engine ALWAYS scores the behavioral factors it owns
+      // (recipient history, amounts, velocity, time) — the same deterministic
+      // rules that score live transactions. The agent's score is advisory
+      // context the engine can't see (invoice anomalies, social-engineering
+      // smell): it can only RAISE the engine's score, never lower or replace
+      // it. An LLM hand-applying the rules table drifts (e.g. scoring a
+      // well-known recipient as unknown) — the engine must win on its turf.
+      const agentScore: number | undefined =
         riskScore != null && Number.isFinite(Number(riskScore))
           ? Math.max(0, Math.min(100, Math.round(Number(riskScore))))
           : undefined;
+
+      let finalRiskScore: number | undefined = agentScore;
       let finalRiskNotes: string | undefined = riskNotes ?? undefined;
 
-      if (finalRiskScore == null) {
-        try {
-          const patterns = await getPatternsForSafe(safeAddress);
-          const synthTx = {
-            to: to ?? "",
-            amount: String(amount),
-            token: token ?? fromToken,
-          } as unknown as PendingTransaction;
-          // Swap fallback scoring matches what the swap builder produces by
-          // construction: a known router (LI.FI first, PancakeSwap fallback)
-          // and an exact-amount approval — so only the amount/velocity/time
-          // factors contribute.
-          const syntheticDecoded: DecodedKind | undefined =
-            requestKind === "swap"
-              ? {
-                  kind: "swap",
-                  router: "",
-                  routerName: "LI.FI / PancakeSwap",
-                  sellTokenAddress: null,
-                  sellAmountWei: 0n,
-                  approval: null,
-                }
-              : undefined;
-          const risk = analyzeRisk(synthTx, patterns, syntheticDecoded);
-          finalRiskScore = risk.riskScore;
-          if (!finalRiskNotes) {
-            finalRiskNotes = `${risk.verdict}: ${risk.reasons.join("; ")}`;
-          }
-        } catch (err) {
-          console.error(
-            "Request risk scoring failed:",
-            err instanceof Error ? err.message : err
-          );
-        }
+      try {
+        const patterns = await getPatternsForSafe(safeAddress);
+        const synthTx = {
+          to: to ?? "",
+          amount: String(amount),
+          token: token ?? fromToken,
+        } as unknown as PendingTransaction;
+        // Swap scoring matches what the swap builder produces by
+        // construction: a known router (LI.FI first, PancakeSwap fallback)
+        // and an exact-amount approval — so only the amount/velocity/time
+        // factors contribute.
+        const syntheticDecoded: DecodedKind | undefined =
+          requestKind === "swap"
+            ? {
+                kind: "swap",
+                router: "",
+                routerName: "LI.FI / PancakeSwap",
+                sellTokenAddress: null,
+                sellAmountWei: 0n,
+                approval: null,
+              }
+            : undefined;
+        const engine = analyzeRisk(synthTx, patterns, syntheticDecoded);
+        finalRiskScore = Math.max(engine.riskScore, agentScore ?? 0);
+        const engineNotes = `${engine.verdict}: ${engine.reasons.join("; ")}`;
+        finalRiskNotes =
+          agentScore != null && agentScore > engine.riskScore && riskNotes
+            ? `${engineNotes} | Agent: ${riskNotes}`
+            : engineNotes;
+      } catch (err) {
+        // Engine unavailable — the agent's score (if any) stands alone.
+        console.error(
+          "Request risk scoring failed:",
+          err instanceof Error ? err.message : err
+        );
       }
 
       // Draft path: the agent builds the SafeTx as a DRAFT row (no nonce, no

--- a/server/src/routes/transactions.ts
+++ b/server/src/routes/transactions.ts
@@ -371,11 +371,12 @@ export function createTransactionsRouter(): IRouter {
     }
   });
 
-  // POST /transactions/:id/finalize — assign the Safe nonce and compute the
-  // EIP-712 hash for an agent-proposed DRAFT so the user can sign it. Nonce
-  // assignment is deferred to this moment (not draft creation) so a dismissed
-  // draft never parks a nonce that would block the queue tail. Idempotent —
-  // a second call returns the already-finalized transaction.
+  // POST /transactions/:id/finalize — make an agent-proposed DRAFT signable:
+  // assign the Safe nonce, compute the EIP-712 hash, mirror at 1/2. Swap
+  // drafts additionally get their quote rebuilt here — including
+  // eager-finalized ones, re-proposed fresh at the same nonce — so the user
+  // always signs a current route/min-out (see finalizeDraft). Idempotent for
+  // signed or non-swap finalized rows.
   router.post("/:id/finalize", async (req: Request, res: Response) => {
     try {
       const { id } = req.params;

--- a/server/src/routes/transactions.ts
+++ b/server/src/routes/transactions.ts
@@ -11,7 +11,9 @@ import {
   updateTransaction,
   getUserDetails,
   syncLinkedRequest,
+  getRequestByTxId,
 } from "../lib/supabase/index.js";
+import { KIND_BUILDERS, buildSafeTxFromCalls } from "../lib/safe/builders.js";
 import { getSafeAddressFromCallerId } from "../lib/caller.js";
 import { notify } from "../notifications/index.js";
 import { fetchTransfers, type ZerionHistoryItem } from "../lib/zerion.js";
@@ -405,12 +407,55 @@ export function createTransactionsRouter(): IRouter {
         return;
       }
 
-      const nonce = await getNextSafeNonce(tx.safeAddress);
-      const safeTx = { ...tx.safeTx, nonce };
-      const safeTxHash = computeSafeTxHash(tx.safeAddress, safeTx);
-      await updateTransaction(id, { safeTx, safeTxHash, safeNonce: nonce });
+      // Swap drafts re-quote NOW: their calldata (route + min-out) was built
+      // when the agent queued the request, and a quote goes stale between
+      // then and the user's approval — a stale min-out reverts on-chain
+      // (GS013). Nothing is signed yet, so rebuilding is free; the user
+      // signs the fresh payload this endpoint returns.
+      let safeTxBase = tx.safeTx;
+      let display: { to?: string; toTokenAddress?: string } = {};
+      const linkedRequest = await getRequestByTxId(id).catch(() => null);
+      if (linkedRequest?.kind === "swap" && linkedRequest.fromToken && linkedRequest.toToken) {
+        const rebuilt = await KIND_BUILDERS.swap({
+          safeAddress: tx.safeAddress,
+          fromToken: linkedRequest.fromToken,
+          toToken: linkedRequest.toToken,
+          sellAmount: linkedRequest.amount,
+          slippage: linkedRequest.slippage,
+        });
+        if (!rebuilt) {
+          res.status(502).json({
+            error: "Swap route could not be refreshed — ask Zhentan to queue the swap again",
+          });
+          return;
+        }
+        safeTxBase = buildSafeTxFromCalls(rebuilt.calls, 0);
+        display = {
+          to: rebuilt.display.to,
+          toTokenAddress: rebuilt.display.toTokenAddress,
+        };
+      }
 
-      const finalized = { ...tx, safeTx, safeTxHash, safeNonce: nonce, draft: undefined };
+      const nonce = await getNextSafeNonce(tx.safeAddress);
+      const safeTx = { ...safeTxBase!, nonce };
+      const safeTxHash = computeSafeTxHash(tx.safeAddress, safeTx);
+      await updateTransaction(id, {
+        safeTx,
+        safeTxHash,
+        safeNonce: nonce,
+        ...(display.to && { to: display.to }),
+        ...(display.toTokenAddress && { toTokenAddress: display.toTokenAddress }),
+      });
+
+      const finalized = {
+        ...tx,
+        ...(display.to && { to: display.to }),
+        ...(display.toTokenAddress && { toTokenAddress: display.toTokenAddress }),
+        safeTx,
+        safeTxHash,
+        safeNonce: nonce,
+        draft: undefined,
+      };
       res.json({ transaction: { ...finalized, status: getTransactionStatus(finalized) } });
     } catch (err) {
       const message = err instanceof Error ? err.message : "Unknown error";

--- a/server/src/routes/transactions.ts
+++ b/server/src/routes/transactions.ts
@@ -2,14 +2,8 @@ import { Router, Request, Response, type IRouter } from "express";
 import type { Hex } from "viem";
 import type { TransactionWithStatus } from "../types.js";
 import { getTransactionStatus } from "../lib/format.js";
-import {
-  recoverSafeTxSigner,
-  computeSafeTxHash,
-  getNextSafeNonce,
-  getProtocolKit,
-  getApiKit,
-  proposeToService,
-} from "../lib/safe/service.js";
+import { recoverSafeTxSigner, getApiKit } from "../lib/safe/service.js";
+import { finalizeDraft, SwapRefreshError } from "../lib/safe/finalizeDraft.js";
 import { getAgentAddress } from "../lib/safe/relayer.js";
 import {
   getTransactionsByAddress,
@@ -18,9 +12,7 @@ import {
   updateTransaction,
   getUserDetails,
   syncLinkedRequest,
-  getRequestByTxId,
 } from "../lib/supabase/index.js";
-import { KIND_BUILDERS, buildSafeTxFromCalls } from "../lib/safe/builders.js";
 import { getSafeAddressFromCallerId } from "../lib/caller.js";
 import { notify } from "../notifications/index.js";
 import { fetchTransfers, type ZerionHistoryItem } from "../lib/zerion.js";
@@ -408,83 +400,16 @@ export function createTransactionsRouter(): IRouter {
         res.status(403).json({ error: "Forbidden" });
         return;
       }
-      if (tx.safeTxHash) {
-        // Already finalized (or a user proposal, which is born finalized).
-        res.json({ transaction: { ...tx, status: getTransactionStatus(tx) } });
-        return;
-      }
-
-      // Swap drafts re-quote NOW: their calldata (route + min-out) was built
-      // when the agent queued the request, and a quote goes stale between
-      // then and the user's approval — a stale min-out reverts on-chain
-      // (GS013). Nothing is signed yet, so rebuilding is free; the user
-      // signs the fresh payload this endpoint returns.
-      let safeTxBase = tx.safeTx;
-      let display: { to?: string; toTokenAddress?: string } = {};
-      const linkedRequest = await getRequestByTxId(id).catch(() => null);
-      if (linkedRequest?.kind === "swap" && linkedRequest.fromToken && linkedRequest.toToken) {
-        const rebuilt = await KIND_BUILDERS.swap({
-          safeAddress: tx.safeAddress,
-          fromToken: linkedRequest.fromToken,
-          toToken: linkedRequest.toToken,
-          sellAmount: linkedRequest.amount,
-          slippage: linkedRequest.slippage,
-        });
-        if (!rebuilt) {
-          res.status(502).json({
-            error: "Swap route could not be refreshed — ask Zhentan to queue the swap again",
-          });
+      try {
+        const finalized = await finalizeDraft(tx);
+        res.json({ transaction: { ...finalized, status: getTransactionStatus(finalized) } });
+      } catch (err) {
+        if (err instanceof SwapRefreshError) {
+          res.status(502).json({ error: err.message });
           return;
         }
-        safeTxBase = buildSafeTxFromCalls(rebuilt.calls, 0);
-        display = {
-          to: rebuilt.display.to,
-          toTokenAddress: rebuilt.display.toTokenAddress,
-        };
+        throw err;
       }
-
-      const nonce = await getNextSafeNonce(tx.safeAddress);
-      const safeTx = { ...safeTxBase!, nonce };
-      const safeTxHash = computeSafeTxHash(tx.safeAddress, safeTx);
-      await updateTransaction(id, {
-        safeTx,
-        safeTxHash,
-        safeNonce: nonce,
-        ...(display.to && { to: display.to }),
-        ...(display.toTokenAddress && { toTokenAddress: display.toTokenAddress }),
-      });
-
-      // Mirror to the Transaction Service at 1/2 — the agent proposes with
-      // its own signature (it screened this draft, so signing is consistent
-      // with the invariant), making the tx visible in app.safe.global from
-      // the moment the user starts signing, exactly like the pre-draft flow.
-      // Best-effort: a service outage must not block signing — execution
-      // assembles signatures locally.
-      try {
-        const protocolKit = await getProtocolKit(tx.safeAddress);
-        const agentSig = await protocolKit.signHash(safeTxHash);
-        await proposeToService({
-          safeAddress: tx.safeAddress,
-          safeTx,
-          safeTxHash,
-          senderAddress: getAgentAddress(),
-          senderSignature: agentSig.data,
-          origin: "Zhentan (agent draft)",
-        });
-      } catch (err) {
-        console.error("Draft finalize: service mirror failed (continuing):", err);
-      }
-
-      const finalized = {
-        ...tx,
-        ...(display.to && { to: display.to }),
-        ...(display.toTokenAddress && { toTokenAddress: display.toTokenAddress }),
-        safeTx,
-        safeTxHash,
-        safeNonce: nonce,
-        draft: undefined,
-      };
-      res.json({ transaction: { ...finalized, status: getTransactionStatus(finalized) } });
     } catch (err) {
       const message = err instanceof Error ? err.message : "Unknown error";
       res.status(500).json({ error: message });

--- a/server/src/routes/transactions.ts
+++ b/server/src/routes/transactions.ts
@@ -2,7 +2,7 @@ import { Router, Request, Response, type IRouter } from "express";
 import type { Hex } from "viem";
 import type { TransactionWithStatus } from "../types.js";
 import { getTransactionStatus } from "../lib/format.js";
-import { recoverSafeTxSigner } from "../lib/safe/service.js";
+import { recoverSafeTxSigner, computeSafeTxHash, getNextSafeNonce } from "../lib/safe/service.js";
 import { getAgentAddress } from "../lib/safe/relayer.js";
 import {
   getTransactionsByAddress,
@@ -206,6 +206,7 @@ export function createTransactionsRouter(): IRouter {
           .filter(
             (t) =>
               t.txType === "safetx" &&
+              !!t.safeTxHash && // drafts have no hash to reconcile by
               !t.txHash &&
               (!t.rejected || t.rejectReason?.startsWith("Superseded:"))
           )
@@ -270,6 +271,7 @@ export function createTransactionsRouter(): IRouter {
           (t) =>
             !t.txHash &&
             !t.txKind && // config rows are not transfers — never fold one into a Zerion send
+            !t.draft && // an unsigned draft can't be the source of an on-chain send
             (t.status === "pending" ||
               t.status === "in_review" ||
               t.status === "confirming") &&
@@ -368,11 +370,59 @@ export function createTransactionsRouter(): IRouter {
     }
   });
 
+  // POST /transactions/:id/finalize — assign the Safe nonce and compute the
+  // EIP-712 hash for an agent-proposed DRAFT so the user can sign it. Nonce
+  // assignment is deferred to this moment (not draft creation) so a dismissed
+  // draft never parks a nonce that would block the queue tail. Idempotent —
+  // a second call returns the already-finalized transaction.
+  router.post("/:id/finalize", async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      const tx = await getTransaction(id);
+      if (!tx) {
+        res.status(404).json({ error: `Transaction not found: ${id}` });
+        return;
+      }
+      if (tx.txType !== "safetx" || !tx.safeTx) {
+        res.status(400).json({ error: "Not a SafeTx" });
+        return;
+      }
+      if (tx.executedAt || tx.rejected) {
+        res.status(409).json({ error: "Transaction already resolved" });
+        return;
+      }
+      // Ownership: client calls carry req.user; the tx must be theirs.
+      if (
+        req.user &&
+        tx.safeAddress.toLowerCase() !== req.user.safe_address.toLowerCase()
+      ) {
+        res.status(403).json({ error: "Forbidden" });
+        return;
+      }
+      if (tx.safeTxHash) {
+        // Already finalized (or a user proposal, which is born finalized).
+        res.json({ transaction: { ...tx, status: getTransactionStatus(tx) } });
+        return;
+      }
+
+      const nonce = await getNextSafeNonce(tx.safeAddress);
+      const safeTx = { ...tx.safeTx, nonce };
+      const safeTxHash = computeSafeTxHash(tx.safeAddress, safeTx);
+      await updateTransaction(id, { safeTx, safeTxHash, safeNonce: nonce });
+
+      const finalized = { ...tx, safeTx, safeTxHash, safeNonce: nonce, draft: undefined };
+      res.json({ transaction: { ...finalized, status: getTransactionStatus(finalized) } });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unknown error";
+      res.status(500).json({ error: message });
+    }
+  });
+
   // POST /transactions/:id/sign — the user adds their signature to an
-  // agent-proposed (pre-signed, 1-of-2) tx, then the relayer executes it. This
-  // is the completion half of the auto-approve flow: the agent already
-  // contributed its co-signature at request time, so the user's one signature
-  // reaches the threshold and the agent EOA relays execTransaction.
+  // agent-proposed tx, then the relayer executes it. This is the completion
+  // half of the request draft flow: the draft was finalized above (nonce +
+  // hash), the user's signature is added here, and the agent co-signs at
+  // execution time — it screened the request when it built the draft.
   router.post("/:id/sign", async (req: Request, res: Response) => {
     try {
       const { id } = req.params;
@@ -384,6 +434,12 @@ export function createTransactionsRouter(): IRouter {
       const tx = await getTransaction(id);
       if (!tx) {
         res.status(404).json({ error: `Transaction not found: ${id}` });
+        return;
+      }
+      if (tx.draft && !tx.safeTxHash) {
+        res.status(409).json({
+          error: "Draft not finalized — call /transactions/:id/finalize first",
+        });
         return;
       }
       if (tx.txType !== "safetx" || !tx.safeTxHash) {

--- a/server/src/routes/transactions.ts
+++ b/server/src/routes/transactions.ts
@@ -2,7 +2,14 @@ import { Router, Request, Response, type IRouter } from "express";
 import type { Hex } from "viem";
 import type { TransactionWithStatus } from "../types.js";
 import { getTransactionStatus } from "../lib/format.js";
-import { recoverSafeTxSigner, computeSafeTxHash, getNextSafeNonce } from "../lib/safe/service.js";
+import {
+  recoverSafeTxSigner,
+  computeSafeTxHash,
+  getNextSafeNonce,
+  getProtocolKit,
+  getApiKit,
+  proposeToService,
+} from "../lib/safe/service.js";
 import { getAgentAddress } from "../lib/safe/relayer.js";
 import {
   getTransactionsByAddress,
@@ -447,6 +454,27 @@ export function createTransactionsRouter(): IRouter {
         ...(display.toTokenAddress && { toTokenAddress: display.toTokenAddress }),
       });
 
+      // Mirror to the Transaction Service at 1/2 — the agent proposes with
+      // its own signature (it screened this draft, so signing is consistent
+      // with the invariant), making the tx visible in app.safe.global from
+      // the moment the user starts signing, exactly like the pre-draft flow.
+      // Best-effort: a service outage must not block signing — execution
+      // assembles signatures locally.
+      try {
+        const protocolKit = await getProtocolKit(tx.safeAddress);
+        const agentSig = await protocolKit.signHash(safeTxHash);
+        await proposeToService({
+          safeAddress: tx.safeAddress,
+          safeTx,
+          safeTxHash,
+          senderAddress: getAgentAddress(),
+          senderSignature: agentSig.data,
+          origin: "Zhentan (agent draft)",
+        });
+      } catch (err) {
+        console.error("Draft finalize: service mirror failed (continuing):", err);
+      }
+
       const finalized = {
         ...tx,
         ...(display.to && { to: display.to }),
@@ -530,6 +558,16 @@ export function createTransactionsRouter(): IRouter {
       syncLinkedRequest(id, { status: "approved" }).catch((err) =>
         console.error("syncLinkedRequest (approved) failed:", err)
       );
+      // Mirror the user's confirmation to the Transaction Service (the agent
+      // proposed this draft at finalize, so the service is missing exactly
+      // this signature). Best-effort — execution assembles locally.
+      getApiKit()
+        .confirmTransaction(tx.safeTxHash, userSignature)
+        .catch((err) => {
+          if (!/already/i.test(String(err))) {
+            console.error("Draft sign: service confirm failed (continuing):", err);
+          }
+        });
 
       // Execute via the relayer (agent re-signs its part + the user's sig → n/n).
       const port = Number(process.env.PORT) || 3001;

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -83,6 +83,15 @@ export interface PendingTransaction {
   userSignatures?: { signer: string; data: string }[];
   /** Pre-signed empty tx at the same nonce, used to cancel on reject. */
   rejectionSignature?: string;
+  /**
+   * Agent-proposed row awaiting the user's decision. Drafts carry a safeTx
+   * with a placeholder nonce and NO safeTxHash — the nonce is assigned and
+   * the hash computed only when the user finalizes to sign, so dismissing a
+   * draft never parks a Safe nonce.
+   */
+  draft?: boolean;
+  /** Swap rows: the token being bought (the actual risk surface for analysis). */
+  toTokenAddress?: string;
   proposedAt: string;
   executedAt?: string;
   executedBy?: string;
@@ -121,6 +130,13 @@ export type RequestStatus = "queued" | "approved" | "executed" | "rejected";
 /** 'invoice' = parsed invoice document; 'transfer' = general transaction instruction */
 export type RequestType = "invoice" | "transfer";
 
+/**
+ * How a request SETTLES on-chain, orthogonal to `type` (which is
+ * presentation: an invoice is a transfer with billing metadata). Defaults to
+ * "transfer"; invoices are always transfers.
+ */
+export type RequestKind = "transfer" | "swap";
+
 export interface InvoiceService {
   description: string;
   qty: number;
@@ -142,11 +158,19 @@ export interface InvoiceParty {
 export interface QueuedRequest {
   id: string;
   type: RequestType;
+  /** Settlement kind — absent means "transfer" (all pre-kind rows). */
+  kind?: RequestKind;
   /** Owner Safe address — requests are scoped per-Safe. */
   safeAddress?: string;
   to: string;
   amount: string;
   token: string;
+  /** Swap requests: sell-token symbol. */
+  fromToken?: string;
+  /** Swap requests: buy-token symbol. */
+  toToken?: string;
+  /** Swap requests: slippage as a fraction (0.005 = 0.5%). */
+  slippage?: number;
   /** Free-text instruction/summary from the agent (e.g. the user's original ask). */
   description?: string;
   invoiceNumber?: string;

--- a/server/supabase/migrations/20260731090000_tx_kinds.sql
+++ b/server/supabase/migrations/20260731090000_tx_kinds.sql
@@ -1,0 +1,20 @@
+-- Kind-based transaction pipeline (issue #69).
+--
+-- transactions.to_token_address: swaps store the token being BOUGHT so deep
+-- analysis can scan the actual risk surface (the sell token is already the
+-- user's). NULL for every other kind.
+--
+-- requests.kind: how a request SETTLES on-chain ('transfer' | 'swap'),
+-- orthogonal to request_type (presentation — an invoice is a transfer with
+-- billing metadata). Swap requests carry their pair + slippage.
+--
+-- Note: draft rows (agent-proposed, nonce deferred to user-sign time) need
+-- NO column — a draft is exactly tx_type='safetx' AND safe_tx_hash IS NULL,
+-- derived at read time so it can never drift from the row's actual state.
+
+ALTER TABLE transactions ADD COLUMN IF NOT EXISTS to_token_address TEXT;
+
+ALTER TABLE requests ADD COLUMN IF NOT EXISTS kind TEXT NOT NULL DEFAULT 'transfer';
+ALTER TABLE requests ADD COLUMN IF NOT EXISTS from_token TEXT;
+ALTER TABLE requests ADD COLUMN IF NOT EXISTS to_token TEXT;
+ALTER TABLE requests ADD COLUMN IF NOT EXISTS slippage NUMERIC;


### PR DESCRIPTION
## Summary

Implements the remaining work in #69 (closes it together with #70, which this PR stacks on — base is `fix/tx-id-namespace`; retarget to `main` after #70 merges).

The architecture is a **kind registry** mirroring the existing `DERIVATIONS` pattern: adding a future kind (bridge, claim, batch payment…) = one decoder case + one builder entry + one risk strategy.

### Kind decoder — `server/src/lib/safe/kind.ts`
Classifies any SafeTx from its **calldata** (never client display fields) into `transfer | swap | approval | config | dapp-call | unknown`. Flattens MultiSend batches; recognizes the approve+router swap shape via a router allowlist (PancakeSwap Smart Router, LI.FI Diamond). One decode, consumed by risk, deep-analyze, pattern learning, and requests.

### Kind-aware risk
- `analyzeRisk(tx, patterns, decoded?)` — swaps score **router recognition** and **approval bounds** (unlimited approval +30, over-approval +15, unknown router +50) instead of treating the router as an unknown recipient. Omitting `decoded` preserves the old behavior byte-for-byte.
- Verified behavior change: routine PancakeSwap swap **50/REVIEW → 10/APPROVE**; unknown router + infinite approval → **90/BLOCK**.
- Deep-analyze (`/analyze/:id`) now scans the **buy token** (new `to_token_address`, stored at proposal time) and labels the router — previously it scanned the sell token and scored the router as a "recipient".
- Pattern learning stops recording routers/token contracts as recipients (recipient-profile pollution).

### Agent-initiated transactions (extends #69 task 3)
- **Builder registry** (`lib/safe/builders.ts`): `transfer` and `swap` (PancakeSwap quote infra, exact-amount approvals only) feeding a server-side port of the client SafeTx/MultiSend builder — packed encoding **round-trip verified** against `decodeMultiSendData`.
- Requests gain `kind` (`transfer` default | `swap`) + `fromToken`/`toToken`/`slippage`. MCP `queue_request` updated; SKILL.md documents the swap flow.
- **Invoices unchanged**: `type` stays presentation, `kind` is settlement; an invoice is always a transfer, and swap-with-invoice-fields is rejected 400.

### Draft rows (the nonce/rejection design from #69)
Agent proposals are now **drafts**: full call payload, but no nonce, no hash, no signatures. `POST /transactions/:id/finalize` assigns the nonce and computes the EIP-712 hash only when the user decides to sign — so a dismissed draft **never parks a Safe nonce** (the gap that previously blocked the queue tail on rejected agent proposals). Draft-ness is **derived** (`tx_type='safetx' AND safe_tx_hash IS NULL`), never stored, so it can't drift. The agent signs at execution time like every screened tx; pre-existing pre-signed `req-tx-` rows still complete via the idempotent finalize.

Trade-off (as decided on the issue): drafts aren't mirrored to the Safe Transaction Service until signed — no app.safe.global visibility for unconfirmed agent proposals.

## Migration

`20260731090000_tx_kinds.sql` — `transactions.to_token_address`; `requests.kind/from_token/to_token/slippage`. Run `pnpm --filter zhentan-server db:push` on deploy. All columns nullable/defaulted; old rows and old clients keep working.

## Testing

- `zhentan-server`, `zhentan-mcp` build clean; client type-checks clean
- Decoder smoke test: 8 payload shapes classify correctly (ERC20/native transfer, approve+router batch, infinite approval, config self-call, dapp call, native-sell router call); MultiSend encode→decode round-trips
- Risk smoke test: verdicts above

Refs #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)