### PR TITLE
docs: D5 verification matrix + runtime deploy tooling + user-docs architecture overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,6 @@ client/.ds-styles.css
 .design-sync/dist/
 client/.ds-dist/
 .local/
-docs
 *.swp
 *.swo
 screening/dist/

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ See `scripts/.env.example` and `server/.env.example` for full templates.
 ```bash
 pnpm dev:client      # http://localhost:3000
 pnpm dev:server      # http://localhost:3001
-pnpm dev:docs        # http://localhost:3002
+pnpm dev:runtime     # agent runtime worker — health on 127.0.0.1:3002
+pnpm dev:docs        # docs preview (pass a port if the runtime holds 3002)
 ```
 
 ## Structure

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -1,5 +1,12 @@
 # Project: Zhentan
 
+> **Historical document** — written during the original build; the
+> architecture has since evolved (the agent now runs as a separate
+> runtime service that screens and signs). For current docs see
+> [docs/technology/architecture](technology/architecture.mdx) and the
+> root CLAUDE.md.
+
+
 > Live onchain activity (smart accounts + transactions on BNB Chain): [docs/ONCHAIN.md](./ONCHAIN.md)
 
 ## 1. Problem

--- a/docs/TECHNICAL.md
+++ b/docs/TECHNICAL.md
@@ -1,5 +1,12 @@
 # Technical Documentation
 
+> **Historical document** — written during the original build; the
+> architecture has since evolved (the agent now runs as a separate
+> runtime service that screens and signs). For current docs see
+> [docs/technology/architecture](technology/architecture.mdx) and the
+> root CLAUDE.md.
+
+
 > One place for **how** the system works and how to run and use it.
 > Live onchain activity: [docs/ONCHAIN.md](./ONCHAIN.md)
 

--- a/docs/api/execute-transaction.mdx
+++ b/docs/api/execute-transaction.mdx
@@ -5,9 +5,9 @@ description: Relay a queued SafeTx on-chain — the agent pays gas, and signs on
 
 ## POST /execute
 
-Executes a queued SafeTx. The agent EOA relays `execTransaction` and pays BNB gas. Its signing behavior depends on whose signatures are already on the row:
+Executes a queued SafeTx. A dedicated sponsor EOA relays `execTransaction` and pays BNB gas; the agent's signature — when one is needed — is produced by the [agent runtime](/technology/architecture#agent-runtime) only after it independently verifies the transaction against its own screening record and on-chain state. Behavior depends on whose signatures are already on the row:
 
-- **User signatures below threshold, screening on:** the agent adds its confirmation (2 of 2) via the Safe Transaction Service, then executes. Called after an APPROVE verdict or a Telegram approval.
+- **User signatures below threshold, screening on:** the server requests the runtime's signature, uses it to confirm 2 of 2 via the Safe Transaction Service, and executes. Called after an APPROVE verdict or a Telegram approval.
 - **User signatures meet the threshold** (starter wallets, or screening-off with a backup co-signature): **relay-only** — the agent submits and pays gas but contributes **no signature**.
 - **Screening off, below threshold:** refused with *"Awaiting backup co-signature"* — no caller (client, Telegram, MCP, or the agent itself) can make the agent sign an unscreened transaction. Complete the row via [`/cosign`](/api/cosign-transaction) or the Safe app. [Legacy v1 accounts](/technology/legacy) without a backup key are exempt.
 
@@ -37,5 +37,7 @@ Idempotency and nonce races are handled server-side: if the Safe's on-chain nonc
 
 | Field | Description |
 |-------|-------------|
-| `status` | `executed`, `already_executed`, or `superseded` |
+| `status` | `executed`, `already_executed`, `in_progress` (another execution of this row is mid-flight), or `superseded` |
 | `txHash` | On-chain transaction hash |
+
+If the agent runtime is unavailable or refuses to sign (for example, no screening record exists for this exact transaction), the execution attempt fails with the named reason and the transaction **stays safely queued** — retry once the runtime is reachable; a re-screen happens automatically where needed.

--- a/docs/api/queue-transaction.mdx
+++ b/docs/api/queue-transaction.mdx
@@ -68,16 +68,32 @@ Proposals with `screeningDisabled` below the threshold are **rejected outright**
 
 ## Response
 
+Screening runs in the agent runtime; with it co-located the verdict (and any auto-execution) completes within the request:
+
 ```json
 {
   "success": true,
   "id": "tx-1a2b3c4d",
-  "risk": { "riskScore": 15, "verdict": "APPROVE", "reasons": [] }
+  "risk": { "riskScore": 15, "verdict": "APPROVE", "reasons": [] },
+  "autoExecuted": true,
+  "txHash": "0x..."
+}
+```
+
+If the screening service doesn't answer within the bounded window, the response **degrades instead of failing** — the proposal is queued, screening completes when the service returns, and notifications fire then:
+
+```json
+{
+  "success": true,
+  "id": "tx-1a2b3c4d",
+  "screening": "pending"
 }
 ```
 
 | Field | Description |
 |-------|-------------|
 | `id` | Transaction ID in the queue |
-| `risk` | Present when screening is on — score, verdict, reasons |
+| `risk` | Present when the verdict arrived in-window — score, verdict, reasons |
+| `autoExecuted` / `txHash` | Present on an APPROVE verdict that executed within the window |
+| `screening` | `"pending"` — verdict not yet available; the transaction is safely queued (fail-closed) and resolves automatically |
 | `serviceWarning` | Present if the Safe Transaction Service mirror failed (queuing still succeeds) |

--- a/docs/app/screening.mdx
+++ b/docs/app/screening.mdx
@@ -3,7 +3,7 @@ title: Screening
 description: How AI transaction screening works from the user's perspective.
 ---
 
-Every transaction you initiate is scored 0–100 against your behavioral profile before anything executes. The result is one of three verdicts.
+Every transaction you initiate is scored 0–100 against your behavioral profile before anything executes. Screening runs in a dedicated agent service — the same one that holds the signing key, which is why an unscreened transaction can never be signed. The result is one of three verdicts.
 
 ## The Three Verdicts
 
@@ -79,3 +79,9 @@ After every confirmed transaction, Zhentan records the pattern. Recipients you t
 | `reject <tx-id>` | Manually reject a pending transaction |
 | `get-status` | See current screening mode and recent decisions |
 | `screening on` / `screening off` | Toggle screening |
