### PR TITLE
fix: server run.sh broke on workspace protocol (deploy blocker)

### DIFF
--- a/server/run.sh
+++ b/server/run.sh
@@ -17,8 +17,10 @@ case "$1" in
     echo "PM2 installed!"
     ;;
   "build")
-    echo "Building Zhentan server..."
-    cd server && npm install --force --legacy-peer-deps && npm run build && cd ..
+    echo "Building Zhentan server (screening core first)..."
+    pnpm install
+    pnpm --filter zhentan-screening build
+    pnpm --filter zhentan-server build
     echo "Building server complete!"
     ;;
   "start")
@@ -61,7 +63,9 @@ case "$1" in
   "update")
     echo "Updating server..."
     git pull
-    cd server && npm install --force --legacy-peer-deps && npm run build && cd ..
+    pnpm install
+    pnpm --filter zhentan-screening build
+    pnpm --filter zhentan-server build
     pm2 reload zhentan-server
     echo "Update complete!"
     ;;

--- a/server/src/lib/chain/sponsor.ts
+++ b/server/src/lib/chain/sponsor.ts
@@ -29,9 +29,11 @@ import { BSC_RPC } from "../constants.js";
 import { notifyTelegram } from "../../notify.js";
 import { getRelayerPublicClient } from "../safe/relayer.js";
 
-/** Pure resolution — exported for tests. */
+/** Pure resolution — exported for tests. Typed as a plain string record so
+ *  process.env stays assignable across @types/node versions (newer ones
+ *  fail the weak-type overlap check against a two-optional-key object). */
 export function resolveSponsorPrivateKey(
-  env: { SPONSOR_PRIVATE_KEY?: string; AGENT_PRIVATE_KEY?: string } = process.env
+  env: Record<string, string | undefined> = process.env
 ): string {
   const key = env.SPONSOR_PRIVATE_KEY || env.AGENT_PRIVATE_KEY;
   if (!key) throw new Error("Missing SPONSOR_PRIVATE_KEY and AGENT_PRIVATE_KEY");


### PR DESCRIPTION
Found executing the v3.0.0 deploy checklist: `./server/run.sh build` fails with `EUNSUPPORTEDPROTOCOL — workspace:*` because it still runs raw `npm install` inside `server/`, which predates the D1 workspace dependency on `zhentan-screening` (and the misleading 'complete!' still printed). Now uses pnpm from the root and builds the screening core first, matching `runtime/run.sh`. Verified locally: build compiles clean.

**Deploy-blocking for v3.0.0** — should promote to main immediately after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)