### PR TITLE
fix: signature count always showed 0 of N (rowToTx hardcoded empty signatures)

### DIFF
--- a/server/src/lib/supabase/db.ts
+++ b/server/src/lib/supabase/db.ts
@@ -35,7 +35,15 @@ export function rowToTx(row: TransactionRow): PendingTransaction {
     tokenAddress: row.token_address ?? "",
     tokenIconUrl: row.token_icon_url ?? null,
     proposedBy: row.proposed_by ?? "",
-    signatures: [],
+    // Real signature state: the proposer's signature + any co-signatures.
+    // The agent's signature is requested transiently at execution (D4) and
+    // never stored, so this is exactly what the UI should count — e.g.
+    // "1 of 2" while a SafeTx sits in review. (Was hardcoded [] — a
+    // vestige of the pre-DB queue format — making every dialog show 0/2.)
+    signatures: [
+      ...(row.user_signature ? [row.user_signature] : []),
+      ...(row.user_signatures ?? []).map((s) => s.data),
+    ],
     ownerAddresses: row.owner_addresses ?? [],
     threshold: row.threshold ?? 2,
     safeAddress: row.safe_address,


### PR DESCRIPTION
Reported live: a REVIEW-state transaction's dialog showed 0/2 signatures despite the proposer having signed.

**Root cause**: [db.ts](server/src/lib/supabase/db.ts) `rowToTx` hardcoded `signatures: []` — a vestige of the pre-DB JSON-queue format never wired to the real columns. Every DB-read transaction claimed zero signatures; SendPanel renders `{tx.signatures.length} of {tx.threshold}`.

**Fix**: populate from `user_signature` + `user_signatures` — the correct user-visible count, since the agent's signature is requested transiently at execution (D4) and never stored. `tx.signatures` has exactly one consumer (the SendPanel display); no logic depended on the empty array.

**Verified** against real rows: single-signed → `1/2`, backup-co-signed → `2/2`. Server 124 tests + lint green.

## Manual UI tests
- [x] Propose a REVIEW-band transfer → dialog shows **1 of 2**
- [x] Co-sign with backup key (screening off) → shows 2 of 2 before execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)