+
+## If Screening Is Momentarily Unavailable
+
+Screening is **fail-closed**: if the screening service is ever briefly unreachable, your proposal is accepted and simply waits — you'll see it as *pending* with its real signature count (e.g. 1 of 2). Nothing executes without a verdict, and the moment the service returns, screening completes automatically and the normal flow (auto-execute, or the Telegram review) picks up where it left off. Transactions that never involve the agent's signature — starter wallets and screening-off co-signed transfers — are unaffected and execute as usual.
+
+Paused, never unsafe.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -46,7 +46,10 @@
         "groups": [
           {
             "group": "Get Started",
-            "pages": ["introduction", "quickstart"]
+            "pages": [
+              "introduction",
+              "quickstart"
+            ]
           },
           {
             "group": "Zhentan App",
@@ -66,7 +69,8 @@
               "technology/risk-scoring",
               "technology/agent",
               "technology/legacy",
-              "technology/contracts"
+              "technology/contracts",
+              "technology/self-hosting"
             ]
           }
         ]

--- a/docs/technology/agent.mdx
+++ b/docs/technology/agent.mdx
@@ -5,7 +5,16 @@ description: The NanoBot/Hermes skill pack — skills, transaction lifecycle, an
 
 ## Overview
 
-The Zhentan agent is an NanoBot/Hermes skill pack. It holds the 2nd signing key on the Safe 2-of-2 and is the only component that communicates with the user via Telegram. The server handles deterministic screening — the agent handles everything interactive.
+"The agent" is two components with sharply different powers — a separation worth being precise about:
+
+| | Conversational agent (this page) | [Agent runtime](/technology/architecture#agent-runtime) |
+|---|---|---|
+| What it is | NanoBot/Hermes skill pack | A separate worker service |
+| What it does | Telegram dialogue, deep analysis, review decisions, invoices | Screens every transaction, **signs** approved ones |
+| Keys held | **None** | The agent owner key — the only signing key in the system |
+| How it acts | Authenticated commands to the server (via MCP) | Pulls screening/signing jobs from the server; verifies everything before its key touches a hash |
+
+The conversational agent is the interactive layer: it talks to you, investigates flagged transactions, and forwards your decisions. It can *ask* for things to happen — it cannot make them happen. Every command it sends is authorized by the server, and every signature is produced by the runtime only after independent verification.
 
 **AI models:** Qwen3-235B / Claude Sonnet 4.5 via OpenRouter
 
@@ -37,7 +46,7 @@ The Zhentan agent is an NanoBot/Hermes skill pack. It holds the 2nd signing key 
 | `check-pending.js` | Monitors the pending queue for new transactions |
 | `analyze-risk.js` | Pattern-based risk scoring |
 | `deep-analyze.js` | GoPlus + Honeypot.is external security analysis |
-| `sign-and-execute.js` | Co-signs 2-of-2 and submits the UserOperation to Pimlico |
+| `sign-and-execute.js` | Requests execution via the server — the runtime signs, the sponsor submits |
 | `mark-review.js` | Marks a transaction as pending review |
 | `reject-tx.js` | Rejects a transaction |
 | `record-pattern.js` | Records confirmed transaction into the behavioral profile |
@@ -57,7 +66,7 @@ pnpm --filter zhentan-agent sign-and-execute
 
 | Command | Action |
 |---------|--------|
-| `approve <tx-id>` | Sign 2-of-2, execute, record pattern, update TG message with txHash |
+| `approve <tx-id>` | Approve a reviewed transaction — the server obtains the runtime's verified signature, executes, and updates the TG message with the txHash |
 | `reject <tx-id>` | Reject, update TG message |
 | `analyze <tx-id>` | Run deep analysis (GoPlus + Honeypot.is) on demand |
 | `get-status [safeAddress]` | Current screening mode and recent decisions |
@@ -72,17 +81,14 @@ pending → in_review → executed
 
 | Status | Description |
 |--------|-------------|
-| `pending` | Queued by the client, risk score assigned |
+| `pending` | Queued by the client; screening runs in the agent runtime |
 | `in_review` | Sent to Telegram, awaiting user response |
-| `executed` | Agent signed 2-of-2, UserOperation confirmed on-chain |
-| `rejected` | Blocked (score > 70) or rejected by the user |
+| `executed` | Runtime-signed SafeTx executed on-chain (sponsor relays and pays gas) |
+| `rejected` | Blocked (score > 70) or rejected by the user — an on-chain cancel consumes the nonce |
 
 ## Environment Variables
 
-```env
-AGENT_PRIVATE_KEY=0xYourAgentPrivateKey
-PIMLICO_API_KEY=your_pimlico_api_key
-```
+The skill pack needs **no keys** — commands are authorized by the server per Telegram caller. The agent owner key belongs exclusively to the runtime's environment (`runtime/.env`), never to the skill pack or the server. See the [architecture page](/technology/architecture#agent-runtime).
 
 <Note>
   Queue file paths default to `~/.nanobot/workspace/skills/zhentan/pending-queue.json`. Override with `QUEUE_PATH`.

--- a/docs/technology/architecture.mdx
+++ b/docs/technology/architecture.mdx
@@ -8,8 +8,10 @@ description: System overview, component breakdown, and data flow.
 | Component | Role |
 |-----------|------|
 | `client/` | Next.js 14 frontend — onboarding, wallet profiles, dashboard, send/swap, WalletConnect, invoices |
-| `server/` | Express API — inline risk analysis, queue management, Safe Transaction Service integration, address derivation, relay execution, Zerion portfolio |
-| `agent/` | NanoBot/Hermes skill pack — Telegram commands, deep analysis, screening decisions, pattern recording |
+| `server/` | Express API — canonical state, proposal validation, Safe Transaction Service integration, address derivation, notifications, sponsor relay, Zerion portfolio. **Holds no signing key.** |
+| `runtime/` | The agent runtime — a separate worker process that **screens every transaction and holds the only signing key**. Pulls work from the server over an authenticated API; has no database access and accepts no inbound connections |
+| `screening/` | Pure risk engine shared by server and runtime — same code, same decision, wherever it runs |
+| `agent/` | NanoBot/Hermes skill pack — the conversational layer: Telegram commands, deep analysis, review dialogue. **Holds no keys** |
 
 ```mermaid
 flowchart TD
@@ -18,19 +20,20 @@ flowchart TD
     C -->|POST /queue — SafeTx, EIP-712 signed 1-of-2| S[Server :3001]
     S -->|propose 1/2| TS[Safe Transaction Service]
     TS -->|visible + confirmable| SA[app.safe.global]
-    S -->|analyzeRisk inline| R{Risk Score}
-    R -->|< 40 APPROVE| OC[NanoBot/Hermes Agent]
-    R -->|40-70 REVIEW| OC
-    R -->|> 70 BLOCK| OC
+    S -->|screen job| RT[Agent Runtime]
+    RT -->|verdict| R{Risk Score}
+    R -->|< 40 APPROVE| S
+    R -->|40-70 REVIEW| TG[Telegram / User]
+    R -->|> 70 BLOCK| TG
+    TG -->|approve / reject| OC[NanoBot/Hermes Agent]
+    OC -->|commands via MCP| S
     OC -->|REVIEW: deep-analyze| EXT[GoPlus / Honeypot.is]
-    EXT -->|address + token report| OC
-    OC <-->|REVIEW: report + buttons\nBLOCK: alert| TG[Telegram / User]
-    OC -->|confirm 2/2 via service| TS
-    OC -->|execTransaction — agent pays gas| BC[BNB Chain]
+    S -->|sign job| RT
+    RT -->|verified signature| S
+    S -->|confirm 2/2 via service| TS
+    S -->|execTransaction — sponsor pays gas| BC[BNB Chain]
     SA -->|override: backup key confirms + executes| BC
     BC -->|txHash| C
-    BC -->|confirmed| OC
-    OC -->|record-pattern| P[(patterns)]
 ```
 
 ## Client
@@ -45,19 +48,25 @@ flowchart TD
 ## Server
 
 - **Express** with TypeScript (`tsx` for dev, PM2 for production)
-- Runs `analyzeRisk()` inline on every `/queue` request — no async roundtrip
+- Owns **canonical state**: user records, the transaction queue, notifications (Telegram + email), and the Supabase (Postgres) database — the runtime never touches any of these directly
 - **Hard-validates every proposal**: signature recovery against the recorded owner set, threshold arithmetic for screening-off, and owner-management transitions
+- Sends every screening and signing request to the runtime as a **job** over the Runtime API (bearer-authenticated, fail-closed) and applies the verdicts that come back — exactly once, atomically
 - Mirrors every proposal to the **Safe Transaction Service** so it appears in app.safe.global at 1/2; a `safeSync` worker reconciles transactions confirmed or executed there directly
-- **Relays execution**: the agent EOA submits `execTransaction` and pays BNB gas — relay-only (no agent signature) whenever user signatures meet the threshold
-- Derives addresses server-side through a [versioned registry](/technology/signing#address-derivation); user records and transactions persist in Supabase (Postgres)
+- **Relays execution**: a dedicated sponsor EOA submits `execTransaction` and pays BNB gas — relay-only (no agent signature) whenever user signatures meet the threshold
+- Derives addresses server-side through a [versioned registry](/technology/signing#address-derivation)
 
-## Agent
+## Agent Runtime
 
-- **NanoBot/Hermes skill pack** — holds the agent owner key
-- Responds to Telegram commands from the owner
-- Runs deep analysis (GoPlus + Honeypot.is) on REVIEW-tier transactions
-- Records patterns after every confirmed transaction
-- **Never signs unscreened transactions** — with screening off it either relays only (v2) or, for [legacy v1 accounts](/technology/legacy), co-signs by explicit exemption
+- A **separate worker process** — the security core of the system
+- **Screens** every proposal with the shared risk engine, from inputs the server assembles into the job itself
+- **Holds the only signing key**, behind a verifying authority: before signing anything it independently recomputes the transaction hash, reads the Safe's owners and nonce **from chain**, and requires **its own record of having screened this exact transaction** — a claim in the request is not evidence
+- Keeps its own append-only decision log; has **no database credential** and opens no inbound port (a localhost health endpoint is its only listener)
+- **Fail-closed**: if the runtime is down, screened transactions simply wait — nothing executes without a verdict, and flows that never need the agent's signature (relay-only, backup co-sign) continue unaffected
+
+## Conversational Agent
+
+- **NanoBot/Hermes skill pack** — Telegram commands, review dialogue, deep analysis (GoPlus + Honeypot.is) on REVIEW-tier transactions
+- Sends every command through the server's authenticated API (via MCP) — it holds no keys and touches no state directly
 
 ## Data Flow
 
@@ -65,44 +74,43 @@ flowchart TD
 sequenceDiagram
     participant C as Client
     participant S as Server
+    participant RT as Agent Runtime
     participant TS as Safe Tx Service
-    participant OC as NanoBot/Hermes Agent
-    participant EXT as GoPlus / Honeypot.is
     participant TG as Telegram
     participant BC as BNB Chain
 
     C->>S: POST /queue {SafeTx, EIP-712 signature 1-of-2}
     S->>TS: propose (1/2 in app.safe.global)
-    S->>S: analyzeRisk() → score
-    S->>OC: notify (verdict + score)
+    S->>RT: screen job (tx + behavioral snapshot)
+    RT->>RT: risk engine → verdict, recorded locally
+    RT-->>S: verdict
     alt APPROVE
-        OC->>TS: confirm (2/2)
-        OC->>BC: execTransaction (agent pays gas)
+        S->>RT: sign job
+        RT->>BC: verify owners + nonce on chain
+        RT->>RT: check own screening record → sign
+        RT-->>S: verified signature
+        S->>TS: confirm (2/2)
+        S->>BC: execTransaction (sponsor pays gas)
         BC-->>C: txHash
-        OC->>S: record-pattern
-    else REVIEW
-        OC->>EXT: deep-analyze (recipient + token)
-        EXT-->>OC: address reputation, token security
-        OC->>TG: analysis report + [Approve] [Reject]
-        TG-->>OC: user responds
-        OC->>BC: execTransaction (if approved)
-        OC->>S: record-pattern
-    else BLOCK
-        OC->>TG: blocked alert
-        Note over C,BC: Override: user confirms with backup key in the Safe app — safeSync reconciles
+    else REVIEW / BLOCK
+        S->>TG: report + [Approve] [Reject]
+        TG-->>S: user decision (via agent command)
+        S->>RT: sign job (with approval evidence)
+        RT-->>S: verified signature
+        S->>BC: execTransaction (if approved)
     end
+    Note over C,BC: Override at any time: user confirms with backup key in the Safe app — safeSync reconciles
 ```
 
-Rejections execute a **pre-signed empty transaction at the same nonce**, so a rejected proposal never leaves a nonce hole blocking later transactions.
+Rejections execute a **pre-signed empty transaction at the same nonce**, so a rejected proposal never leaves a nonce hole blocking later transactions — the cancel's agent signature comes from the runtime like any other.
 
 ## State
 
 | Store | Purpose |
 |-------|---------|
-| Supabase (Postgres) | User records (owner sets, thresholds, immutable creation snapshots), transaction queue and outcomes |
+| Supabase (Postgres) | User records (owner sets, thresholds, immutable creation snapshots), transaction queue and outcomes, screening/signing job queue — **server-only access** |
 | Safe Transaction Service | Proposal mirror — the source the Safe app reads and writes |
-| `state.json` | Screening mode and agent decisions (agent runtime) |
-| `patterns.json` | Learned behavioral patterns (agent runtime) |
+| Runtime decision log | Append-only record of every screening decision, kept by the runtime itself — what the signing authority verifies against |
 
 ## Tech Stack
 
@@ -110,9 +118,10 @@ Rejections execute a **pre-signed empty transaction at the same nonce**, so a re
 |-------|-----------|
 | Chain | BNB Chain (BSC), Chain ID 56 |
 | Smart Account | Safe 1.4.1 multisig — standard SafeTx flow via the Safe Transaction Service |
-| Gas | Agent EOA relays `execTransaction` and pays BNB (ERC-4337/Pimlico survives only for legacy queued rows) |
+| Gas | Sponsor EOA relays `execTransaction` and pays BNB |
 | Frontend | Next.js 14, React 18, TypeScript, Tailwind CSS, Framer Motion |
 | Auth | Privy (Google OAuth + embedded wallets, wallet login, backup-key linking) |
 | Blockchain libs | viem, @safe-global/protocol-kit + api-kit |
 | Backend | Express, Supabase (Postgres), tsx (dev), PM2 (production) |
+| Agent runtime | Node worker (PM2), shared `zhentan-screening` risk core, viem for chain verification |
 | AI Agent | NanoBot/Hermes with Qwen3-235B / Claude Sonnet 4.5 via OpenRouter |

--- a/docs/technology/legacy.mdx
+++ b/docs/technology/legacy.mdx
@@ -13,7 +13,7 @@ They keep working without any action — but they run under a few carefully-scop
 |--------|-------------|
 | **Profile** | Classifies as **Guarded** — one user key, agent co-signer, threshold 2 |
 | **Address derivation** | Pinned to the v1 recipe (4337-module initializer) **forever** — the derivation version is part of the account's immutable creation snapshot, so its address stays re-derivable |
-| **Execution** | New transactions use the standard SafeTx flow like everyone else; ERC-4337 survives **only** for pre-refactor queued rows (`tx_type='4337'`) |
+| **Execution** | The standard SafeTx flow like everyone else. The legacy ERC-4337 execution path is fully **retired** — all remaining pre-refactor queued rows were audited and closed out; nothing executes as a UserOperation anymore |
 | **Screening off** | Allowed, with the agent as blind co-signer (see below) |
 
 ## The Screening-Off Exception
@@ -26,7 +26,7 @@ So v1 accounts get a capability-scoped exemption:
 A v1 account **without a backup key** may pause screening; the agent still co-signs (it just skips risk analysis). The exemption is keyed on **capability, not version** — it applies only while the account's own keys cannot meet the threshold. The moment a backup key is added, the strict v2 rules apply automatically.
 </Note>
 
-This is enforced in three places: at proposal validation, again at execution (defense in depth — no surface can make the agent sign an unscreened transaction for an upgraded account), and in the client flow.
+This is enforced at proposal validation, at execution, and — since the signing key moved into the [agent runtime](/technology/architecture#agent-runtime) — **at the key itself**: before blind co-signing, the runtime independently re-derives the capability from the account's registered derivation version and the owner set it reads from chain. A request merely *claiming* the exemption is refused; an upgraded account (own keys meet the threshold on-chain) loses the capability automatically, no matter what any request says.
 
 ## Upgrading to the Full Model
 

--- a/docs/technology/overview.mdx
+++ b/docs/technology/overview.mdx
@@ -3,7 +3,7 @@ title: Overview
 description: Technical overview of how Zhentan is built.
 ---
 
-Zhentan is built on three independently runnable components that work together: an instant deterministic scoring layer, an interactive AI agent layer, and a Safe multisig execution layer where **the user always holds the majority of keys**.
+Zhentan is built on independently runnable components with one security spine: a deterministic risk engine, an **agent runtime** that both screens and signs (the only component holding a signing key — and it refuses to sign anything it didn't screen itself), an interactive AI agent layer for dialogue and investigation, and a Safe multisig execution layer where **the user always holds the majority of keys**.
 
 <CardGroup cols="2">
   <Card title="Signing & Wallet Profiles" icon="signature" iconType="duotone" href="/technology/signing">

--- a/docs/technology/risk-scoring.mdx
+++ b/docs/technology/risk-scoring.mdx
@@ -5,7 +5,7 @@ description: How every transaction is scored 0–100 against learned behavioral 
 
 ## Overview
 
-When a transaction hits `/queue`, the server runs `analyzeRisk()` instantly against your behavioral profile. This is deterministic and synchronous — no LLM, no async roundtrip. The agent only acts after the verdict is determined.
+Every transaction is scored against your behavioral profile by a deterministic risk engine — no LLM in the verdict path. The engine lives in a shared package (`zhentan-screening`) and **runs inside the [agent runtime](/technology/architecture#agent-runtime)**: the server assembles your behavioral snapshot and sends it with the transaction as a screening job; the runtime computes the verdict, records it in its own decision log (the record its signing authority later verifies against), and returns it. With the runtime co-located this completes in milliseconds — the propose response is still synchronous.
 
 ## Scoring Factors
 

--- a/docs/technology/self-hosting.mdx
+++ b/docs/technology/self-hosting.mdx
@@ -1,0 +1,45 @@
+---
+title: Self-Hosting the Agent
+description: Where the self-hostable agent stands today, and what's coming.
+---
+
+Zhentan's long-term goal is that **you run your own agent** — the service that screens your transactions and holds the co-signing key answers to you, on your machine, while the Zhentan backend keeps doing what a backend should: canonical state, the Safe Transaction Service mirror, and gas relay.
+
+The architecture for this already exists. This page is honest about which parts are real today and which are on the roadmap.
+
+## What Exists Today
+
+The agent runtime is a **fully separable process** with a hard boundary:
+
+- It talks to the backend exclusively over an authenticated HTTPS API — configure `RUNTIME_API_URL` and it can run anywhere
+- It has **no database credential** (enforced by lint, dependency guards, and a boot test) and accepts no inbound connections
+- It holds the signing key (`AGENT_PRIVATE_KEY`) behind a verifying authority: it recomputes every transaction hash, reads the Safe's owners and nonce from chain (`RUNTIME_RPC_URL`), and signs only what **its own decision log** proves it screened
+- It ships with deployment tooling: `./runtime/run.sh build && ./runtime/run.sh start` (PM2), a localhost health endpoint, and an env template at `runtime/.env.example`
+
+```
+runtime/.env
+├── RUNTIME_API_URL      # the backend — anywhere reachable
+├── RUNTIME_API_TOKEN    # authenticates the runtime to the backend
+├── AGENT_PRIVATE_KEY    # the ONLY signing key in the system
+└── RUNTIME_RPC_URL      # chain reads for pre-sign verification
+```
+
+If the runtime is offline, screened transactions **wait** — nothing executes without a verdict, and your relay-only and backup-key flows continue untouched.
+
+## What's Coming
+
+Today there is one shared agent identity, so running the runtime yourself is an operational split, not yet *your* agent. The remaining milestones:
+
+| Milestone | What it adds |
+|-----------|--------------|
+| **Agent identities & pairing** | Each Safe maps to a named agent identity; you pair your runtime to your wallet |
+| **Per-agent credentials** | Your runtime's credential is scoped to your Safe alone — it cannot lease anyone else's work |
+| **Policy snapshots & evidence** | Your behavioral profile flows down to your runtime; screening evidence flows back up |
+| **Your own signer key** | A per-user agent key, swapped in as your Safe's owner via a reviewed owner-management transaction |
+| **Your agent talks to you** | Review prompts come from your own runtime through your own channel, and your approvals return as first-party evidence |
+
+The signing rules, wire protocol, and verification model shipping today were built for that end state — self-hosting swaps credentials and configuration, not architecture.
+
+<Note>
+Until per-agent credentials ship, the runtime deployment is operated by Zhentan. The security properties above — user-held key majority, screened-only signing, the Safe-app override — hold either way.
+</Note>

--- a/docs/technology/signing.mdx
+++ b/docs/technology/signing.mdx
@@ -13,15 +13,15 @@ A fully set up Zhentan wallet has three owners and a threshold of 2:
 |-------|---------|------|
 | **Embedded key** | You (Privy embedded wallet, or your connected wallet for wallet login) | Proposes and signs every transaction |
 | **Backup key** | You (any external wallet — pasted address, ENS/.bnb name, or connected) | Your override and recovery key |
-| **Agent key** | Zhentan agent | Screens, co-signs approved transactions, relays and pays gas |
+| **Agent key** | Zhentan agent runtime | Screens and co-signs approved transactions — held by the [agent runtime](/technology/architecture#agent-runtime), a separate service whose only job is to verify before signing |
 
 Your two keys meet the threshold — so the agent is an **advisory speed bump, not a gatekeeper**. If it ever blocks something you want (or disappears entirely), you can execute from [app.safe.global](https://app.safe.global) with your embedded + backup keys and go around it.
 
 <Note>
-**Two hard invariants**, enforced server-side on every proposal:
+**Two hard invariants:**
 
-1. The agent **never reaches the threshold alone** — it cannot move funds without you.
-2. The agent **never signs a transaction it didn't screen** — when screening is off, your own keys must meet the threshold and the agent only relays.
+1. The agent **never reaches the threshold alone** — it cannot move funds without you. Enforced server-side on every proposal and transition.
+2. The agent **never signs a transaction it didn't screen** — enforced **cryptographically, next to the key itself**: the signing key lives in a separate runtime service that refuses to sign unless it independently re-verifies the transaction hash, reads the Safe's owners and nonce from chain, and finds **its own record** of having screened this exact transaction. When screening is off, your own keys must meet the threshold and the system only relays.
 </Note>
 
 ## Wallet Profiles
@@ -56,28 +56,33 @@ Every user transaction is a standard Safe transaction (EIP-712 SafeTx) — visib
 sequenceDiagram
     participant U as User (embedded key)
     participant S as Zhentan Server
+    participant RT as Agent Runtime
     participant TS as Safe Transaction Service
-    participant A as Agent
     participant BC as BNB Chain
 
     U->>S: POST /queue — SafeTx + EIP-712 signature (1 of 2)
     S->>TS: propose — appears in app.safe.global at 1/2
-    S->>S: analyzeRisk() → APPROVE / REVIEW / BLOCK
+    S->>RT: screen → APPROVE / REVIEW / BLOCK
     alt APPROVE (screened)
-        A->>TS: confirm (2 of 2)
-        A->>BC: execTransaction — agent EOA pays BNB gas
+        S->>RT: request signature
+        RT->>RT: verify hash + chain state + own screening record → sign
+        S->>TS: confirm (2 of 2) with the runtime's signature
+        S->>BC: execTransaction — sponsor EOA pays BNB gas
         BC-->>U: executed
     else REVIEW
-        A->>U: Telegram report + [Approve] [Reject]
+        S->>U: Telegram report + [Approve] [Reject]
+        Note over S,RT: on approval, the signature request carries your approval as evidence
     else BLOCK
-        A->>U: blocked alert (override still available in the Safe app)
+        S->>U: blocked alert (override still available in the Safe app)
     end
 ```
 
 Key properties:
 
-- **The agent relays and pays gas.** Users never need BNB — the agent EOA submits `execTransaction` on-chain.
-- **Rejections never leave nonce holes.** Every proposal pre-signs a same-nonce empty cancel transaction, so a rejection consumes the nonce cleanly and later proposals aren't blocked.
+- **Zhentan relays and pays gas.** Users never need BNB — a dedicated sponsor EOA submits `execTransaction` on-chain. Signing and sending are different hands: the runtime signs, the sponsor sends.
+- **One signature, verified twice.** The runtime's signature is checked by the server (it must recover to the registered agent address) before being used — once for the Safe-app confirmation and once on-chain. They are the same bytes over the same transaction hash.
+- **Rejections never leave nonce holes.** Every proposal pre-signs a same-nonce empty cancel transaction, so a rejection consumes the nonce cleanly and later proposals aren't blocked. The cancel's co-signature comes from the runtime under a dedicated rule: under the rejection purpose it will sign **nothing but** the empty self-call at the current nonce.
+- **If the screening service is ever unavailable, nothing executes.** Screened proposals simply wait (you'll see them pending) and complete automatically when it returns — while relay-only and backup-key flows continue unaffected. Unavailable means paused, never unsafe.
 - **The Safe app is a first-class surface.** A sync worker reconciles transactions confirmed or executed directly from app.safe.global — the override path is fully supported, not an afterthought.
 
 ## Relay-Only Execution

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,7 +132,7 @@ importers:
         version: 16.6.1
       viem:
         specifier: ^2.7.6
-        version: 2.55.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)
+        version: 2.55.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       zhentan-screening:
         specifier: workspace:*
         version: link:../screening
@@ -140,6 +140,9 @@ importers:
       '@types/node':
         specifier: ^20.11.5
         version: 20.19.37
+      pm2:
+        specifier: ^5.3.0
+        version: 5.4.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       tsx:
         specifier: ^4.7.0
         version: 4.21.0
@@ -163,19 +166,19 @@ importers:
     dependencies:
       '@pancakeswap/sdk':
         specifier: ^5.9.0
-        version: 5.9.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+        version: 5.9.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)
       '@pancakeswap/smart-router':
         specifier: ^7.6.0
         version: 7.6.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@18.3.1)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@safe-global/api-kit':
         specifier: ^5.0.1
-        version: 5.0.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+        version: 5.0.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)
       '@safe-global/protocol-kit':
         specifier: ^8.0.4
