### PR TITLE
fix(client): require tokenDecimals on proposeTransaction; remove USDC_DECIMALS fallback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,6 @@ See `scripts/.env.example` and `server/.env.example` for templates.
 
 ## Known Issues
 
-- **USDC decimals discrepancy**: `client/src/lib/constants.ts` declares `USDC_DECIMALS = 18`, but scripts use 6 decimals. BSC mainnet USDC uses 18 decimals; other chains may differ.
+- **USDC decimals discrepancy**: RESOLVED — `USDC_DECIMALS` removed from `client/src/lib/constants.ts`; `proposeTransaction` now requires `tokenDecimals: number` and fails loudly if missing. Token decimals come from on-chain/portfolio metadata. Note: `scripts/test/*` and `scripts/propose-tx.js` still hardcode `6` for their default BSC-testnet USDC token (`0x1c7D...7238`, a 6-decimals contract) — correct for that token, intentionally left as standalone CLI tools.
 - **Queue file paths**: Scripts default to `~/.nanobot/workspace/skills/zhentan/pending-queue.json`. Override with `QUEUE_PATH` env var.
 - **Live demo** at zhentan.me runs without the NanoBot/Hermes agent (no screening). Full AI screening requires local setup with agent.

--- a/client/src/components/SendPanel.tsx
+++ b/client/src/components/SendPanel.tsx
@@ -248,13 +248,14 @@ export function SendPanel({ onSuccess, onClose, onRefreshActivities, tokens, scr
           : undefined;
 
       if (!safeAddress || !safeConfig) throw new Error("Wallet not ready");
+      if (!selectedToken) throw new Error("Select a token to send");
       const pendingTx = await proposeTransaction({
         recipient: address,
         amount,
         safe: { safeAddress, ...safeConfig },
         getOwnerAccount,
-        tokenAddress: selectedToken?.address ?? undefined,
-        tokenDecimals: selectedToken?.decimals,
+        tokenAddress: selectedToken.address ?? undefined,
+        tokenDecimals: selectedToken.decimals,
         tokenSymbol: selectedToken?.symbol,
         tokenIconUrl: selectedToken?.iconUrl ?? undefined,
         screeningDisabled: !screeningMode,

--- a/client/src/lib/constants.ts
+++ b/client/src/lib/constants.ts
@@ -89,8 +89,6 @@ export const SAFE_TX_TYPES = {
   ],
 } as const;
 
-export const USDC_DECIMALS = 18;
-
 export const ERC20_TRANSFER_ABI = [
   {
     name: "transfer",

--- a/client/src/lib/propose.ts
+++ b/client/src/lib/propose.ts
@@ -3,7 +3,6 @@
 import { parseUnits, encodeFunctionData, type Address } from "viem";
 
 import {
-  USDC_DECIMALS,
   ERC20_TRANSFER_ABI,
   NATIVE_TOKEN_ADDRESS,
 } from "./constants";
@@ -28,7 +27,10 @@ export async function proposeTransaction({
 }: ProposeParams) {
   const tokenAddress = tokenAddressParam;
   if (!tokenAddress) throw new Error("Token address required");
-  const decimals = tokenDecimals ?? USDC_DECIMALS;
+  if (typeof tokenDecimals !== "number" || !Number.isFinite(tokenDecimals)) {
+    throw new Error("Token decimals required — refusing to assume a default");
+  }
+  const decimals = tokenDecimals;
   const symbol = tokenSymbol ?? "USDC";
   const isNative =
     tokenAddress.toLowerCase() === NATIVE_TOKEN_ADDRESS.toLowerCase();

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -277,8 +277,8 @@ export interface ProposeParams {
   getOwnerAccount: () => Promise<import("viem").LocalAccount | null>;
   /** ERC20 token contract address (default: USDC from env) */
   tokenAddress?: string;
-  /** Token decimals (default: USDC decimals) */
-  tokenDecimals?: number;
+  /** Token decimals — required. Read from on-chain/portfolio metadata, never assumed. */
+  tokenDecimals: number;
   /** Token symbol for display (e.g. "USDC") */
   tokenSymbol?: string;
   /** Token icon URL for display in activity (e.g. from Zerion) */


### PR DESCRIPTION
## Problem

`client/src/lib/propose.ts` silently fell back to `USDC_DECIMALS = 18` (`client/src/lib/constants.ts`) whenever a caller omitted `tokenDecimals`. For any non-USDC ERC-20 — or any token whose on-chain decimals ≠ 18 — the resulting `parseUnits` call produced a transfer off by 10^12, silently corrupting the on-chain `value` field.

Issue: #40

## Fix

- **Remove `USDC_DECIMALS`** from `client/src/lib/constants.ts` — no magic constant.
- **Make `tokenDecimals` required** in `ProposeParams` (`client/src/types/index.ts`).
- **Fail loudly** in `proposeTransaction` if `tokenDecimals` is missing or non-finite — refuse to assume a default rather than ship a 10^12 error.
- **SendPanel**: null-guard `selectedToken` before proposing (the third call site — `requests/page.tsx` and `useRequestActions.ts` — already passed `token.decimals` from portfolio metadata, untouched).
- **CLAUDE.md** known-issues updated to RESOLVED.

## Out of scope (intentionally left)

`scripts/test/*` and `scripts/propose-tx.js` declare `const USDC_DECIMALS = 6` locally — correct for their default token `0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238` (BSC-testnet USDC, 6-decimals). These are self-contained dev CLI tools; lifting the constant into a shared map would only add coupling without fixing a real bug.

## Verification

- `npx tsc --noEmit -p client/tsconfig.json` passes cleanly.
- All three call sites (`SendPanel.tsx`, `requests/page.tsx`, `useRequestActions.ts`) confirmed to pass `token.decimals` from on-chain/portfolio metadata.

Closes #40