### PR TITLE
Sync preview with main (A3: sponsor split)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ pnpm agent-sign      # agent-sign.js — agent co-signs and executes
 
 ### Environment variables
 - **Client**: `NEXT_PUBLIC_AGENT_ADDRESS`, `NEXT_PUBLIC_PRIVY_APP_ID`, `NEXT_PUBLIC_BACKEND_URL` (optional, for remote server)
-- **Server**: `QUEUE_PATH`, `AGENT_PRIVATE_KEY`, `PIMLICO_API_KEY` (legacy 4337 rows + treasury only), `SAFE_API_KEY` (Safe Transaction Service, from developer.safe.global), `SAFE_TX_SERVICE_URL` (optional override), `SAFE_DERIVATION_VERSION` (new-account derivation, default 2), `AGENT_MIN_BNB` (relayer gas alert threshold, default 0.05), `PORT` (default 3001), `CORS_ORIGIN`
+- **Server**: `QUEUE_PATH`, `AGENT_PRIVATE_KEY`, `SPONSOR_PRIVATE_KEY` (gas-paying EOA, defaults to the agent key — leave unset until sign/send separation ships), `PIMLICO_API_KEY` (legacy 4337 rows + treasury only), `SAFE_API_KEY` (Safe Transaction Service, from developer.safe.global), `SAFE_TX_SERVICE_URL` (optional override), `SAFE_DERIVATION_VERSION` (new-account derivation, default 2), `AGENT_MIN_BNB` (relayer gas alert threshold, default 0.05), `PORT` (default 3001), `CORS_ORIGIN`
 - **Scripts**: `PRIVATE_KEY`, `PIMLICO_API_KEY`, `RECIPIENT_ADDRESS`, `USDC_AMOUNT`, `USDC_CONTRACT_ADDRESS`, `OWNER_ADDRESS1`, `OWNER_ADDRESS2`, `SAFE_THRESHOLD`
 
 See `scripts/.env.example` and `server/.env.example` for templates.

--- a/server/.env.example
+++ b/server/.env.example
@@ -10,6 +10,13 @@ SUPABASE_SERVICE_ROLE_KEY=
 # Generate a private key for your agent and use the signer address on client .env
 AGENT_PRIVATE_KEY=
 
+# Gas sponsor private key — the EOA that sends transactions and pays BNB gas
+# (Safe deploys, execTransaction relaying). Defaults to AGENT_PRIVATE_KEY.
+# LEAVE UNSET until the sign/send separation ships: protocol-kit still sends
+# execTransaction with the agent key, so a distinct sponsor here would pay
+# for deploys only and executedBy would misreport executions.
+SPONSOR_PRIVATE_KEY=
+
 # Treasury Safe — server-controlled 3-owner / threshold-1 Safe used for payouts
 # TREASURY_PRIVATE_KEY: server signer (generates the Safe's autonomous signer)
 # TREASURY_SIGNER_1/2: external signer addresses (owners for manual recovery; no private key needed)

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -24,7 +24,7 @@ import { createSwapRouter } from "./routes/swap.js";
 import { createNotificationsRouter } from "./routes/notifications.js";
 import { createSafeRouter } from "./routes/safe.js";
 import { startSafeSyncWorker } from "./workers/safeSync.js";
-import { assertSponsorGas } from "./lib/chain/sponsor.js";
+import { assertSponsorGas, resolveSponsorPrivateKey } from "./lib/chain/sponsor.js";
 import { editNotification } from "./notify.js";
 import { markBotConnectedByChatId, getUserByTelegramId } from "./lib/supabase/index.js";
 