-        version: 8.0.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+        version: 8.0.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)
       '@safe-global/types-kit':
         specifier: ^4.0.1
-        version: 4.0.1(typescript@5.9.3)(zod@3.25.76)
+        version: 4.0.1(typescript@5.9.3)(zod@4.3.6)
       '@supabase/supabase-js':
         specifier: ^2.100.0
         version: 2.100.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
@@ -196,10 +199,10 @@ importers:
         version: 0.2.0
       permissionless:
         specifier: ^0.2.14
-        version: 0.2.57(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))
+        version: 0.2.57(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6))
       viem:
         specifier: ^2.21.0
-        version: 2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+        version: 2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)
       zhentan-screening:
         specifier: workspace:*
         version: link:../screening
@@ -9628,7 +9631,7 @@ snapshots:
       '@types/debug': 4.1.13
       debug: 4.4.3
       pony-cause: 2.1.11
-      semver: 7.7.4
+      semver: 7.8.5
       uuid: 9.0.1
     transitivePeerDependencies:
       - supports-color
@@ -10268,6 +10271,27 @@ snapshots:
       - utf-8-validate
       - zod
 
+  '@pancakeswap/sdk@5.9.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)':
+    dependencies:
+      '@pancakeswap/chains': 0.8.0
+      '@pancakeswap/swap-sdk-core': 1.6.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@pancakeswap/swap-sdk-evm': 1.2.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)
+      '@pancakeswap/swap-sdk-solana': 1.1.7(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@pancakeswap/v2-sdk': 1.2.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)
+      big.js: 5.2.2
+      decimal.js-light: 2.5.1
+      tiny-invariant: 1.3.3
+      tiny-warning: 1.0.3
+      toformat: 2.0.0
+      viem: 2.37.13(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - typescript
+      - utf-8-validate
+      - zod
+
   '@pancakeswap/smart-router@7.6.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@18.3.1)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
       '@pancakeswap/chains': 0.8.0
@@ -10349,6 +10373,20 @@ snapshots:
       - utf-8-validate
       - zod
 
+  '@pancakeswap/swap-sdk-evm@1.2.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)':
+    dependencies:
+      '@pancakeswap/chains': 0.8.0
+      '@pancakeswap/swap-sdk-core': 1.6.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      tiny-invariant: 1.3.3
+      tiny-warning: 1.0.3
+      viem: 2.37.13(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - typescript
+      - utf-8-validate
+      - zod
+
   '@pancakeswap/swap-sdk-solana@1.1.7(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
       '@pancakeswap/chains': 0.8.0
@@ -10408,6 +10446,20 @@ snapshots:
       - utf-8-validate
       - zod
 
+  '@pancakeswap/v2-sdk@1.2.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)':
+    dependencies:
+      '@pancakeswap/chains': 0.8.0
+      '@pancakeswap/swap-sdk-core': 1.6.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@pancakeswap/swap-sdk-evm': 1.2.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)
+      tiny-invariant: 1.3.3
+      viem: 2.37.13(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - typescript
+      - utf-8-validate
+      - zod
+
   '@pancakeswap/v3-sdk@3.10.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)':
     dependencies:
       '@pancakeswap/chains': 0.8.0
@@ -10448,6 +10500,26 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@pm2/agent@2.0.4(bufferutil@4.1.0)(utf-8-validate@5.0.10)':
+    dependencies:
+      async: 3.2.6
+      chalk: 3.0.0
+      dayjs: 1.8.36
+      debug: 4.3.7
+      eventemitter2: 5.0.1
+      fast-json-patch: 3.1.1
+      fclone: 1.0.11
+      nssocket: 0.6.0
+      pm2-axon: 4.0.1
+      pm2-axon-rpc: 0.7.1
+      proxy-agent: 6.3.1
+      semver: 7.5.4
+      ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   '@pm2/agent@2.0.4(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
       async: 3.2.6
@@ -10480,6 +10552,18 @@ snapshots:
       tslib: 1.9.3
     transitivePeerDependencies:
       - supports-color
+
+  '@pm2/js-api@0.8.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)':
+    dependencies:
+      async: 2.6.4
+      debug: 4.3.7
+      eventemitter2: 6.4.9
+      extrareqp2: 1.0.0(debug@4.3.7)
+      ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   '@pm2/js-api@0.8.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
@@ -11509,12 +11593,12 @@ snapshots:
 
   '@rushstack/eslint-patch@1.16.1': {}
 
-  '@safe-global/api-kit@5.0.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)':
+  '@safe-global/api-kit@5.0.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)':
     dependencies:
-      '@safe-global/protocol-kit': 8.0.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
-      '@safe-global/types-kit': 4.0.1(typescript@5.9.3)(zod@3.25.76)
+      '@safe-global/protocol-kit': 8.0.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)
+      '@safe-global/types-kit': 4.0.1(typescript@5.9.3)(zod@4.3.6)
       node-fetch: 2.7.0
-      viem: 2.55.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+      viem: 2.55.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -11522,14 +11606,14 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@safe-global/protocol-kit@8.0.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)':
+  '@safe-global/protocol-kit@8.0.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)':
     dependencies:
       '@safe-global/safe-deployments': 1.37.60
       '@safe-global/safe-modules-deployments': 3.0.8
-      '@safe-global/types-kit': 4.0.1(typescript@5.9.3)(zod@3.25.76)
-      abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
+      '@safe-global/types-kit': 4.0.1(typescript@5.9.3)(zod@4.3.6)
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.6)
       semver: 7.8.5
-      viem: 2.55.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+      viem: 2.55.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)
     optionalDependencies:
       '@noble/curves': 1.9.7
       '@peculiar/asn1-schema': 2.8.0
