### PR TITLE
docs(server): D0.1 — record sponsor single-sender constraint

### DIFF
--- a/server/ecosystem.config.cjs
+++ b/server/ecosystem.config.cjs
@@ -6,6 +6,12 @@ module.exports = {
       cwd: __dirname,
       script: "dist/index.js",
       node_args: "--enable-source-maps",
+      // MUST stay 1 (D0.1): sponsor sends (execution, rejection, deployment)
+      // serialize the sponsor EOA's nonces via viem's IN-PROCESS nonceManager
+      // (lib/chain/sponsor.ts). Two instances = nonce collisions on chain.
+      // Raising this requires a DB-backed per-sponsor submission queue first.
+      // Cross-process execution dedup is already safe (DB lease, D0) — this
+      // constraint is only about who SENDS from the sponsor EOA.
       instances: 1,
       autorestart: true,
       watch: false,


### PR DESCRIPTION
Implements **D0.1** (#92) — documentation/ops task from the agent-service separation plan: *record, don't build*.

## What
The sponsor EOA's nonces are serialized by viem's **in-process** `nonceManager` (`server/src/lib/chain/sponsor.ts`). All sponsor sends — execution, rejection cancels, Safe deployments — therefore must run in exactly ONE process until a DB-backed per-sponsor submission queue exists. The D0 lease (#118) already makes execution **dedup** cross-process-safe; this surviving constraint is only about who **sends** from the sponsor EOA.

Recorded where ops will actually see it:
- `server/ecosystem.config.cjs` — comment pinning `instances: 1` with the why and the unlock condition (per-sponsor submission queue)
- `CLAUDE.md` Known Issues — already landed with #118 (no change needed here)

## Tests
None — comment-only change, no code paths touched.

## Manual UI tests
None required — no runtime behavior changes.

Closes #92.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