@@ -301,6 +301,11 @@ app.get("/me", auth, async (req, res) => {
 app.get("/health", (_req, res) => {
   res.json({ ok: true });
 });
+
+// Fail fast on invalid sponsor config: a sponsor key that differs from the
+// agent key is not supported until sign/send separation (B1) — refuse to
+// boot rather than gas-check the wrong sender and misreport executedBy.
+if (process.env.SPONSOR_PRIVATE_KEY) resolveSponsorPrivateKey();
 
 const port = Number(process.env.PORT) || 3001;
 app.listen(port, () => {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -24,7 +24,7 @@ import { createSwapRouter } from "./routes/swap.js";
 import { createNotificationsRouter } from "./routes/notifications.js";
 import { createSafeRouter } from "./routes/safe.js";
 import { startSafeSyncWorker } from "./workers/safeSync.js";
-import { assertAgentGas } from "./lib/safe/relayer.js";
+import { assertSponsorGas } from "./lib/chain/sponsor.js";
 import { editNotification } from "./notify.js";
 import { markBotConnectedByChatId, getUserByTelegramId } from "./lib/supabase/index.js";
 
@@ -308,6 +308,6 @@ app.listen(port, () => {
   startSafeSyncWorker();
   // Surface a low agent gas balance at boot rather than on the first execute.
   if (process.env.AGENT_PRIVATE_KEY) {
-    assertAgentGas().catch((err) => console.error("Startup gas check failed:", err));
+    assertSponsorGas().catch((err) => console.error("Startup gas check failed:", err));
   }
 });

--- a/server/src/lib/chain/sponsor.test.ts
+++ b/server/src/lib/chain/sponsor.test.ts
@@ -1,27 +1,38 @@
 import { describe, it, expect } from "vitest";
 import { resolveSponsorPrivateKey } from "./sponsor.js";
 
-const SPONSOR = "0x" + "11".repeat(32);
-const AGENT = "0x" + "22".repeat(32);
+const KEY_A = "0x" + "11".repeat(32);
+const KEY_B = "0x" + "22".repeat(32);
 
 describe("resolveSponsorPrivateKey", () => {
-  it("prefers SPONSOR_PRIVATE_KEY when set", () => {
-    expect(
-      resolveSponsorPrivateKey({ SPONSOR_PRIVATE_KEY: SPONSOR, AGENT_PRIVATE_KEY: AGENT })
-    ).toBe(SPONSOR);
+  it("returns SPONSOR_PRIVATE_KEY when it is the only key set", () => {
+    expect(resolveSponsorPrivateKey({ SPONSOR_PRIVATE_KEY: KEY_A })).toBe(KEY_A);
   });
 
   it("falls back to AGENT_PRIVATE_KEY (the operational default)", () => {
-    expect(resolveSponsorPrivateKey({ AGENT_PRIVATE_KEY: AGENT })).toBe(AGENT);
+    expect(resolveSponsorPrivateKey({ AGENT_PRIVATE_KEY: KEY_B })).toBe(KEY_B);
   });
 
   it("treats an empty SPONSOR_PRIVATE_KEY as unset", () => {
     expect(
-      resolveSponsorPrivateKey({ SPONSOR_PRIVATE_KEY: "", AGENT_PRIVATE_KEY: AGENT })
-    ).toBe(AGENT);
+      resolveSponsorPrivateKey({ SPONSOR_PRIVATE_KEY: "", AGENT_PRIVATE_KEY: KEY_B })
+    ).toBe(KEY_B);
   });
 
   it("throws when neither key is configured", () => {
     expect(() => resolveSponsorPrivateKey({})).toThrow(/Missing SPONSOR_PRIVATE_KEY/);
+  });
+
+  it("accepts both keys set to the same key", () => {
+    expect(
+      resolveSponsorPrivateKey({ SPONSOR_PRIVATE_KEY: KEY_A, AGENT_PRIVATE_KEY: KEY_A })
+    ).toBe(KEY_A);
+  });
+
+  // TEMPORARY guard — removed at B1 when the send path moves to the sponsor.
+  it("refuses distinct sponsor and agent keys until B1 ships", () => {
+    expect(() =>
+      resolveSponsorPrivateKey({ SPONSOR_PRIVATE_KEY: KEY_A, AGENT_PRIVATE_KEY: KEY_B })
+    ).toThrow(/different address.*B1|B1.*different address|sign\/send separation/);
   });
 });

--- a/server/src/lib/chain/sponsor.test.ts
+++ b/server/src/lib/chain/sponsor.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { resolveSponsorPrivateKey } from "./sponsor.js";
+
+const SPONSOR = "0x" + "11".repeat(32);
+const AGENT = "0x" + "22".repeat(32);
+
+describe("resolveSponsorPrivateKey", () => {
+  it("prefers SPONSOR_PRIVATE_KEY when set", () => {
+    expect(
+      resolveSponsorPrivateKey({ SPONSOR_PRIVATE_KEY: SPONSOR, AGENT_PRIVATE_KEY: AGENT })
+    ).toBe(SPONSOR);
+  });
+
+  it("falls back to AGENT_PRIVATE_KEY (the operational default)", () => {
+    expect(resolveSponsorPrivateKey({ AGENT_PRIVATE_KEY: AGENT })).toBe(AGENT);
+  });
+
+  it("treats an empty SPONSOR_PRIVATE_KEY as unset", () => {
+    expect(
+      resolveSponsorPrivateKey({ SPONSOR_PRIVATE_KEY: "", AGENT_PRIVATE_KEY: AGENT })
+    ).toBe(AGENT);
+  });
+
+  it("throws when neither key is configured", () => {
+    expect(() => resolveSponsorPrivateKey({})).toThrow(/Missing SPONSOR_PRIVATE_KEY/);
+  });
+});

--- a/server/src/lib/chain/sponsor.ts
+++ b/server/src/lib/chain/sponsor.ts
@@ -1,0 +1,93 @@
+/**
+ * The gas sponsor: the EOA that SENDS transactions and pays BNB gas — Safe
+ * deployments today, execTransaction relaying once sign/send are separated
+ * (B1/B2). Distinct in name from the agent signer (lib/agent/signer.ts),
+ * whose key is threshold-bearing; the sponsor's never is.
+ *
+ * Defaults to the agent key (SPONSOR_PRIVATE_KEY ?? AGENT_PRIVATE_KEY) so
+ * nothing changes operationally. Do NOT set SPONSOR_PRIVATE_KEY to a
+ * distinct key until the sign/send separation lands: protocol-kit still
+ * sends execTransaction with the agent key, so a split sponsor would pay
+ * for deploys only and `executedBy` would misreport executions.
+ *
+ * Nonce serialization lives here with the sender: viem's in-process
+ * nonceManager is correct while exactly ONE process sends (see plan D0.1 —
+ * sponsor sends must stay single-process until a DB-backed queue exists).
+ */
+import {
+  createWalletClient,
+  http,
+  formatEther,
+  parseEther,
+  type WalletClient,
+  type Chain,
+  type Transport,
+  type Account,
+} from "viem";
+import { bsc } from "viem/chains";
+import { privateKeyToAccount, nonceManager } from "viem/accounts";
+
+import { BSC_RPC } from "../constants.js";
+import { notifyTelegram } from "../../notify.js";
+import { getRelayerPublicClient } from "../safe/relayer.js";
+
+/** Pure resolution — exported for tests. */
+export function resolveSponsorPrivateKey(
+  env: { SPONSOR_PRIVATE_KEY?: string; AGENT_PRIVATE_KEY?: string } = process.env
+): string {
+  const key = env.SPONSOR_PRIVATE_KEY || env.AGENT_PRIVATE_KEY;
+  if (!key) throw new Error("Missing SPONSOR_PRIVATE_KEY and AGENT_PRIVATE_KEY");
+  return key;
+}
+
+let walletClient: WalletClient<Transport, Chain, Account> | null = null;
+
+export function getSponsorWalletClient(): WalletClient<Transport, Chain, Account> {
+  if (walletClient) return walletClient;
+  // nonceManager serializes concurrent sends (deploys + executes share one EOA).
+  const account = privateKeyToAccount(resolveSponsorPrivateKey() as `0x${string}`, {
+    nonceManager,
+  });
+  walletClient = createWalletClient({
+    account,
+    chain: bsc,
+    transport: http(BSC_RPC),
+  });
+  return walletClient;
+}
+
+export function getSponsorAddress(): `0x${string}` {
+  return getSponsorWalletClient().account.address;
+}
+
+let lastLowGasAlert = 0;
+const LOW_GAS_ALERT_INTERVAL_MS = 60 * 60 * 1000;
+
+/**
+ * Checks the sponsor EOA's BNB balance against AGENT_MIN_BNB (default 0.05).
+ * Below the threshold it alerts the admin Telegram chat (throttled to 1/hour)
+ * but does NOT throw — a low-but-nonzero balance can still relay.
+ */
+export async function assertSponsorGas(): Promise<void> {
+  try {
+    const minBnb = process.env.AGENT_MIN_BNB || "0.05";
+    const balance = await getRelayerPublicClient().getBalance({
+      address: getSponsorAddress(),
+    });
+    if (balance >= parseEther(minBnb)) return;
+
+    console.warn(
+      `Sponsor relayer low on gas: ${formatEther(balance)} BNB (min ${minBnb})`
+    );
+    const now = Date.now();
+    if (now - lastLowGasAlert < LOW_GAS_ALERT_INTERVAL_MS) return;
+    lastLowGasAlert = now;
+    notifyTelegram(
+      `⛽ Agent relayer low on gas: ${formatEther(balance)} BNB ` +
+        `(threshold ${minBnb} BNB).\n` +
+        `Top up ${getSponsorAddress()} or SafeTx execution will stall.`
+    );
+  } catch (err) {
+    console.error("assertSponsorGas failed:", err);
+  }
+}

--- a/server/src/lib/chain/sponsor.ts
+++ b/server/src/lib/chain/sponsor.ts
@@ -37,6 +37,21 @@ export function resolveSponsorPrivateKey(
 ): string {
   const key = env.SPONSOR_PRIVATE_KEY || env.AGENT_PRIVATE_KEY;
   if (!key) throw new Error("Missing SPONSOR_PRIVATE_KEY and AGENT_PRIVATE_KEY");
+  // TEMPORARY — REMOVE AT B1 (sign/send separation). Until then, execution
+  // and rejection still send via protocol-kit with the AGENT key: a distinct
+  // sponsor would gas-check the wrong sender and misreport executedBy. This
+  // enforces the documented "leave unset" constraint instead of trusting it.
+  if (env.SPONSOR_PRIVATE_KEY && env.AGENT_PRIVATE_KEY) {
+    const sponsor = privateKeyToAccount(env.SPONSOR_PRIVATE_KEY as `0x${string}`).address;
+    const agent = privateKeyToAccount(env.AGENT_PRIVATE_KEY as `0x${string}`).address;
+    if (sponsor !== agent) {
+      throw new Error(
+        "SPONSOR_PRIVATE_KEY resolves to a different address than AGENT_PRIVATE_KEY. " +
+          "Until sign/send separation (B1) ships, execution still sends with the agent key — " +
+          "unset SPONSOR_PRIVATE_KEY or set it to the same key."
+      );
+    }
+  }
   return key;
 }
 

--- a/server/src/lib/execution/execute.ts
+++ b/server/src/lib/execution/execute.ts
@@ -23,7 +23,8 @@ import {
 } from "../supabase/index.js";
 import { getApiKit, getProtocolKit } from "../safe/service.js";
 import { readSafeNonce } from "../safe/onchain.js";
-import { assertAgentGas, getAgentAddress, getRelayerPublicClient } from "../safe/relayer.js";
+import { getAgentAddress, getRelayerPublicClient } from "../safe/relayer.js";
+import { assertSponsorGas, getSponsorAddress } from "../chain/sponsor.js";
 import { getSigningAuthority } from "../agent/signer.js";
 import { finishExecution } from "./finish.js";
 import type { PendingTransaction } from "../../types.js";
@@ -126,7 +127,7 @@ async function executeSafeTx(tx: PendingTransaction): Promise<ExecutionOutcome> 
     throw new Error("Missing SafeTx fields (safeTxHash/safeTx/safeNonce/userSignature)");
   }
 
-  await assertAgentGas();
+  await assertSponsorGas();
 
   // Nonce race guard: the user may have executed something at this nonce
   // directly from the Safe UI while this proposal waited. That "something"
@@ -288,7 +289,10 @@ async function executeSafeTx(tx: PendingTransaction): Promise<ExecutionOutcome> 
     status: "executed",
     txHash,
     success: receipt.status === "success",
-    executedBy: getAgentAddress(),
+    // The EOA that SENT execTransaction — the sponsor, not the agent
+    // identity. Identical while the keys are one; wrong the moment they
+    // split (which is why this reports sponsor).
+    executedBy: getSponsorAddress(),
   };
 }
 
@@ -347,7 +351,7 @@ export async function runExecution(tx: PendingTransaction): Promise<ExecutionRes
         tx,
         outcome.txHash,
         outcome.success ?? true,
-        outcome.executedBy ?? getAgentAddress()
+        outcome.executedBy ?? getSponsorAddress()
       );
     }
     return { status: "already_executed", txId: tx.id, txHash: outcome.txHash };