@@ -11567,9 +11651,9 @@ snapshots:
 
   '@safe-global/safe-modules-deployments@3.0.8': {}
 
-  '@safe-global/types-kit@4.0.1(typescript@5.9.3)(zod@3.25.76)':
+  '@safe-global/types-kit@4.0.1(typescript@5.9.3)(zod@4.3.6)':
     dependencies:
-      abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.6)
     transitivePeerDependencies:
       - typescript
       - zod
@@ -14295,6 +14379,11 @@ snapshots:
       typescript: 5.9.3
       zod: 3.25.76
 
+  abitype@1.1.0(typescript@5.9.3)(zod@4.3.6):
+    optionalDependencies:
+      typescript: 5.9.3
+      zod: 4.3.6
+
   abitype@1.2.3(typescript@5.9.3)(zod@3.22.4):
     optionalDependencies:
       typescript: 5.9.3
@@ -15613,8 +15702,8 @@ snapshots:
       '@typescript-eslint/parser': 8.57.1(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1)
@@ -15633,7 +15722,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -15644,22 +15733,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.57.1(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -15670,7 +15759,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -16016,7 +16105,7 @@ snapshots:
 
   extension-port-stream@3.0.0:
     dependencies:
-      readable-stream: 3.6.2
+      readable-stream: 4.7.0
       webextension-polyfill: 0.10.0
 
   extract-files@9.0.0: {}
@@ -18337,21 +18426,6 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
-  ox@0.14.7(typescript@5.9.3)(zod@3.25.76):
-    dependencies:
-      '@adraffy/ens-normalize': 1.11.1
-      '@noble/ciphers': 1.3.0
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
-      eventemitter3: 5.0.1
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - zod
-
   ox@0.14.7(typescript@5.9.3)(zod@4.3.6):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
@@ -18449,6 +18523,21 @@ snapshots:
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - zod
+
+  ox@0.9.6(typescript@5.9.3)(zod@4.3.6):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.6)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.3
@@ -18584,9 +18673,9 @@ snapshots:
     dependencies:
       viem: 2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.24.0)
 
