### PR TITLE
feat(server): D0.3 — identity-shaped job contracts

### DIFF
--- a/server/src/lib/runtime/jobs.ts
+++ b/server/src/lib/runtime/jobs.ts
@@ -14,9 +14,11 @@ import {
   JOB_LEASE_TTL_MS,
   JOB_SCHEMA_VERSION,
   MAX_JOB_ATTEMPTS,
+  assignedAgentForSafe,
   computeInputHash,
   failureTargetStatus,
   jobNextRetryAt,
+  validateJobContract,
   validateJobResult,
   type JobKind,
   type JobResultSubmission,
@@ -81,6 +83,12 @@ export async function enqueueJob(input: EnqueueJobInput): Promise<RuntimeJobRow>
     input_hash: computeInputHash(input.payload),
     credential_version: input.credentialVersion ?? 1,
   };
+  // Identity-shaped contract (D0.3): a job without a valid safe scope,
+  // credential version, or kind/purpose shape never reaches the queue.
+  const contract = validateJobContract(row);
+  if (!contract.valid) {
+    throw new Error(`Job enqueue rejected for tx ${input.txId}: ${contract.reason}`);
+  }
   for (let attempt = 0; attempt < 3; attempt++) {
     const { data, error } = await supabase.from("runtime_jobs").insert(row).select("*").single<RuntimeJobRow>();
     if (!error) return data;
@@ -163,6 +171,9 @@ export async function leaseNextJob(
   if (error) throw new Error(`Job pull failed: ${error.message}`);
 
   for (const candidate of candidates ?? []) {
+    // Assignment scope (D0.3): an agent only leases jobs for Safes assigned
+    // to it. Every Safe maps to the shared agent until P7/F1.
+    if (assignedAgentForSafe(candidate.safe_address) !== agentInstanceId) continue;
     const leaseToken = randomUUID();
     // Atomic claim: only wins if the row is still in the state we saw —
     // pending, or still holding the same expired lease.

--- a/server/src/lib/runtime/jobs.ts
+++ b/server/src/lib/runtime/jobs.ts
@@ -172,7 +172,11 @@ export async function leaseNextJob(
 
   for (const candidate of candidates ?? []) {
     // Assignment scope (D0.3): an agent only leases jobs for Safes assigned
-    // to it. Every Safe maps to the shared agent until P7/F1.
+    // to it. Every Safe maps to the shared agent until P7/F1, so this
+    // post-window filter currently never skips. F1 REQUIREMENT: once the
+    // mapping is per-agent (agent_identities), assignment must move into
+    // the DB query — otherwise 10 older foreign-agent jobs can fill the
+    // window and starve a claimant whose own jobs sit behind them.
     if (assignedAgentForSafe(candidate.safe_address) !== agentInstanceId) continue;
     const leaseToken = randomUUID();
     // Atomic claim: only wins if the row is still in the state we saw —

--- a/server/src/lib/runtime/jobsPolicy.test.ts
+++ b/server/src/lib/runtime/jobsPolicy.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from "vitest";
 import {
+  assignedAgentForSafe,
   failureTargetStatus,
+  SHARED_AGENT_INSTANCE_ID,
+  validateJobContract,
   JOB_SCHEMA_VERSION,
   SUPPORTED_JOB_SCHEMA_VERSIONS,
   MAX_JOB_ATTEMPTS,
@@ -27,6 +30,7 @@ const job = (over: Partial<JobResultFields> = {}): JobResultFields => ({
   input_hash: computeInputHash(PAYLOAD),
   credential_version: 1,
   status: "leased",
+  agent_instance_id: "shared-agent",
   lease_token: "lease-a",
   lease_expires_at: LIVE,
   attempt_count: 1,
@@ -135,6 +139,67 @@ describe("input-hash verification", () => {
     expect(computeInputHash({ a: 1, b: [2, 3] })).toBe(computeInputHash({ b: [2, 3], a: 1 }));
     expect(computeInputHash({ a: 1 })).not.toBe(computeInputHash({ a: 2 }));
     expect(computeInputHash({ a: 1, skip: undefined })).toBe(computeInputHash({ a: 1 }));
+  });
+});
+
+describe("identity-shaped contracts (D0.3)", () => {
+  const contractFixture = {
+    schema_version: JOB_SCHEMA_VERSION,
+    kind: "sign",
+    purpose: "execution",
+    safe_address: "0x1111111111111111111111111111111111111111",
+    credential_version: 1,
+  };
+
+  it("a fully identity-shaped job is enqueueable", () => {
+    expect(validateJobContract(contractFixture)).toEqual({ valid: true });
+    expect(validateJobContract({ ...contractFixture, kind: "screen", purpose: null })).toEqual({
+      valid: true,
+    });
+  });
+
+  it("a job without a safe assignment scope is rejected", () => {
+    expect(validateJobContract({ ...contractFixture, safe_address: "" })).toEqual({
+      valid: false,
+      reason: "missing_safe_scope",
+    });
+    expect(validateJobContract({ ...contractFixture, safe_address: "not-an-address" })).toEqual({
+      valid: false,
+      reason: "missing_safe_scope",
+    });
+  });
+
+  it("a job without a valid credential version is rejected", () => {
+    expect(validateJobContract({ ...contractFixture, credential_version: 0 })).toEqual({
+      valid: false,
+      reason: "invalid_credential_version",
+    });
+  });
+
+  it("kind/purpose shape is part of the contract", () => {
+    expect(validateJobContract({ ...contractFixture, purpose: null })).toEqual({
+      valid: false,
+      reason: "sign_requires_purpose",
+    });
+    expect(validateJobContract({ ...contractFixture, kind: "screen" })).toEqual({
+      valid: false,
+      reason: "screen_forbids_purpose",
+    });
+    expect(validateJobContract({ ...contractFixture, kind: "notify" })).toEqual({
+      valid: false,
+      reason: "invalid_kind",
+    });
+  });
+
+  it("a result whose agent identity does not match the lease holder is rejected", () => {
+    const verdict = validateJobResult(job(), submission({ agentInstanceId: "rogue-agent" }), 3, 1, NOW);
+    expect(verdict).toEqual({ decision: "reject", reason: "agent_mismatch" });
+  });
+
+  it("every Safe maps to the shared agent until P7/F1", () => {
+    expect(assignedAgentForSafe("0x1111111111111111111111111111111111111111")).toBe(
+      SHARED_AGENT_INSTANCE_ID
+    );
   });
 });
 

--- a/server/src/lib/runtime/jobsPolicy.test.ts
+++ b/server/src/lib/runtime/jobsPolicy.test.ts
@@ -189,6 +189,10 @@ describe("identity-shaped contracts (D0.3)", () => {
       valid: false,
       reason: "invalid_kind",
     });
+    expect(validateJobContract({ ...contractFixture, purpose: "banana" })).toEqual({
+      valid: false,
+      reason: "invalid_purpose",
+    });
   });
 
   it("a result whose agent identity does not match the lease holder is rejected", () => {

--- a/server/src/lib/runtime/jobsPolicy.ts
+++ b/server/src/lib/runtime/jobsPolicy.ts
@@ -48,8 +48,15 @@ export type JobContractVerdict =
         | "invalid_credential_version"
         | "invalid_kind"
         | "sign_requires_purpose"
+        | "invalid_purpose"
         | "screen_forbids_purpose";
     };
+
+const SIGN_PURPOSES: ReadonlySet<string> = new Set([
+  "execution",
+  "rejection",
+  "draft_finalization",
+] satisfies SignPurpose[]);
 
 /** Mirrors the DB CHECKs so contract tests run env-free (and reject earlier). */
 export function validateJobContract(job: JobContractFields): JobContractVerdict {
@@ -67,6 +74,9 @@ export function validateJobContract(job: JobContractFields): JobContractVerdict 
   }
   if (job.kind === "sign" && !job.purpose) {
     return { valid: false, reason: "sign_requires_purpose" };
+  }
+  if (job.kind === "sign" && job.purpose && !SIGN_PURPOSES.has(job.purpose)) {
+    return { valid: false, reason: "invalid_purpose" };
   }
   if (job.kind === "screen" && job.purpose) {
     return { valid: false, reason: "screen_forbids_purpose" };

--- a/server/src/lib/runtime/jobsPolicy.ts
+++ b/server/src/lib/runtime/jobsPolicy.ts
@@ -15,6 +15,65 @@ import { createHash } from "crypto";
 export const JOB_SCHEMA_VERSION = 1;
 export const SUPPORTED_JOB_SCHEMA_VERSIONS: ReadonlySet<number> = new Set([1]);
 
+/**
+ * Identity-shaped contracts from day one (D0.3): every job carries an
+ * assignment scope (safe address) and credential_version; every result
+ * carries the agent_instance_id bound at lease time. Today every Safe maps
+ * to the shared agent; P7/F1 swap this mapping for agent_identities and
+ * per-agent credentials WITHOUT changing any contract.
+ */
+export const SHARED_AGENT_INSTANCE_ID = "shared-agent";
+
+/** Assignment lookup — the P7/F1 seam. One agent for every Safe until then. */
+export function assignedAgentForSafe(_safeAddress: string): string {
+  return SHARED_AGENT_INSTANCE_ID;
+}
+
+/** The identity slice a job must carry to be enqueueable at all. */
+export interface JobContractFields {
+  schema_version: number;
+  kind: string;
+  purpose: string | null;
+  safe_address: string;
+  credential_version: number;
+}
+
+export type JobContractVerdict =
+  | { valid: true }
+  | {
+      valid: false;
+      reason:
+        | "unsupported_schema_version"
+        | "missing_safe_scope"
+        | "invalid_credential_version"
+        | "invalid_kind"
+        | "sign_requires_purpose"
+        | "screen_forbids_purpose";
+    };
+
+/** Mirrors the DB CHECKs so contract tests run env-free (and reject earlier). */
+export function validateJobContract(job: JobContractFields): JobContractVerdict {
+  if (!SUPPORTED_JOB_SCHEMA_VERSIONS.has(job.schema_version)) {
+    return { valid: false, reason: "unsupported_schema_version" };
+  }
+  if (!/^0x[0-9a-fA-F]{40}$/.test(job.safe_address)) {
+    return { valid: false, reason: "missing_safe_scope" };
+  }
+  if (!Number.isInteger(job.credential_version) || job.credential_version < 1) {
+    return { valid: false, reason: "invalid_credential_version" };
+  }
+  if (job.kind !== "screen" && job.kind !== "sign") {
+    return { valid: false, reason: "invalid_kind" };
+  }
+  if (job.kind === "sign" && !job.purpose) {
+    return { valid: false, reason: "sign_requires_purpose" };
+  }
+  if (job.kind === "screen" && job.purpose) {
+    return { valid: false, reason: "screen_forbids_purpose" };
+  }
+  return { valid: true };
+}
+
 /** Lease TTL for one evaluate/sign attempt (heartbeat extends it). */
 export const JOB_LEASE_TTL_MS = 2 * 60 * 1000;
 /** Attempts (lease grants) before a job dead-letters. */
@@ -105,6 +164,8 @@ export interface JobResultFields extends JobLeaseFields {
   tx_version: number;
   input_hash: string;
   credential_version: number;
+  /** Bound at lease time; results must come back under the same identity. */
+  agent_instance_id: string | null;
   result_lease_token: string | null;
 }
 
@@ -133,6 +194,7 @@ export type ResultDecision =
         | "wrong_job"
         | "job_not_leased"
         | "lease_mismatch"
+        | "agent_mismatch"
         | "lease_expired"
         | "job_tx_version_mismatch"
         | "input_hash_mismatch"
@@ -170,6 +232,11 @@ export function validateJobResult(
   }
   if (job.lease_token !== submission.leaseToken) {
     return { decision: "reject", reason: "lease_mismatch" };
+  }
+  // Identity binding (D0.3): the result must come back under the same
+  // agent identity the lease was granted to.
+  if (job.agent_instance_id !== submission.agentInstanceId) {
+    return { decision: "reject", reason: "agent_mismatch" };
   }
   if (!job.lease_expires_at || Date.parse(job.lease_expires_at) <= now.getTime()) {
     return { decision: "reject", reason: "lease_expired" };


### PR DESCRIPTION
Implements **D0.3** (#94) — every job and result carries identity from day one, so P7/F1 later introduce unique agent identities and per-agent credentials **without changing any contract**.

## What
The D0.2 schema was already identity-shaped (`agent_instance_id`, `safe_address` scope, `credential_version`); this PR adds the *enforcement*:

- **`validateJobContract`** (pure, mirrors the DB CHECKs): a job without a valid safe assignment scope, a `credential_version ≥ 1`, or a well-formed kind/purpose shape is rejected at `enqueueJob` before it ever reaches the queue.
- **Results bind to the lease holder's identity**: `agent_instance_id` is fixed at lease time; a submission under any other identity is rejected with `agent_mismatch` even if it somehow held the lease token.
- **`assignedAgentForSafe()` is the P7/F1 seam**: every Safe maps to `SHARED_AGENT_INSTANCE_ID` today; `leaseNextJob` only leases jobs for Safes assigned to the claimant, so the assignment scope is enforced from the first deployment.

No migration required.

## Tests
6 new contract tests (88 total pass): identity-complete fixture accepted, missing/invalid safe scope rejected, invalid credential version rejected, kind/purpose shape violations rejected, result under a foreign agent identity rejected, shared-agent mapping.

## Manual UI tests
None — no live flows touched (still no job producers until D2).

Closes #94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