@@ -357,7 +361,7 @@ export async function runExecution(tx: PendingTransaction): Promise<ExecutionRes
     tx,
     outcome.txHash!,
     outcome.success ?? true,
-    outcome.executedBy ?? getAgentAddress()
+    outcome.executedBy ?? getSponsorAddress()
   );
 
   return {

--- a/server/src/lib/safe/deploy.ts
+++ b/server/src/lib/safe/deploy.ts
@@ -3,7 +3,7 @@
  * Transaction Service only indexes contracts that exist on-chain).
  *
  * Deployment bytes come from lib/safe/derive.ts (versioned — the initializer
- * must reproduce the account's stored address exactly), and the agent EOA
+ * must reproduce the account's stored address exactly), and the sponsor EOA
  * sends the factory call and pays gas.
  */
 import type { Address, Hex } from "viem";
@@ -14,7 +14,8 @@ import {
   type DerivationVersion,
 } from "./derive.js";
 import { SAFE_2OF3_THRESHOLD } from "./owners.js";
-import { getAgentWalletClient, getRelayerPublicClient, assertAgentGas } from "./relayer.js";
+import { getRelayerPublicClient } from "./relayer.js";
+import { getSponsorWalletClient, assertSponsorGas } from "../chain/sponsor.js";
 
 export interface CounterfactualSafe {
   address: Address;
@@ -52,9 +53,9 @@ export async function deploySafe(
     throw new Error(`No deployment tx available for undeployed Safe ${address}`);
   }
 
-  await assertAgentGas();
+  await assertSponsorGas();
 
-  const wallet = getAgentWalletClient();
+  const wallet = getSponsorWalletClient();
   const txHash = await wallet.sendTransaction({
     to: deploymentTx.to,
     value: deploymentTx.value,

--- a/server/src/lib/safe/reject.ts
+++ b/server/src/lib/safe/reject.ts
@@ -12,7 +12,7 @@ import type { Hex } from "viem";
 import type { PendingTransaction, SafeTxData } from "../../types.js";
 import { computeSafeTxHash, getApiKit, getProtocolKit, proposeToService } from "./service.js";
 import { readSafeNonce } from "./onchain.js";
-import { assertAgentGas } from "./relayer.js";
+import { assertSponsorGas } from "../chain/sponsor.js";
 import { getSigningAuthority } from "../agent/signer.js";
 
 export interface RejectionResult {
@@ -52,7 +52,7 @@ export async function executeRejection(tx: PendingTransaction): Promise<Rejectio
     return { status: "skipped", reason: "nonce already consumed on-chain" };
   }
 
-  await assertAgentGas();
+  await assertSponsorGas();
 
   const rejectionTx = buildRejectionTxData(tx.safeAddress, tx.safeNonce);
   const rejectionHash = computeSafeTxHash(tx.safeAddress, rejectionTx);

--- a/server/src/lib/safe/relayer.ts
+++ b/server/src/lib/safe/relayer.ts
@@ -1,27 +1,18 @@
 /**
- * Agent EOA as relayer: wallet client (with nonce management) for Safe
- * deployments and execTransaction relaying, plus a gas watchdog.
+ * Chain read access and the agent's identity address.
+ *
+ * The wallet client that SENDS transactions (and the gas watchdog) live in
+ * lib/chain/sponsor.ts — the sponsor role. What remains here is identity:
+ * getAgentAddress() answers "which EOA is the agent owner on Safes", derived
+ * from AGENT_PRIVATE_KEY alone, independent of who pays gas.
  */
-import {
-  createPublicClient,
-  createWalletClient,
-  http,
-  formatEther,
-  parseEther,
-  type PublicClient,
-  type WalletClient,
-  type Chain,
-  type Transport,
-  type Account,
-} from "viem";
+import { createPublicClient, http, type PublicClient } from "viem";
 import { bsc } from "viem/chains";
-import { privateKeyToAccount, nonceManager } from "viem/accounts";
+import { privateKeyToAccount } from "viem/accounts";
 
 import { BSC_RPC } from "../constants.js";
-import { notifyTelegram } from "../../notify.js";
 
 let publicClient: PublicClient | null = null;
-let walletClient: WalletClient<Transport, Chain, Account> | null = null;
 
 export function getRelayerPublicClient(): PublicClient {
   if (!publicClient) {
@@ -30,54 +21,12 @@ export function getRelayerPublicClient(): PublicClient {
   return publicClient;
 }
 
-export function getAgentWalletClient(): WalletClient<Transport, Chain, Account> {
-  if (walletClient) return walletClient;
-  const agentPrivateKey = process.env.AGENT_PRIVATE_KEY;
-  if (!agentPrivateKey) throw new Error("Missing AGENT_PRIVATE_KEY");
-  // nonceManager serializes concurrent sends (deploys + executes share one EOA).
-  const account = privateKeyToAccount(agentPrivateKey as `0x${string}`, {
-    nonceManager,
-  });
-  walletClient = createWalletClient({
-    account,
-    chain: bsc,
-    transport: http(BSC_RPC),
-  });
-  return walletClient;
-}
+let agentAddress: `0x${string}` | null = null;
 
 export function getAgentAddress(): `0x${string}` {
-  return getAgentWalletClient().account.address;
-}
-
-let lastLowGasAlert = 0;
-const LOW_GAS_ALERT_INTERVAL_MS = 60 * 60 * 1000;
-
-/**
- * Checks the agent EOA's BNB balance against AGENT_MIN_BNB (default 0.05).
- * Below the threshold it alerts the admin Telegram chat (throttled to 1/hour)
- * but does NOT throw — a low-but-nonzero balance can still relay.
- */
-export async function assertAgentGas(): Promise<void> {
-  try {
-    const minBnb = process.env.AGENT_MIN_BNB || "0.05";
-    const balance = await getRelayerPublicClient().getBalance({
-      address: getAgentAddress(),
-    });
-    if (balance >= parseEther(minBnb)) return;
-
-    console.warn(
-      `Agent relayer low on gas: ${formatEther(balance)} BNB (min ${minBnb})`
-    );
-    const now = Date.now();
-    if (now - lastLowGasAlert < LOW_GAS_ALERT_INTERVAL_MS) return;
-    lastLowGasAlert = now;
-    notifyTelegram(
-      `⛽ Agent relayer low on gas: ${formatEther(balance)} BNB ` +
-        `(threshold ${minBnb} BNB).\n` +
-        `Top up ${getAgentAddress()} or SafeTx execution will stall.`
-    );
-  } catch (err) {
-    console.error("assertAgentGas failed:", err);
-  }
+  if (agentAddress) return agentAddress;
+  const agentPrivateKey = process.env.AGENT_PRIVATE_KEY;
+  if (!agentPrivateKey) throw new Error("Missing AGENT_PRIVATE_KEY");
+  agentAddress = privateKeyToAccount(agentPrivateKey as `0x${string}`).address;
+  return agentAddress;
 }


### PR DESCRIPTION
Brings `preview` up to `main` (3 commits): the A3 merge — sponsor/agent key split, `executedBy` fix, and the temporary distinct-key fail-fast guard (#109, closed #83).

Merge this **before** the B0 preview PR so that one stays task-only.

## Manual UI tests for A3 (run on preview after merge)
Behaviour is identical with default env (no `SPONSOR_PRIVATE_KEY`) — verify exactly that:
- [ ] Propose → auto-approve → execute; `executedBy` in the tx record equals the agent/sponsor EOA and matches `from` on BscScan
- [ ] Fresh onboarding: new login → Safe deploys (now via the sponsor wallet path) → same address on refresh
- [ ] Reject an in-review tx — cancel lands, nonce consumed

🤖 Generated with [Claude Code](https://claude.com/claude-code)