-  permissionless@0.2.57(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)):
+  permissionless@0.2.57(viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)):
     dependencies:
-      viem: 2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+      viem: 2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)
 
   picocolors@1.1.1: {}
 
@@ -18712,6 +18801,44 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
     optional: true
+
+  pm2@5.4.3(bufferutil@4.1.0)(utf-8-validate@5.0.10):
+    dependencies:
+      '@pm2/agent': 2.0.4(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      '@pm2/io': 6.0.1
+      '@pm2/js-api': 0.8.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      '@pm2/pm2-version-check': 1.0.4
+      async: 3.2.6
+      blessed: 0.1.81
+      chalk: 3.0.0
+      chokidar: 3.6.0
+      cli-tableau: 2.0.1
+      commander: 2.15.1
+      croner: 4.1.97
+      dayjs: 1.11.20
+      debug: 4.4.3
+      enquirer: 2.3.6
+      eventemitter2: 5.0.1
+      fclone: 1.0.11
+      js-yaml: 4.1.1
+      mkdirp: 1.0.4
+      needle: 2.4.0
+      pidusage: 3.0.2
+      pm2-axon: 4.0.1
+      pm2-axon-rpc: 0.7.1
+      pm2-deploy: 1.0.2
+      pm2-multimeter: 0.1.2
+      promptly: 2.2.0
+      semver: 7.7.4
+      source-map-support: 0.5.21
+      sprintf-js: 1.1.2
+      vizion: 2.2.1
+    optionalDependencies:
+      pm2-sysmonit: 1.2.8
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   pm2@5.4.3(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
@@ -20712,6 +20839,23 @@ snapshots:
       - utf-8-validate
       - zod
 
+  viem@2.37.13(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.1.0(typescript@5.9.3)(zod@4.3.6)
+      isows: 1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      ox: 0.9.6(typescript@5.9.3)(zod@4.3.6)
+      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
   viem@2.47.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6):
     dependencies:
       '@noble/curves': 1.9.1
@@ -20763,15 +20907,15 @@ snapshots:
       - utf-8-validate
       - zod
 
-  viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76):
+  viem@2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.6)
       isows: 1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))
-      ox: 0.14.7(typescript@5.9.3)(zod@3.25.76)
+      ox: 0.14.7(typescript@5.9.3)(zod@4.3.6)
       ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     optionalDependencies:
       typescript: 5.9.3
@@ -20824,23 +20968,6 @@ snapshots:
       isows: 1.0.7(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       ox: 0.14.30(typescript@5.9.3)(zod@4.3.6)
       ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - zod
-
-  viem@2.55.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76):
-    dependencies:
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
-      isows: 1.0.7(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
-      ox: 0.14.30(typescript@5.9.3)(zod@3.25.76)
-      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -11,7 +11,10 @@
     "start": "node dist/index.js",
     "lint": "tsc --noEmit && sh scripts/lint-boundary.sh",
     "test": "vitest run",
-    "pm2:start": "pm2 start ecosystem.config.cjs"
+    "pm2:start": "pm2 start ecosystem.config.cjs",
+    "pm2:stop": "pm2 stop zhentan-runtime",
+    "pm2:restart": "pm2 restart zhentan-runtime",
+    "pm2:logs": "pm2 logs zhentan-runtime"
   },
   "dependencies": {
     "dotenv": "^16.4.5",
@@ -22,6 +25,7 @@
     "@types/node": "^20.11.5",
     "tsx": "^4.7.0",
     "typescript": "^5.3.3",
-    "vitest": "^4.0.0"
+    "vitest": "^4.0.0",
+    "pm2": "^5.3.0"
   }
 }

--- a/runtime/run.sh
+++ b/runtime/run.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+# Zhentan Runtime PM2 Deployment Script
+# Run from repo root: ./runtime/run.sh <command>
+#
+# The runtime is the agent service (D1–D4): it screens transactions and
+# holds the ONLY threshold-bearing key. runtime/.env must carry
+# RUNTIME_API_URL, RUNTIME_API_TOKEN, AGENT_PRIVATE_KEY (and optionally
+# RUNTIME_RPC_URL / AGENT_INSTANCE_ID / HEALTH_PORT) — see .env.example.
+
+set -e
+
+RUNTIME_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$RUNTIME_DIR")"
+
+cd "$ROOT_DIR"
+
+case "$1" in
+  "install")
+    echo "Installing PM2 globally..."
+    npm install -g pm2
+    echo "PM2 installed!"
+    ;;
+  "build")
+    echo "Building Zhentan runtime (screening core first)..."
+    pnpm install
+    pnpm --filter zhentan-screening build
+    pnpm --filter zhentan-runtime build
+    echo "Runtime build complete!"
+    ;;
+  "start")
+    echo "Starting Zhentan runtime with PM2..."
+    if [ ! -f runtime/.env ]; then
+      echo "ERROR: runtime/.env missing — copy .env.example and set RUNTIME_API_TOKEN + AGENT_PRIVATE_KEY."
+      exit 1
+    fi
+    mkdir -p runtime/logs
+    pm2 start runtime/ecosystem.config.cjs --env production
+    pm2 save
+    echo "Runtime started! Health: curl 127.0.0.1:\${HEALTH_PORT:-3002}/health"
+    ;;
+  "startup")
+    echo "Configuring PM2 to start on boot..."
+    pm2 startup
+    pm2 save
+    echo "PM2 will now start automatically on boot!"
+    ;;
+  "stop")
+    echo "Stopping Zhentan runtime..."
+    pm2 stop zhentan-runtime
+    echo "Runtime stopped! (Screened proposals will queue until restart — fail-closed.)"
+    ;;
+  "restart")
+    echo "Restarting Zhentan runtime..."
+    pm2 restart zhentan-runtime
+    echo "Runtime restarted!"
+    ;;
+  "logs")
+    pm2 logs zhentan-runtime
+    ;;
+  "health")
+    curl -s "127.0.0.1:${HEALTH_PORT:-3002}/health" && echo
+    ;;
+  "monitor")
+    pm2 monit
+    ;;
+  "status")
+    pm2 status
+    ;;
+  "update")
+    echo "Updating runtime..."
+    git pull
+    pnpm install
+    pnpm --filter zhentan-screening build
+    pnpm --filter zhentan-runtime build
+    pm2 restart zhentan-runtime
+    echo "Update complete!"
+    ;;
+  "delete")
+    echo "Deleting PM2 process..."
+    pm2 delete zhentan-runtime
+    echo "Process deleted!"
+    ;;
+  *)
+    echo "Usage: $0 {install|build|start|startup|stop|restart|logs|health|monitor|status|update|delete}"
+    echo ""
+    echo "Commands:"
+    echo "  install  - Install PM2 globally"
+    echo "  build    - Install deps and build screening core + runtime"
+    echo "  start    - Start runtime with PM2 (requires runtime/.env)"
+    echo "  startup  - Configure PM2 to start on boot"
+    echo "  stop     - Stop runtime (screened proposals queue: fail-closed)"
+    echo "  restart  - Restart runtime"
+    echo "  logs     - View runtime logs"
+    echo "  health   - Query the localhost health endpoint"
+    echo "  monitor  - Open PM2 monitoring dashboard"
+    echo "  status   - Show PM2 status"
+    echo "  update   - Pull latest code, build, and restart"
+    echo "  delete   - Remove runtime from PM2"
+    exit 1
+    ;;
+esac

--- a/scripts/test/onchain-matrix.md
+++ b/scripts/test/onchain-matrix.md
@@ -60,3 +60,75 @@ Stop and do not merge if any row shows: `GS026` (signature order),
 fresh finalize before concluding), a mismatch between `executedBy` and the
 BscScan `from`, or a nonce consumed by anything other than the intended
 transaction.
+
+---
+
+## D5 addendum — two-process verification (issue #99)
+
+Run AFTER the D4 env migration, with BOTH processes up:
+
+```
+server/.env:   AGENT_ADDRESS set, SPONSOR_PRIVATE_KEY set, NO AGENT_PRIVATE_KEY
+runtime/.env:  AGENT_PRIVATE_KEY set, RUNTIME_API_TOKEN matching the server
+pnpm dev:server   +   pnpm dev:runtime     (or pm2 start both ecosystem files)
+```
+
+Sanity before starting: `curl 127.0.0.1:3002/health` → polling, no lastError.
+
+### D5.A — B3 matrix re-run
+
+Re-execute rows 1–8 above unchanged. Everything must behave identically —
+with two additions to each row's Verify column:
+
+- The screen job AND (where the agent signs) the sign job for the tx show
+  `status='succeeded'` in `runtime_jobs`.
+- The propose response still carries `autoExecuted`/`txHash` synchronously
+  (the co-located runtime answers within the 20s window).
+
+### D5.B — runtime-role rows
+
+| # | Flow | Trigger | Verify |
+|---|------|---------|--------|
+| B1 | Runtime down: screened proposal | Stop the runtime; propose low-risk transfer | Response `screening: "pending"`; tx stays pending; NOTHING executes; job `pending` |
+| B2 | Runtime recovery | Start the runtime | Backlog drains: decision applies, notifications fire, APPROVE auto-executes; total wait ≈ downtime |
+| B3 | Runtime down: relay-only | Stop the runtime; starter-profile transfer (screening off) | Executes normally — no runtime involvement |
+| B4 | Runtime down: rejection | Stop the runtime; reject a pending tx | Rejection stays `requested`/retryable; on runtime start the cancel signs + lands (B4 machinery + sign job) |
+| B5 | Sign refusal visibility | Delete `runtime/data/decisions.jsonl`, then approve a REVIEW tx screened BEFORE the deletion | Runtime refuses (`no local screening record`); reconciler re-screens; second approve succeeds |
+| B6 | signedBy verification | (Code-level, already unit-tested) | — |
+
+### D5.C — draft-flow matrix (agent-created drafts)
+
+| # | Flow | Trigger | Verify |
+|---|------|---------|--------|
+| C1 | Agent-created transfer draft | Queue a transfer request via TG/agent below the review band | Draft appears in dashboard; NO nonce consumed; no safeTxHash yet |
+| C2 | User signs the draft | Sign it from the dashboard | finalizeDraft: nonce assigned, hash computed, sign job (`draft_finalization`) succeeds, service shows 1/2 with agent as sender |
+| C3 | Review-band swap draft | Queue a swap request scoring 40–70 | Draft held for review; finalization only after approval |
+| C4 | Swap-quote refresh at finalization | Let a swap draft sit past quote validity, then sign | Fresh route/min-out signed (never the stale quote); or SwapRefreshError surfaces cleanly |
+| C5 | Runtime down during finalization | Stop runtime; sign a draft | Finalization fails cleanly (mirror is best-effort — flow continues OR surfaces retryably; record actual behaviour) |
+| C6 | Duplicate finalization | Sign the same draft twice (double-click / two tabs) | Idempotent — one nonce, one mirror |
+| C7 | User dismissal before nonce | Dismiss a draft | No nonce parked; row closed |
+| C8 | Service down during mirror | (If feasible: invalid SAFE_API_KEY temporarily) finalize a draft | Flow continues locally; mirror error logged only |
+
+### D5.D — no-agent-signature flows produce NO runtime jobs
+
+After running: relay-only execute (B3 row 3), backup co-sign (row 4),
+a Safe deploy (fresh onboarding), and a safeSync reconciliation (execute
+from app.safe.global directly), assert:
+
+```sql
+select kind, purpose, count(*) from runtime_jobs
+where tx_id in ('<relay-tx>', '<cosign-tx>')
+group by 1, 2;                       -- expect: screen rows only, NO sign rows
+
+select count(*) from runtime_jobs
+where safe_address = '<deployed-safe>';   -- expect 0 (deploy makes no jobs)
+```
+
+(safeSync-reconciled txs must likewise show no sign jobs.)
+
+### Recording
+
+As with B3: record every row here with tx hashes / job ids and paste the
+table into issue #99. Abort criteria unchanged (GS026, GS013, executedBy
+mismatch) plus: any sign job that succeeds WITHOUT a matching decision
+record (check `runtime/data/decisions.jsonl`) is an immediate stop.


### PR DESCRIPTION
Runbook for the D5 gate (#99): B3 re-run additions, runtime-role rows, the full draft-flow matrix, and no-agent-signature job-log assertions. Docs-only.

The gate itself is user-executed on funded Safes — results get recorded in #99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)