### PR TITLE
feat(client): Mao — the agent character on every agentic surface

### DIFF
--- a/client/src/app/(app)/settings/page.tsx
+++ b/client/src/app/(app)/settings/page.tsx
@@ -8,8 +8,6 @@ import { ActivationDialog } from "@/components/ActivationDialog";
 import { useAuth } from "@/app/context/AuthContext";
 import { useScreeningStatus } from "@/app/context/ScreeningStatusContext";
 import {
-  ShieldCheck,
-  ShieldOff,
   Loader2,
   Rocket,
   Server,
@@ -32,6 +30,7 @@ import { useSafeTransitions } from "@/lib/useSafeUpgrade";
 import { useForceExecuteSetting } from "@/lib/useForceExecute";
 import { useTour } from "@/components/tour/TourProvider";
 import { mainTour, upgradeTour } from "@/lib/tours";
+import { MaoAvatar } from "@/components/MaoAvatar";
 
 /** Section label + hairline rule, per the grouped settings design. */
 function SectionHeader({ label, danger }: { label: string; danger?: boolean }) {
@@ -447,11 +446,12 @@ function SettingsPageContent() {
                 <div data-tour="guard-card" className="rounded-2xl bg-card overflow-hidden shadow-[0_20px_50px_-38px_rgba(0,0,0,0.7)]">
                   <SettingsRow
                     icon={
-                      isScreeningActive ? (
-                        <ShieldCheck className="h-[18px] w-[18px]" />
-                      ) : (
-                        <ShieldOff className="h-[18px] w-[18px]" />
-                      )
+                      <MaoAvatar
+                        state={isScreeningActive ? "scanning" : "resting"}
+                        size={20}
+                        variant="solid"
+                        color="currentColor"
+                      />
                     }
                     iconTint={clsx(
                       "transition-colors",

--- a/client/src/app/globals.css
+++ b/client/src/app/globals.css
@@ -491,6 +491,163 @@
   }
 }
 
+/* Gesture vocabulary — the lens carries status, the body carries intent.
+   Each gesture is under ~a second, fires once, returns Mao to rest. */
+@keyframes mao-perk-root {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  30% {
+    transform: translateY(-5px);
+  }
+}
+
+@keyframes mao-perk-l {
+  0%,
+  100% {
+    transform: rotate(0deg);
+  }
+  30% {
+    transform: rotate(-13deg);
+  }
+}
+
+@keyframes mao-perk-r {
+  0%,
+  100% {
+    transform: rotate(0deg);
+  }
+  30% {
+    transform: rotate(13deg);
+  }
+}
+
+@keyframes mao-tilt {
+  0% {
+    transform: rotate(0deg);
+  }
+  22%,
+  68% {
+    transform: rotate(8deg);
+  }
+  100% {
+    transform: rotate(0deg);
+  }
+}
+
+@keyframes mao-nod {
+  0%,
+  100% {
+    transform: translateY(0) scaleY(1);
+  }
+  25%,
+  75% {
+    transform: translateY(5px) scaleY(0.95);
+  }
+  50% {
+    transform: translateY(0) scaleY(1);
+  }
+}
+
+@keyframes mao-shake {
+  0%,
+  100% {
+    transform: translateX(0) rotate(0deg);
+  }
+  20% {
+    transform: translateX(-5px) rotate(-3deg);
+  }
+  45% {
+    transform: translateX(5px) rotate(3deg);
+  }
+  72% {
+    transform: translateX(-3px) rotate(-2deg);
+  }
+}
+
+@keyframes mao-take {
+  0% {
+    transform: scale(1) rotate(0deg);
+  }
+  18% {
+    transform: scale(0.93) rotate(4deg);
+  }
+  46% {
+    transform: scale(1.07) rotate(-7deg);
+  }
+  76% {
+    transform: scale(1) rotate(-2deg);
+  }
+  100% {
+    transform: scale(1) rotate(0deg);
+  }
+}
+
+@keyframes mao-shades-down {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  22%,
+  74% {
+    transform: translateY(9px);
+  }
+}
+
+@keyframes mao-stretch {
+  0% {
+    transform: scale(1, 1);
+  }
+  25% {
+    transform: scale(1.09, 0.88);
+  }
+  55% {
+    transform: scale(0.95, 1.09);
+  }
+  80% {
+    transform: scale(1.02, 0.98);
+  }
+  100% {
+    transform: scale(1, 1);
+  }
+}
+
+@keyframes mao-pounce {
+  0% {
+    transform: translateY(0) scale(1, 1);
+  }
+  20% {
+    transform: translateY(7px) scale(1.06, 0.9);
+  }
+  46% {
+    transform: translateY(-17px) scale(0.94, 1.1);
+  }
+  76% {
+    transform: translateY(2px) scale(1.04, 0.96);
+  }
+  100% {
+    transform: translateY(0) scale(1, 1);
+  }
+}
+
+@keyframes mao-glint {
+  0% {
+    transform: translateX(-70px);
+    opacity: 0;
+  }
+  18% {
+    opacity: 1;
+  }
+  82% {
+    opacity: 1;
+  }
+  100% {
+    transform: translateX(70px);
+    opacity: 0;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .mao-anim {
     animation: none !important;

--- a/client/src/app/globals.css
+++ b/client/src/app/globals.css
@@ -655,7 +655,7 @@
 }
 
 .mao-poke:hover {
-  transform: scale(1.15);
+  transform: scale(1.22);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/client/src/app/globals.css
+++ b/client/src/app/globals.css
@@ -648,9 +648,22 @@
   }
 }
 
+/* Poke mode — Mao grows a touch under the cursor and invites a click. */
+.mao-poke {
+  cursor: pointer;
+  transition: transform 0.25s cubic-bezier(0.3, 0, 0.3, 1);
+}
+
+.mao-poke:hover {
+  transform: scale(1.08);
+}
+
 @media (prefers-reduced-motion: reduce) {
   .mao-anim {
     animation: none !important;
+  }
+  .mao-poke:hover {
+    transform: none;
   }
 }
 

--- a/client/src/app/globals.css
+++ b/client/src/app/globals.css
@@ -380,6 +380,123 @@
   animation: signal-pulse 2.2s ease-in-out infinite;
 }
 
+/* ── Mao — the agent character (see MaoAvatar.tsx) ────────────
+   The lens is the only surface that animates. One sweep pass per
+   1.6s, no bounce; a returning sweep reads as scrubbing, not
+   scanning. Under reduced motion every animation stops and the
+   sweep bar rests at centre-glass, so the state still reads. */
+@keyframes mao-sweep {
+  0% {
+    transform: translateX(-78px);
+  }
+  100% {
+    transform: translateX(78px);
+  }
+}
+
+@keyframes mao-sweep-soft {
+  0% {
+    transform: translateX(-78px);
+    opacity: 0;
+  }
+  12% {
+    opacity: 1;
+  }
+  78% {
+    opacity: 1;
+  }
+  100% {
+    transform: translateX(78px);
+    opacity: 0;
+  }
+}
+
+@keyframes mao-dot {
+  0%,
+  100% {
+    opacity: 0.22;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+@keyframes mao-alert {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
+}
+
+@keyframes mao-tick {
+  0% {
+    stroke-dashoffset: 26;
+  }
+  60%,
+  100% {
+    stroke-dashoffset: 0;
+  }
+}
+
+@keyframes mao-zzz {
+  0% {
+    opacity: 0;
+    transform: translate(0, 0) scale(0.7);
+  }
+  25% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+    transform: translate(9px, -14px) scale(1.1);
+  }
+}
+
+@keyframes mao-twitch-l {
+  0% {
+    transform: rotate(0deg);
+  }
+  22% {
+    transform: rotate(-10deg);
+  }
+  48% {
+    transform: rotate(3.5deg);
+  }
+  72% {
+    transform: rotate(-2deg);
+  }
+  100% {
+    transform: rotate(0deg);
+  }
+}
+
+@keyframes mao-twitch-r {
+  0% {
+    transform: rotate(0deg);
+  }
+  22% {
+    transform: rotate(10deg);
+  }
+  48% {
+    transform: rotate(-3.5deg);
+  }
+  72% {
+    transform: rotate(2deg);
+  }
+  100% {
+    transform: rotate(0deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mao-anim {
+    animation: none !important;
+  }
+}
+
 .skeleton-shimmer {
   background: linear-gradient(
     90deg,

--- a/client/src/app/globals.css
+++ b/client/src/app/globals.css
@@ -655,7 +655,7 @@
 }
 
 .mao-poke:hover {
-  transform: scale(1.08);
+  transform: scale(1.15);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/client/src/components/GuardianCard.module.css
+++ b/client/src/components/GuardianCard.module.css
@@ -119,14 +119,9 @@
 }
 
 .sonarCenter {
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-  background: rgba(245, 208, 96, 0.1);
   display: flex;
   align-items: center;
   justify-content: center;
-  animation: sonarBreath 2.4s ease-in-out infinite;
   position: relative;
   z-index: 1;
 }
@@ -142,11 +137,6 @@
 @keyframes sonarExpand {
   0%   { transform: scale(1);   opacity: 0.9; }
   100% { transform: scale(2.2); opacity: 0;   }
-}
-
-@keyframes sonarBreath {
-  0%, 100% { transform: scale(1);    }
-  50%       { transform: scale(1.06); }
 }
 
 /* ── Transaction card ── */

--- a/client/src/components/GuardianCard.tsx
+++ b/client/src/components/GuardianCard.tsx
@@ -2,6 +2,7 @@
 
 import { ReactNode, useEffect, useState } from "react";
 import { TwinTick } from "@/components/BrandMark";
+import { MaoAvatar } from "@/components/MaoAvatar";
 import s from "./GuardianCard.module.css";
 
 function SwapIcon() {
@@ -153,7 +154,7 @@ export function GuardianCard() {
             <span key={i} className={s.sonarRing} style={{ animationDelay: `${i * 0.8}s` }} />
           ))}
           <div className={s.sonarCenter}>
-            <TwinTick size={22} halo="none" style={{ opacity: 0.85 }} />
+            <MaoAvatar state="scanning" size={50} earTwitch={false} />
           </div>
         </div>
         <p className={s.sonarLabel}>Zhentan is monitoring</p>

--- a/client/src/components/MaoAvatar.tsx
+++ b/client/src/components/MaoAvatar.tsx
@@ -33,6 +33,43 @@ export type MaoState =
   | "resting" //  dimmed rim + z — screening paused
   | "asking"; //  ?? in the lenses — paused on YOUR decision
 
+/**
+ * Gesture vocabulary (design: "the lens carries status; the body carries
+ * intent"). Each gesture is under ~a second, fires once, and returns Mao to
+ * rest. Some carry event semantics — shake is refusal (flagged results
+ * only), nod confirms, double-take means something looks off — so ambient
+ * pools should stick to the neutral ones.
+ */
+export type MaoGesture =
+  | "perk" //        ears snap up, head lifts — work just arrived
+  | "tilt" //        head cocks and holds — pairs with a question
+  | "nod" //         two dips — confirms the action you chose
+  | "shake" //       refusal — only ever with a flagged result
+  | "double-take" // recoil then lean in — something looks off
+  | "shades-down" // glass drops for a beat — off the record
+  | "stretch" //     squash then rebound — waking from rest
+  | "pounce" //      crouch, hop, land — found the thing
+  | "ear-flick" //   ambient — the baseline idle motion
+  | "glint"; //      light crosses the glass — acknowledges you
+
+/** Animation target → [keyframe spec] per gesture (timings from the design). */
+const GESTURE_PARTS: Record<MaoGesture, [target: "root" | "earL" | "earR" | "ear" | "shades" | "glint", anim: string][]> = {
+  perk: [
+    ["root", "mao-perk-root 0.7s cubic-bezier(.2,1.4,.4,1) 1"],
+    ["earL", "mao-perk-l 0.7s cubic-bezier(.2,1.4,.4,1) 1"],
+    ["earR", "mao-perk-r 0.7s cubic-bezier(.2,1.4,.4,1) 1"],
+  ],
+  tilt: [["root", "mao-tilt 1.3s cubic-bezier(.3,0,.3,1) 1"]],
+  nod: [["root", "mao-nod 0.8s cubic-bezier(.3,0,.3,1) 1"]],
+  shake: [["root", "mao-shake 0.62s cubic-bezier(.36,0,.3,1) 1"]],
+  "double-take": [["root", "mao-take 0.8s cubic-bezier(.3,0,.3,1) 1"]],
+  "shades-down": [["shades", "mao-shades-down 1.5s cubic-bezier(.3,0,.3,1) 1"]],
+  stretch: [["root", "mao-stretch 0.9s cubic-bezier(.3,0,.3,1) 1"]],
+  pounce: [["root", "mao-pounce 0.85s cubic-bezier(.3,0,.35,1) 1"]],
+  "ear-flick": [["ear", ""]], // resolved at fire time — random ear, twitch keyframe
+  glint: [["glint", "mao-glint 0.7s cubic-bezier(.4,0,.4,1) 1"]],
+};
+
 interface MaoAvatarProps {
   state?: MaoState;
   /** Rendered width/height in px (the mark is square). */
@@ -50,6 +87,12 @@ interface MaoAvatarProps {
   mouth?: "auto" | "smile";
   /** Random ear flicks (detail weight, awake states, ≥48px). Defaults on. */
   earTwitch?: boolean;
+  /**
+   * Ambient gesture pool (detail weight, awake states, ≥48px). While Mao
+   * waits, a random gesture from this pool fires every 4–11s — richer
+   * company than the default lone ear flick. Overrides `earTwitch`.
+   */
+  ambient?: MaoGesture[];
   className?: string;
   "aria-label"?: string;
 }
@@ -219,37 +262,65 @@ function MaoDetail({
   size,
   earTwitch,
   mouth = "auto",
+  ambient,
 }: {
   state: MaoState;
   size: number;
   earTwitch: boolean;
   mouth?: "auto" | "smile";
+  ambient?: MaoGesture[];
 }) {
   const uid = useId().replace(/[^a-zA-Z0-9]/g, "");
   const clipId = `maoShades-${uid}`;
   const meta = STATE_META[state];
   const [earL, earR] = EARS[meta.ears];
+  const rootRef = useRef<SVGGElement>(null);
   const earLRef = useRef<SVGGElement>(null);
   const earRRef = useRef<SVGGElement>(null);
+  const shadesRef = useRef<SVGGElement>(null);
+  const glintRef = useRef<SVGGElement>(null);
 
-  // Occasional ear flick — the timer only decides WHEN; the flick itself is a
-  // CSS keyframe so it plays independently of React renders. Awake states only.
+  // Ambient motion — the timer only decides WHEN; each gesture is a CSS
+  // keyframe that fires once and returns Mao to rest, so it plays
+  // independently of React renders. Awake states only; the pool defaults to
+  // the lone ear flick unless the caller hands over a richer vocabulary.
   const awake = state === "idle" || state === "scanning" || state === "thinking" || state === "asking";
-  const flicking = earTwitch && awake && size >= 48;
+  const pool = ambient ?? (earTwitch ? ["ear-flick" as const] : []);
+  const active = awake && size >= 48 && pool.length > 0;
+  const poolKey = pool.join(",");
   useEffect(() => {
-    if (!flicking) return;
+    if (!active) return;
     if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) return;
+    const gestures = poolKey.split(",") as MaoGesture[];
+    const targets = {
+      root: rootRef,
+      earL: earLRef,
+      earR: earRRef,
+      shades: shadesRef,
+      glint: glintRef,
+    };
+    const fire = (el: SVGGElement | null, anim: string) => {
+      if (!el) return;
+      el.style.animation = "none";
+      void el.getBoundingClientRect().width;
+      el.style.animation = anim;
+    };
     let alive = true;
     let timer: ReturnType<typeof setTimeout>;
     const schedule = (delay: number) => {
       timer = setTimeout(() => {
         if (!alive) return;
-        const left = Math.random() < 0.5;
-        const el = (left ? earLRef : earRRef).current;
-        if (el) {
-          el.style.animation = "none";
-          void el.getBoundingClientRect().width;
-          el.style.animation = `${left ? "mao-twitch-l" : "mao-twitch-r"} 0.44s cubic-bezier(.3,0,.4,1) 1`;
+        const gesture = gestures[Math.floor(Math.random() * gestures.length)];
+        for (const [target, anim] of GESTURE_PARTS[gesture]) {
+          if (target === "ear") {
+            const left = Math.random() < 0.5;
+            fire(
+              (left ? earLRef : earRRef).current,
+              `${left ? "mao-twitch-l" : "mao-twitch-r"} 0.44s cubic-bezier(.3,0,.4,1) 1`
+            );
+          } else {
+            fire(targets[target].current, anim);
+          }
         }
         schedule(4000 + Math.random() * 7000);
       }, delay);
@@ -259,70 +330,84 @@ function MaoDetail({
       alive = false;
       clearTimeout(timer);
     };
-  }, [flicking]);
+  }, [active, poolKey]);
 
   const face = size >= 48; //  whiskers + mouth survive to 48px
   const innerEars = size >= 96 && meta.ears === "default";
 
   return (
-    <svg viewBox="0 0 100 100" width={size} height={size} style={{ display: "block" }} aria-hidden="true">
+    <svg
+      viewBox="0 0 100 100"
+      width={size}
+      height={size}
+      style={{ display: "block", overflow: "visible" }} //  pounce overshoots the box
+      aria-hidden="true"
+    >
       <defs>
         <clipPath id={clipId}>
           <path d={SHADES} />
         </clipPath>
       </defs>
 
-      <g ref={earLRef} style={{ transformOrigin: "30px 42px" }}>
-        <path d={earL} fill={GOLD} />
-        {innerEars && <path d={INNER_EARS[0]} fill={INK_FAINT} />}
-      </g>
-      <g ref={earRRef} style={{ transformOrigin: "70px 42px" }}>
-        <path d={earR} fill={GOLD} />
-        {innerEars && <path d={INNER_EARS[1]} fill={INK_FAINT} />}
-      </g>
-
-      <path d={HEAD} fill={GOLD} />
-
-      {face && (
-        <g fill="none" stroke={INK_SOFT} strokeWidth="1.8" strokeLinecap="round">
-          {WHISKERS.map((d) => (
-            <path key={d} d={d} />
-          ))}
+      <g ref={rootRef} style={{ transformOrigin: "50px 76px" }}>
+        <g ref={earLRef} style={{ transformOrigin: "30px 42px" }}>
+          <path d={earL} fill={GOLD} />
+          {innerEars && <path d={INNER_EARS[0]} fill={INK_FAINT} />}
         </g>
-      )}
+        <g ref={earRRef} style={{ transformOrigin: "70px 42px" }}>
+          <path d={earR} fill={GOLD} />
+          {innerEars && <path d={INNER_EARS[1]} fill={INK_FAINT} />}
+        </g>
 
-      <path d={NOSE} fill={INK} />
-      {face &&
-        (() => {
-          const m = mouth === "smile" ? { shape: "smile" as const, color: INK } : meta.mouth;
-          if (!m) return null;
-          return (
-            <g fill="none" stroke={m.color} strokeWidth="2.2" strokeLinecap="round">
-              {MOUTHS[m.shape].map((d) => (
-                <path key={d} d={d} />
-              ))}
+        <path d={HEAD} fill={GOLD} />
+
+        {face && (
+          <g fill="none" stroke={INK_SOFT} strokeWidth="1.8" strokeLinecap="round">
+            {WHISKERS.map((d) => (
+              <path key={d} d={d} />
+            ))}
+          </g>
+        )}
+
+        <path d={NOSE} fill={INK} />
+        {face &&
+          (() => {
+            const m = mouth === "smile" ? { shape: "smile" as const, color: INK } : meta.mouth;
+            if (!m) return null;
+            return (
+              <g fill="none" stroke={m.color} strokeWidth="2.2" strokeLinecap="round">
+                {MOUTHS[m.shape].map((d) => (
+                  <path key={d} d={d} />
+                ))}
+              </g>
+            );
+          })()}
+
+        {/* The glass block moves as one during shades-down: rim, light, glint. */}
+        <g ref={shadesRef}>
+          <path
+            d={SHADES}
+            fill={meta.glass}
+            stroke={meta.rim}
+            strokeWidth={meta.rim ? 2.8 : undefined}
+            strokeLinejoin={meta.rim ? "round" : undefined}
+          />
+          <g clipPath={`url(#${clipId})`}>
+            <LensContent state={state} />
+            <g ref={glintRef} style={{ opacity: 0 }}>
+              <rect x="46" y="30" width="11" height="46" fill={GOLD_LIGHT} opacity="0.85" transform="rotate(24 50 50)" />
             </g>
-          );
-        })()}
-
-      <path
-        d={SHADES}
-        fill={meta.glass}
-        stroke={meta.rim}
-        strokeWidth={meta.rim ? 2.8 : undefined}
-        strokeLinejoin={meta.rim ? "round" : undefined}
-      />
-      <g clipPath={`url(#${clipId})`}>
-        <LensContent state={state} />
-      </g>
-
-      {state === "resting" && (
-        <g className="mao-anim" style={{ animation: "mao-zzz 2.6s ease-out infinite" }}>
-          <text x="76" y="22" fontFamily="var(--font-mono, monospace)" fontSize="15" fontWeight="700" fill={GOLD}>
-            z
-          </text>
+          </g>
         </g>
-      )}
+
+        {state === "resting" && (
+          <g className="mao-anim" style={{ animation: "mao-zzz 2.6s ease-out infinite" }}>
+            <text x="76" y="22" fontFamily="var(--font-mono, monospace)" fontSize="15" fontWeight="700" fill={GOLD}>
+              z
+            </text>
+          </g>
+        )}
+      </g>
     </svg>
   );
 }
@@ -381,6 +466,7 @@ export function MaoAvatar({
   color,
   mouth,
   earTwitch = true,
+  ambient,
   className,
   "aria-label": ariaLabel,
 }: MaoAvatarProps) {
@@ -395,7 +481,7 @@ export function MaoAvatar({
       {weight === "solid" ? (
         <MaoSolid state={state} size={size} color={color} />
       ) : (
-        <MaoDetail state={state} size={size} earTwitch={earTwitch} mouth={mouth} />
+        <MaoDetail state={state} size={size} earTwitch={earTwitch} mouth={mouth} ambient={ambient} />
       )}
     </span>
   );

--- a/client/src/components/MaoAvatar.tsx
+++ b/client/src/components/MaoAvatar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { useEffect, useId, useRef } from "react";
+import { useCallback, useEffect, useId, useRef } from "react";
 
 /**
  * Mao — the Zhentan agent character. One geometric cat, solid gold, opaque
@@ -70,6 +70,9 @@ const GESTURE_PARTS: Record<MaoGesture, [target: "root" | "earL" | "earR" | "ear
   glint: [["glint", "mao-glint 0.7s cubic-bezier(.4,0,.4,1) 1"]],
 };
 
+/** Neutral gestures — safe to play without an event behind them. */
+const NEUTRAL_GESTURES: MaoGesture[] = ["ear-flick", "perk", "tilt", "stretch", "pounce", "shades-down"];
+
 interface MaoAvatarProps {
   state?: MaoState;
   /** Rendered width/height in px (the mark is square). */
@@ -93,6 +96,12 @@ interface MaoAvatarProps {
    * company than the default lone ear flick. Overrides `earTwitch`.
    */
   ambient?: MaoGesture[];
+  /**
+   * Poke mode (detail weight): clicking Mao fires a random gesture from the
+   * ambient pool (or the neutral set), and he grows slightly on hover.
+   * Clicks don't bubble — safe inside a Link.
+   */
+  interactive?: boolean;
   className?: string;
   "aria-label"?: string;
 }
@@ -263,12 +272,14 @@ function MaoDetail({
   earTwitch,
   mouth = "auto",
   ambient,
+  interactive = false,
 }: {
   state: MaoState;
   size: number;
   earTwitch: boolean;
   mouth?: "auto" | "smile";
   ambient?: MaoGesture[];
+  interactive?: boolean;
 }) {
   const uid = useId().replace(/[^a-zA-Z0-9]/g, "");
   const clipId = `maoShades-${uid}`;
@@ -280,18 +291,11 @@ function MaoDetail({
   const shadesRef = useRef<SVGGElement>(null);
   const glintRef = useRef<SVGGElement>(null);
 
-  // Ambient motion — the timer only decides WHEN; each gesture is a CSS
-  // keyframe that fires once and returns Mao to rest, so it plays
-  // independently of React renders. Awake states only; the pool defaults to
-  // the lone ear flick unless the caller hands over a richer vocabulary.
-  const awake = state === "idle" || state === "scanning" || state === "thinking" || state === "asking";
-  const pool = ambient ?? (earTwitch ? ["ear-flick" as const] : []);
-  const active = awake && size >= 48 && pool.length > 0;
-  const poolKey = pool.join(",");
-  useEffect(() => {
-    if (!active) return;
+  // Each gesture is a CSS keyframe that fires once and returns Mao to rest,
+  // so it plays independently of React renders. Shared by the ambient timer
+  // and pokes.
+  const fireGesture = useCallback((gesture: MaoGesture) => {
     if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) return;
-    const gestures = poolKey.split(",") as MaoGesture[];
     const targets = {
       root: rootRef,
       earL: earLRef,
@@ -305,23 +309,35 @@ function MaoDetail({
       void el.getBoundingClientRect().width;
       el.style.animation = anim;
     };
+    for (const [target, anim] of GESTURE_PARTS[gesture]) {
+      if (target === "ear") {
+        const left = Math.random() < 0.5;
+        fire(
+          (left ? earLRef : earRRef).current,
+          `${left ? "mao-twitch-l" : "mao-twitch-r"} 0.44s cubic-bezier(.3,0,.4,1) 1`
+        );
+      } else {
+        fire(targets[target].current, anim);
+      }
+    }
+  }, []);
+
+  // Ambient motion — the timer only decides WHEN. Awake states only; the
+  // pool defaults to the lone ear flick unless the caller hands over a
+  // richer vocabulary.
+  const awake = state === "idle" || state === "scanning" || state === "thinking" || state === "asking";
+  const pool = ambient ?? (earTwitch ? ["ear-flick" as const] : []);
+  const active = awake && size >= 48 && pool.length > 0;
+  const poolKey = pool.join(",");
+  useEffect(() => {
+    if (!active) return;
+    const gestures = poolKey.split(",") as MaoGesture[];
     let alive = true;
     let timer: ReturnType<typeof setTimeout>;
     const schedule = (delay: number) => {
       timer = setTimeout(() => {
         if (!alive) return;
-        const gesture = gestures[Math.floor(Math.random() * gestures.length)];
-        for (const [target, anim] of GESTURE_PARTS[gesture]) {
-          if (target === "ear") {
-            const left = Math.random() < 0.5;
-            fire(
-              (left ? earLRef : earRRef).current,
-              `${left ? "mao-twitch-l" : "mao-twitch-r"} 0.44s cubic-bezier(.3,0,.4,1) 1`
-            );
-          } else {
-            fire(targets[target].current, anim);
-          }
-        }
+        fireGesture(gestures[Math.floor(Math.random() * gestures.length)]);
         schedule(4000 + Math.random() * 7000);
       }, delay);
     };
@@ -330,7 +346,19 @@ function MaoDetail({
       alive = false;
       clearTimeout(timer);
     };
-  }, [active, poolKey]);
+  }, [active, poolKey, fireGesture]);
+
+  // Poke — a click plays a random gesture from the same pool the ambient
+  // loop draws from. Never bubbles: Mao often sits inside a Link, and
+  // petting the cat shouldn't navigate.
+  const pokePool = pool.length > 0 ? pool : NEUTRAL_GESTURES;
+  const poke = interactive
+    ? (e: React.MouseEvent<SVGSVGElement>) => {
+        e.preventDefault();
+        e.stopPropagation();
+        fireGesture(pokePool[Math.floor(Math.random() * pokePool.length)]);
+      }
+    : undefined;
 
   const face = size >= 48; //  whiskers + mouth survive to 48px
   const innerEars = size >= 96 && meta.ears === "default";
@@ -341,6 +369,8 @@ function MaoDetail({
       width={size}
       height={size}
       style={{ display: "block", overflow: "visible" }} //  pounce overshoots the box
+      className={interactive ? "mao-poke" : undefined}
+      onClick={poke}
       aria-hidden="true"
     >
       <defs>
@@ -467,6 +497,7 @@ export function MaoAvatar({
   mouth,
   earTwitch = true,
   ambient,
+  interactive = false,
   className,
   "aria-label": ariaLabel,
 }: MaoAvatarProps) {
@@ -481,7 +512,14 @@ export function MaoAvatar({
       {weight === "solid" ? (
         <MaoSolid state={state} size={size} color={color} />
       ) : (
-        <MaoDetail state={state} size={size} earTwitch={earTwitch} mouth={mouth} ambient={ambient} />
+        <MaoDetail
+          state={state}
+          size={size}
+          earTwitch={earTwitch}
+          mouth={mouth}
+          ambient={ambient}
+          interactive={interactive}
+        />
       )}
     </span>
   );

--- a/client/src/components/MaoAvatar.tsx
+++ b/client/src/components/MaoAvatar.tsx
@@ -4,40 +4,44 @@ import * as React from "react";
 import { useEffect, useId, useRef } from "react";
 
 /**
- * Mao — the Zhentan agent character. A geometric black cat with gold
- * linework and opaque shades; the lens is the status screen. Every state
- * the agent can be in is drawn INSIDE the glass — work is never a spinner
- * somewhere else on the page, it's light moving across Mao's shades.
+ * Mao — the Zhentan agent character. One geometric cat, solid gold, opaque
+ * shades; the lens is the status screen. Every state the agent can be in is
+ * drawn INSIDE the glass — work is never a spinner somewhere else on the
+ * page, it's light moving across Mao's shades.
  *
- * Two weights (per the character spec):
- *  - "line": outlined head, detailed lens animations. 28px and up.
- *  - "solid": filled head with knocked-out glass. Below 28px, and for
- *    chips/pills where the mark takes the surrounding text color.
+ * The mark is ONE weight (per the character spec): solid gold head, ink
+ * details, knocked-out glass — so nothing changes down the size ladder,
+ * details just drop away:
+ *  - "detail" (≥28px): whiskers/mouth from 48px, inner ears from 96px;
+ *    cleared/flagged/resting keep the gold body and speak through a colored
+ *    glass rim + the light inside the lens.
+ *  - "solid" (below 28px): the simplified mark for chips and pills; the
+ *    WHOLE cat takes the state tint (or `currentColor` from the chip).
  *
- * Only the lens animates; ears, whiskers and mouth hold still while a
- * loader runs (an occasional ear flick is the one exception — it plays
- * between loads of work, never during a result). Under reduced motion the
- * sweep bar rests at centre-glass, so the state still reads.
+ * Only the lens animates; the silhouette holds still while a loader runs
+ * (an occasional ear flick is the one exception — it plays between loads of
+ * work, never during a result). Under reduced motion every animation stops
+ * and the sweep bar rests at centre-glass, so the state still reads.
  */
 
 export type MaoState =
   | "idle" //     two static glints + a slow soft sweep — on duty, nothing to do
-  | "scanning" // bright sweep, mouth flat — actively screening
+  | "scanning" // bright sweep — actively screening
   | "thinking" // ears back, dots pulse — weighing a verdict
-  | "cleared" //  green, twin ticks draw in the glass
-  | "flagged" //  red, alert bars pulse — blocked / needs attention
-  | "resting" //  dimmed glass, z — screening paused
+  | "cleared" //  green rim, twin ticks draw in the glass
+  | "flagged" //  red rim, alert bars pulse — blocked / needs attention
+  | "resting" //  dimmed rim + z — screening paused
   | "asking"; //  ?? in the lenses — paused on YOUR decision
 
 interface MaoAvatarProps {
   state?: MaoState;
   /** Rendered width/height in px (the mark is square). */
   size?: number;
-  /** Defaults to "solid" below 28px, "line" otherwise. */
-  variant?: "line" | "solid";
+  /** Defaults to "solid" below 28px, "detail" otherwise. */
+  variant?: "detail" | "solid";
   /** Solid-weight tint override (e.g. "currentColor" inside a colored chip). */
   color?: string;
-  /** Random ear flicks (line weight, awake states, ≥48px). Defaults on. */
+  /** Random ear flicks (detail weight, awake states, ≥48px). Defaults on. */
   earTwitch?: boolean;
   className?: string;
   "aria-label"?: string;
@@ -49,12 +53,14 @@ const GOLD_LIGHT = "#e8b93a";
 const SAFE = "var(--safe, #3fbe76)";
 const DANGER = "var(--danger, #e5524f)";
 const MUTED = "var(--ink-300, #8e938a)";
-const HEAD = "#12171a";
+const INK = "#0a0d0e";
+const INK_SOFT = "rgba(10,13,14,0.5)"; //  whiskers on the gold head
+const INK_FAINT = "rgba(10,13,14,0.34)"; // inner ears
 
-/* ── Line-weight geometry ──────────────────────────────────────────── */
-const L_HEAD =
+/* ── Detail-weight geometry ────────────────────────────────────────── */
+const HEAD =
   "M50 19 C72 19, 88 34, 88 55 C88 76, 71 89, 50 89 C29 89, 12 76, 12 55 C12 34, 28 19, 50 19 Z";
-const L_SHADES =
+const SHADES =
   "M18 41 L82 41 C84.8 41, 86 42.8, 85.4 45.4 L82.6 57.4 C82 60, 80 61.4, 77.4 61.4 L60 61.4 C57.4 61.4, 55.6 60, 55 57.4 L53.4 51 L46.6 51 L45 57.4 C44.4 60, 42.6 61.4, 40 61.4 L22.6 61.4 C20 61.4, 18 60, 17.4 57.4 L14.6 45.4 C14 42.8, 15.2 41, 18 41 Z";
 const NOSE = "M46.6 62.6 L53.4 62.6 L50 68.6 Z";
 const EARS: Record<"default" | "back" | "alert", [string, string]> = {
@@ -64,31 +70,58 @@ const EARS: Record<"default" | "back" | "alert", [string, string]> = {
 };
 const INNER_EARS: [string, string] = ["M25 21 L35 31 L23 36 Z", "M75 21 L65 31 L77 36 Z"];
 const WHISKERS = ["M37 70 L18 66", "M37 75 L17 78", "M63 70 L82 66", "M63 75 L83 78"];
-const MOUTHS: Record<"smile" | "flat" | "worried" | "frown", string[]> = {
+const MOUTHS: Record<"smile" | "frown", string[]> = {
   smile: ["M50 69.4 C48 73, 44.4 72.6, 43.2 69.6", "M50 69.4 C52 73, 55.6 72.6, 56.8 69.6"],
-  flat: ["M43.6 71 L56.4 71"],
-  worried: ["M43.6 71.6 C46.4 69.8, 51 69.8, 53.6 71.2"],
   frown: ["M43.6 72 C46.4 69.8, 53.6 69.8, 56.4 72"],
 };
 
-/* ── Solid-weight geometry (fill head, knocked-out glass) ──────────── */
+/* ── Solid-weight geometry (simplified mark for chips) ─────────────── */
 const S_EARS: [string, string] = ["M18 8 L42 32 L14 46 Z", "M82 8 L58 32 L86 46 Z"];
 const S_HEAD =
   "M50 17 C74 17, 91 33, 91 55 C91 78, 71 92, 50 92 C29 92, 9 78, 9 55 C9 33, 26 17, 50 17 Z";
 const S_SHADES =
   "M16 40 L84 40 C87 40, 88.4 42, 87.6 44.8 L84.6 58 C84 60.8, 81.8 62.4, 79 62.4 L60 62.4 C57.2 62.4, 55.2 60.8, 54.6 58 L53 51 L47 51 L45.4 58 C44.8 60.8, 42.8 62.4, 40 62.4 L21 62.4 C18.2 62.4, 16 60.8, 15.4 58 L12.4 44.8 C11.6 42, 13 40, 16 40 Z";
 
+/**
+ * Per-state look. The body is ALWAYS gold — mood lives in the ear pose, the
+ * glass rim, the mouth, and the light inside the lens. Working/resting
+ * states drop the mouth entirely (all attention on the glass); results and
+ * social states get one back, in the state's color.
+ */
 const STATE_META: Record<
   MaoState,
-  { tone: string; glass: string; ears: keyof typeof EARS; mouth: keyof typeof MOUTHS; label: string }
+  {
+    glass: string;
+    rim?: string;
+    ears: keyof typeof EARS;
+    mouth?: { shape: keyof typeof MOUTHS; color: string };
+    label: string;
+  }
 > = {
-  idle: { tone: GOLD, glass: "#0f1214", ears: "default", mouth: "smile", label: "Zhentan agent on duty" },
-  scanning: { tone: GOLD, glass: "#0f1214", ears: "default", mouth: "flat", label: "Zhentan agent scanning" },
-  thinking: { tone: GOLD, glass: "#0f1214", ears: "back", mouth: "worried", label: "Zhentan agent thinking" },
-  cleared: { tone: SAFE, glass: "#0d1613", ears: "default", mouth: "smile", label: "Cleared by the Zhentan agent" },
-  flagged: { tone: DANGER, glass: "#180f0e", ears: "alert", mouth: "frown", label: "Flagged by the Zhentan agent" },
-  resting: { tone: GOLD, glass: "#0f1214", ears: "default", mouth: "smile", label: "Zhentan agent paused" },
-  asking: { tone: GOLD, glass: "#0f1214", ears: "default", mouth: "smile", label: "Zhentan agent awaiting your decision" },
+  idle: { glass: "#0b0e10", ears: "default", mouth: { shape: "smile", color: INK }, label: "Zhentan agent on duty" },
+  scanning: { glass: "#0b0e10", ears: "default", label: "Zhentan agent scanning" },
+  thinking: { glass: "#0b0e10", ears: "back", label: "Zhentan agent thinking" },
+  cleared: {
+    glass: "#0d1613",
+    rim: SAFE,
+    ears: "default",
+    mouth: { shape: "smile", color: SAFE },
+    label: "Cleared by the Zhentan agent",
+  },
+  flagged: {
+    glass: "#180f0e",
+    rim: DANGER,
+    ears: "alert",
+    mouth: { shape: "frown", color: DANGER },
+    label: "Flagged by the Zhentan agent",
+  },
+  resting: { glass: "#0b0e10", rim: "rgba(196,148,40,0.5)", ears: "default", label: "Zhentan agent paused" },
+  asking: {
+    glass: "#0b0e10",
+    ears: "default",
+    mouth: { shape: "smile", color: INK },
+    label: "Zhentan agent awaiting your decision",
+  },
 };
 
 /** One sweep bar (bright core + two faint trailers), rotated to the lens angle. */
@@ -109,7 +142,7 @@ function SweepBars({ soft }: { soft?: boolean }) {
   );
 }
 
-/** What lives inside the glass for each state (line weight). */
+/** What lives inside the glass for each state (detail weight). */
 function LensContent({ state }: { state: MaoState }) {
   switch (state) {
     case "idle":
@@ -174,11 +207,10 @@ function LensContent({ state }: { state: MaoState }) {
   }
 }
 
-function MaoLine({ state, size, earTwitch }: { state: MaoState; size: number; earTwitch: boolean }) {
+function MaoDetail({ state, size, earTwitch }: { state: MaoState; size: number; earTwitch: boolean }) {
   const uid = useId().replace(/[^a-zA-Z0-9]/g, "");
   const clipId = `maoShades-${uid}`;
   const meta = STATE_META[state];
-  const dimmed = state === "resting";
   const [earL, earR] = EARS[meta.ears];
   const earLRef = useRef<SVGGElement>(null);
   const earRRef = useRef<SVGGElement>(null);
@@ -212,48 +244,51 @@ function MaoLine({ state, size, earTwitch }: { state: MaoState; size: number; ea
     };
   }, [flicking]);
 
-  const stroke = meta.tone;
-  const detail = size >= 64;
+  const face = size >= 48; //  whiskers + mouth survive to 48px
+  const innerEars = size >= 96 && meta.ears === "default";
 
   return (
     <svg viewBox="0 0 100 100" width={size} height={size} style={{ display: "block" }} aria-hidden="true">
       <defs>
         <clipPath id={clipId}>
-          <path d={L_SHADES} />
+          <path d={SHADES} />
         </clipPath>
       </defs>
 
       <g ref={earLRef} style={{ transformOrigin: "30px 42px" }}>
-        <path d={earL} fill={HEAD} stroke={stroke} strokeWidth="2.6" strokeLinejoin="round" />
-        {detail && meta.ears === "default" && <path d={INNER_EARS[0]} fill="rgba(196,148,40,0.3)" />}
+        <path d={earL} fill={GOLD} />
+        {innerEars && <path d={INNER_EARS[0]} fill={INK_FAINT} />}
       </g>
       <g ref={earRRef} style={{ transformOrigin: "70px 42px" }}>
-        <path d={earR} fill={HEAD} stroke={stroke} strokeWidth="2.6" strokeLinejoin="round" />
-        {detail && meta.ears === "default" && <path d={INNER_EARS[1]} fill="rgba(196,148,40,0.3)" />}
+        <path d={earR} fill={GOLD} />
+        {innerEars && <path d={INNER_EARS[1]} fill={INK_FAINT} />}
       </g>
 
-      <path d={L_HEAD} fill={HEAD} stroke={stroke} strokeWidth="2.6" />
+      <path d={HEAD} fill={GOLD} />
 
-      <g fill="none" stroke={stroke} strokeOpacity="0.55" strokeWidth="1.8" strokeLinecap="round">
-        {WHISKERS.map((d) => (
-          <path key={d} d={d} />
-        ))}
-      </g>
+      {face && (
+        <g fill="none" stroke={INK_SOFT} strokeWidth="1.8" strokeLinecap="round">
+          {WHISKERS.map((d) => (
+            <path key={d} d={d} />
+          ))}
+        </g>
+      )}
 
-      <path d={NOSE} fill={stroke} />
-      <g fill="none" stroke={stroke} strokeWidth="2.2" strokeLinecap="round">
-        {MOUTHS[meta.mouth].map((d) => (
-          <path key={d} d={d} />
-        ))}
-      </g>
+      <path d={NOSE} fill={INK} />
+      {face && meta.mouth && (
+        <g fill="none" stroke={meta.mouth.color} strokeWidth="2.2" strokeLinecap="round">
+          {MOUTHS[meta.mouth.shape].map((d) => (
+            <path key={d} d={d} />
+          ))}
+        </g>
+      )}
 
       <path
-        d={L_SHADES}
+        d={SHADES}
         fill={meta.glass}
-        stroke={stroke}
-        strokeOpacity={dimmed ? 0.5 : 1}
-        strokeWidth="2.8"
-        strokeLinejoin="round"
+        stroke={meta.rim}
+        strokeWidth={meta.rim ? 2.8 : undefined}
+        strokeLinejoin={meta.rim ? "round" : undefined}
       />
       <g clipPath={`url(#${clipId})`}>
         <LensContent state={state} />
@@ -273,19 +308,18 @@ function MaoLine({ state, size, earTwitch }: { state: MaoState; size: number; ea
 function MaoSolid({ state, size, color }: { state: MaoState; size: number; color?: string }) {
   const uid = useId().replace(/[^a-zA-Z0-9]/g, "");
   const clipId = `maoShadesS-${uid}`;
-  const meta = STATE_META[state];
-  const tone = color ?? (state === "resting" ? MUTED : meta.tone);
+  const tone = color ?? (state === "resting" ? MUTED : state === "flagged" ? DANGER : state === "cleared" ? SAFE : GOLD);
   // The knockout glass stays ink even on light surfaces — black shades on a
   // tinted cat is the mark; "currentColor" callers keep it too.
-  const glass = "#0a0d0e";
+  const glass = INK;
 
-  // At solid sizes only the sweep, ticks and alert bars survive; everything
-  // finer (dots, glints, "?") collapses to a static mark.
+  // At chip sizes only the sweep, ticks and alert bars survive; everything
+  // finer (dots, glints, "?") collapses to the silent mark.
   const lens =
     state === "scanning" ? (
       <g clipPath={`url(#${clipId})`}>
         <g className="mao-anim" style={{ animation: "mao-sweep 1.6s cubic-bezier(.5,0,.5,1) infinite" }}>
-          <rect x="42" y="30" width="20" height="46" fill={GOLD_LIGHT} opacity="0.95" transform="rotate(24 50 50)" />
+          <rect x="42" y="30" width="21" height="46" fill={GOLD_LIGHT} transform="rotate(24 50 50)" />
         </g>
       </g>
     ) : state === "cleared" ? (
@@ -327,7 +361,7 @@ export function MaoAvatar({
   className,
   "aria-label": ariaLabel,
 }: MaoAvatarProps) {
-  const weight = variant ?? (size < 28 ? "solid" : "line");
+  const weight = variant ?? (size < 28 ? "solid" : "detail");
   return (
     <span
       role="img"
@@ -338,7 +372,7 @@ export function MaoAvatar({
       {weight === "solid" ? (
         <MaoSolid state={state} size={size} color={color} />
       ) : (
-        <MaoLine state={state} size={size} earTwitch={earTwitch} />
+        <MaoDetail state={state} size={size} earTwitch={earTwitch} />
       )}
     </span>
   );

--- a/client/src/components/MaoAvatar.tsx
+++ b/client/src/components/MaoAvatar.tsx
@@ -41,6 +41,13 @@ interface MaoAvatarProps {
   variant?: "detail" | "solid";
   /** Solid-weight tint override (e.g. "currentColor" inside a colored chip). */
   color?: string;
+  /**
+   * Mouth override (detail weight). "auto" follows the state (working states
+   * are mouthless — all attention on the glass); "smile" forces the hero's
+   * ink smile, for ambient placements where Mao is the friendly face of the
+   * agent rather than a status readout.
+   */
+  mouth?: "auto" | "smile";
   /** Random ear flicks (detail weight, awake states, ≥48px). Defaults on. */
   earTwitch?: boolean;
   className?: string;
@@ -207,7 +214,17 @@ function LensContent({ state }: { state: MaoState }) {
   }
 }
 
-function MaoDetail({ state, size, earTwitch }: { state: MaoState; size: number; earTwitch: boolean }) {
+function MaoDetail({
+  state,
+  size,
+  earTwitch,
+  mouth = "auto",
+}: {
+  state: MaoState;
+  size: number;
+  earTwitch: boolean;
+  mouth?: "auto" | "smile";
+}) {
   const uid = useId().replace(/[^a-zA-Z0-9]/g, "");
   const clipId = `maoShades-${uid}`;
   const meta = STATE_META[state];
@@ -275,13 +292,18 @@ function MaoDetail({ state, size, earTwitch }: { state: MaoState; size: number; 
       )}
 
       <path d={NOSE} fill={INK} />
-      {face && meta.mouth && (
-        <g fill="none" stroke={meta.mouth.color} strokeWidth="2.2" strokeLinecap="round">
-          {MOUTHS[meta.mouth.shape].map((d) => (
-            <path key={d} d={d} />
-          ))}
-        </g>
-      )}
+      {face &&
+        (() => {
+          const m = mouth === "smile" ? { shape: "smile" as const, color: INK } : meta.mouth;
+          if (!m) return null;
+          return (
+            <g fill="none" stroke={m.color} strokeWidth="2.2" strokeLinecap="round">
+              {MOUTHS[m.shape].map((d) => (
+                <path key={d} d={d} />
+              ))}
+            </g>
+          );
+        })()}
 
       <path
         d={SHADES}
@@ -357,6 +379,7 @@ export function MaoAvatar({
   size = 40,
   variant,
   color,
+  mouth,
   earTwitch = true,
   className,
   "aria-label": ariaLabel,
@@ -372,7 +395,7 @@ export function MaoAvatar({
       {weight === "solid" ? (
         <MaoSolid state={state} size={size} color={color} />
       ) : (
-        <MaoDetail state={state} size={size} earTwitch={earTwitch} />
+        <MaoDetail state={state} size={size} earTwitch={earTwitch} mouth={mouth} />
       )}
     </span>
   );

--- a/client/src/components/MaoAvatar.tsx
+++ b/client/src/components/MaoAvatar.tsx
@@ -1,0 +1,345 @@
+"use client";
+
+import * as React from "react";
+import { useEffect, useId, useRef } from "react";
+
+/**
+ * Mao — the Zhentan agent character. A geometric black cat with gold
+ * linework and opaque shades; the lens is the status screen. Every state
+ * the agent can be in is drawn INSIDE the glass — work is never a spinner
+ * somewhere else on the page, it's light moving across Mao's shades.
+ *
+ * Two weights (per the character spec):
+ *  - "line": outlined head, detailed lens animations. 28px and up.
+ *  - "solid": filled head with knocked-out glass. Below 28px, and for
+ *    chips/pills where the mark takes the surrounding text color.
+ *
+ * Only the lens animates; ears, whiskers and mouth hold still while a
+ * loader runs (an occasional ear flick is the one exception — it plays
+ * between loads of work, never during a result). Under reduced motion the
+ * sweep bar rests at centre-glass, so the state still reads.
+ */
+
+export type MaoState =
+  | "idle" //     two static glints + a slow soft sweep — on duty, nothing to do
+  | "scanning" // bright sweep, mouth flat — actively screening
+  | "thinking" // ears back, dots pulse — weighing a verdict
+  | "cleared" //  green, twin ticks draw in the glass
+  | "flagged" //  red, alert bars pulse — blocked / needs attention
+  | "resting" //  dimmed glass, z — screening paused
+  | "asking"; //  ?? in the lenses — paused on YOUR decision
+
+interface MaoAvatarProps {
+  state?: MaoState;
+  /** Rendered width/height in px (the mark is square). */
+  size?: number;
+  /** Defaults to "solid" below 28px, "line" otherwise. */
+  variant?: "line" | "solid";
+  /** Solid-weight tint override (e.g. "currentColor" inside a colored chip). */
+  color?: string;
+  /** Random ear flicks (line weight, awake states, ≥48px). Defaults on. */
+  earTwitch?: boolean;
+  className?: string;
+  "aria-label"?: string;
+}
+
+/* ── Palette (mirrors the brand tokens in globals.css) ─────────────── */
+const GOLD = "#c49428";
+const GOLD_LIGHT = "#e8b93a";
+const SAFE = "var(--safe, #3fbe76)";
+const DANGER = "var(--danger, #e5524f)";
+const MUTED = "var(--ink-300, #8e938a)";
+const HEAD = "#12171a";
+
+/* ── Line-weight geometry ──────────────────────────────────────────── */
+const L_HEAD =
+  "M50 19 C72 19, 88 34, 88 55 C88 76, 71 89, 50 89 C29 89, 12 76, 12 55 C12 34, 28 19, 50 19 Z";
+const L_SHADES =
+  "M18 41 L82 41 C84.8 41, 86 42.8, 85.4 45.4 L82.6 57.4 C82 60, 80 61.4, 77.4 61.4 L60 61.4 C57.4 61.4, 55.6 60, 55 57.4 L53.4 51 L46.6 51 L45 57.4 C44.4 60, 42.6 61.4, 40 61.4 L22.6 61.4 C20 61.4, 18 60, 17.4 57.4 L14.6 45.4 C14 42.8, 15.2 41, 18 41 Z";
+const NOSE = "M46.6 62.6 L53.4 62.6 L50 68.6 Z";
+const EARS: Record<"default" | "back" | "alert", [string, string]> = {
+  default: ["M20 12 L42 32 L16 44 Z", "M80 12 L58 32 L84 44 Z"],
+  back: ["M23 15 L43 33 L20 45 Z", "M77 15 L57 33 L80 45 Z"],
+  alert: ["M19 9 L42 31 L15 43 Z", "M81 9 L58 31 L85 43 Z"],
+};
+const INNER_EARS: [string, string] = ["M25 21 L35 31 L23 36 Z", "M75 21 L65 31 L77 36 Z"];
+const WHISKERS = ["M37 70 L18 66", "M37 75 L17 78", "M63 70 L82 66", "M63 75 L83 78"];
+const MOUTHS: Record<"smile" | "flat" | "worried" | "frown", string[]> = {
+  smile: ["M50 69.4 C48 73, 44.4 72.6, 43.2 69.6", "M50 69.4 C52 73, 55.6 72.6, 56.8 69.6"],
+  flat: ["M43.6 71 L56.4 71"],
+  worried: ["M43.6 71.6 C46.4 69.8, 51 69.8, 53.6 71.2"],
+  frown: ["M43.6 72 C46.4 69.8, 53.6 69.8, 56.4 72"],
+};
+
+/* ── Solid-weight geometry (fill head, knocked-out glass) ──────────── */
+const S_EARS: [string, string] = ["M18 8 L42 32 L14 46 Z", "M82 8 L58 32 L86 46 Z"];
+const S_HEAD =
+  "M50 17 C74 17, 91 33, 91 55 C91 78, 71 92, 50 92 C29 92, 9 78, 9 55 C9 33, 26 17, 50 17 Z";
+const S_SHADES =
+  "M16 40 L84 40 C87 40, 88.4 42, 87.6 44.8 L84.6 58 C84 60.8, 81.8 62.4, 79 62.4 L60 62.4 C57.2 62.4, 55.2 60.8, 54.6 58 L53 51 L47 51 L45.4 58 C44.8 60.8, 42.8 62.4, 40 62.4 L21 62.4 C18.2 62.4, 16 60.8, 15.4 58 L12.4 44.8 C11.6 42, 13 40, 16 40 Z";
+
+const STATE_META: Record<
+  MaoState,
+  { tone: string; glass: string; ears: keyof typeof EARS; mouth: keyof typeof MOUTHS; label: string }
+> = {
+  idle: { tone: GOLD, glass: "#0f1214", ears: "default", mouth: "smile", label: "Zhentan agent on duty" },
+  scanning: { tone: GOLD, glass: "#0f1214", ears: "default", mouth: "flat", label: "Zhentan agent scanning" },
+  thinking: { tone: GOLD, glass: "#0f1214", ears: "back", mouth: "worried", label: "Zhentan agent thinking" },
+  cleared: { tone: SAFE, glass: "#0d1613", ears: "default", mouth: "smile", label: "Cleared by the Zhentan agent" },
+  flagged: { tone: DANGER, glass: "#180f0e", ears: "alert", mouth: "frown", label: "Flagged by the Zhentan agent" },
+  resting: { tone: GOLD, glass: "#0f1214", ears: "default", mouth: "smile", label: "Zhentan agent paused" },
+  asking: { tone: GOLD, glass: "#0f1214", ears: "default", mouth: "smile", label: "Zhentan agent awaiting your decision" },
+};
+
+/** One sweep bar (bright core + two faint trailers), rotated to the lens angle. */
+function SweepBars({ soft }: { soft?: boolean }) {
+  const anim = soft
+    ? "mao-sweep-soft 6.5s ease-in-out infinite"
+    : "mao-sweep 1.6s cubic-bezier(.5,0,.5,1) infinite";
+  return (
+    <g className="mao-anim" style={{ animation: anim }}>
+      <rect x="46" y="30" width={soft ? 7 : 14} height="46" fill={GOLD_LIGHT} opacity={soft ? 0.5 : 0.9} transform="rotate(24 50 50)" />
+      {!soft && (
+        <>
+          <rect x="40" y="30" width="4" height="46" fill={GOLD_LIGHT} opacity="0.38" transform="rotate(24 50 50)" />
+          <rect x="61" y="30" width="4" height="46" fill={GOLD_LIGHT} opacity="0.38" transform="rotate(24 50 50)" />
+        </>
+      )}
+    </g>
+  );
+}
+
+/** What lives inside the glass for each state (line weight). */
+function LensContent({ state }: { state: MaoState }) {
+  switch (state) {
+    case "idle":
+      return (
+        <>
+          <rect x="20" y="34" width="5" height="36" fill="rgba(232,185,58,0.42)" transform="rotate(24 30 50)" />
+          <rect x="62" y="34" width="5" height="36" fill="rgba(232,185,58,0.42)" transform="rotate(24 66 50)" />
+          <SweepBars soft />
+        </>
+      );
+    case "scanning":
+      return <SweepBars />;
+    case "thinking":
+      return (
+        <g fill={GOLD_LIGHT}>
+          {[26, 33.5, 41, 60, 67.5, 75].map((cx, i) => (
+            <circle
+              key={cx}
+              cx={cx}
+              cy="51"
+              r="2.6"
+              className="mao-anim"
+              style={{ animation: `mao-dot 1.3s ease-in-out ${i * 0.18}s infinite` }}
+            />
+          ))}
+        </g>
+      );
+    case "cleared":
+      return (
+        <g fill="none" stroke={SAFE} strokeWidth="3.4" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M26 51.4 L31 56 L39 46" strokeDasharray="26" className="mao-anim" style={{ animation: "mao-tick 2.6s ease-out infinite" }} />
+          <path d="M60 51.4 L65 56 L73 46" strokeDasharray="26" className="mao-anim" style={{ animation: "mao-tick 2.6s ease-out .12s infinite" }} />
+        </g>
+      );
+    case "flagged":
+      return (
+        <g className="mao-anim" style={{ animation: "mao-alert 1.1s ease-in-out infinite" }}>
+          {[
+            [24, 44],
+            [24, 52],
+            [58, 44],
+            [58, 52],
+          ].map(([x, y]) => (
+            <rect key={`${x}-${y}`} x={x} y={y} width="18" height="4.4" rx="1.6" fill={DANGER} />
+          ))}
+        </g>
+      );
+    case "resting":
+      return (
+        <>
+          <rect x="24" y="49.6" width="18" height="2.8" rx="1.4" fill="rgba(232,185,58,0.45)" />
+          <rect x="58" y="49.6" width="18" height="2.8" rx="1.4" fill="rgba(232,185,58,0.45)" />
+        </>
+      );
+    case "asking":
+      return (
+        <g fill={GOLD_LIGHT} fontFamily="var(--font-mono, monospace)" fontSize="16" fontWeight="700">
+          <text x="26" y="57">?</text>
+          <text x="61" y="57">?</text>
+        </g>
+      );
+  }
+}
+
+function MaoLine({ state, size, earTwitch }: { state: MaoState; size: number; earTwitch: boolean }) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, "");
+  const clipId = `maoShades-${uid}`;
+  const meta = STATE_META[state];
+  const dimmed = state === "resting";
+  const [earL, earR] = EARS[meta.ears];
+  const earLRef = useRef<SVGGElement>(null);
+  const earRRef = useRef<SVGGElement>(null);
+
+  // Occasional ear flick — the timer only decides WHEN; the flick itself is a
+  // CSS keyframe so it plays independently of React renders. Awake states only.
+  const awake = state === "idle" || state === "scanning" || state === "thinking" || state === "asking";
+  const flicking = earTwitch && awake && size >= 48;
+  useEffect(() => {
+    if (!flicking) return;
+    if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) return;
+    let alive = true;
+    let timer: ReturnType<typeof setTimeout>;
+    const schedule = (delay: number) => {
+      timer = setTimeout(() => {
+        if (!alive) return;
+        const left = Math.random() < 0.5;
+        const el = (left ? earLRef : earRRef).current;
+        if (el) {
+          el.style.animation = "none";
+          void el.getBoundingClientRect().width;
+          el.style.animation = `${left ? "mao-twitch-l" : "mao-twitch-r"} 0.44s cubic-bezier(.3,0,.4,1) 1`;
+        }
+        schedule(4000 + Math.random() * 7000);
+      }, delay);
+    };
+    schedule(2500 + Math.random() * 5500);
+    return () => {
+      alive = false;
+      clearTimeout(timer);
+    };
+  }, [flicking]);
+
+  const stroke = meta.tone;
+  const detail = size >= 64;
+
+  return (
+    <svg viewBox="0 0 100 100" width={size} height={size} style={{ display: "block" }} aria-hidden="true">
+      <defs>
+        <clipPath id={clipId}>
+          <path d={L_SHADES} />
+        </clipPath>
+      </defs>
+
+      <g ref={earLRef} style={{ transformOrigin: "30px 42px" }}>
+        <path d={earL} fill={HEAD} stroke={stroke} strokeWidth="2.6" strokeLinejoin="round" />
+        {detail && meta.ears === "default" && <path d={INNER_EARS[0]} fill="rgba(196,148,40,0.3)" />}
+      </g>
+      <g ref={earRRef} style={{ transformOrigin: "70px 42px" }}>
+        <path d={earR} fill={HEAD} stroke={stroke} strokeWidth="2.6" strokeLinejoin="round" />
+        {detail && meta.ears === "default" && <path d={INNER_EARS[1]} fill="rgba(196,148,40,0.3)" />}
+      </g>
+
+      <path d={L_HEAD} fill={HEAD} stroke={stroke} strokeWidth="2.6" />
+
+      <g fill="none" stroke={stroke} strokeOpacity="0.55" strokeWidth="1.8" strokeLinecap="round">
+        {WHISKERS.map((d) => (
+          <path key={d} d={d} />
+        ))}
+      </g>
+
+      <path d={NOSE} fill={stroke} />
+      <g fill="none" stroke={stroke} strokeWidth="2.2" strokeLinecap="round">
+        {MOUTHS[meta.mouth].map((d) => (
+          <path key={d} d={d} />
+        ))}
+      </g>
+
+      <path
+        d={L_SHADES}
+        fill={meta.glass}
+        stroke={stroke}
+        strokeOpacity={dimmed ? 0.5 : 1}
+        strokeWidth="2.8"
+        strokeLinejoin="round"
+      />
+      <g clipPath={`url(#${clipId})`}>
+        <LensContent state={state} />
+      </g>
+
+      {state === "resting" && (
+        <g className="mao-anim" style={{ animation: "mao-zzz 2.6s ease-out infinite" }}>
+          <text x="76" y="22" fontFamily="var(--font-mono, monospace)" fontSize="15" fontWeight="700" fill={GOLD}>
+            z
+          </text>
+        </g>
+      )}
+    </svg>
+  );
+}
+
+function MaoSolid({ state, size, color }: { state: MaoState; size: number; color?: string }) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, "");
+  const clipId = `maoShadesS-${uid}`;
+  const meta = STATE_META[state];
+  const tone = color ?? (state === "resting" ? MUTED : meta.tone);
+  // The knockout glass stays ink even on light surfaces — black shades on a
+  // tinted cat is the mark; "currentColor" callers keep it too.
+  const glass = "#0a0d0e";
+
+  // At solid sizes only the sweep, ticks and alert bars survive; everything
+  // finer (dots, glints, "?") collapses to a static mark.
+  const lens =
+    state === "scanning" ? (
+      <g clipPath={`url(#${clipId})`}>
+        <g className="mao-anim" style={{ animation: "mao-sweep 1.6s cubic-bezier(.5,0,.5,1) infinite" }}>
+          <rect x="42" y="30" width="20" height="46" fill={GOLD_LIGHT} opacity="0.95" transform="rotate(24 50 50)" />
+        </g>
+      </g>
+    ) : state === "cleared" ? (
+      <g clipPath={`url(#${clipId})`} fill="none" stroke={tone} strokeWidth="4" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M26 51.4 L31 56 L39 46" />
+        <path d="M60 51.4 L65 56 L73 46" />
+      </g>
+    ) : state === "flagged" ? (
+      <g clipPath={`url(#${clipId})`} className="mao-anim" style={{ animation: "mao-alert 1.1s ease-in-out infinite" }}>
+        <rect x="22" y="43" width="22" height="6" fill={tone} />
+        <rect x="22" y="53" width="22" height="6" fill={tone} />
+        <rect x="56" y="43" width="22" height="6" fill={tone} />
+        <rect x="56" y="53" width="22" height="6" fill={tone} />
+      </g>
+    ) : null;
+
+  return (
+    <svg viewBox="0 0 100 100" width={size} height={size} style={{ display: "block" }} aria-hidden="true">
+      <defs>
+        <clipPath id={clipId}>
+          <path d={S_SHADES} />
+        </clipPath>
+      </defs>
+      <path d={S_EARS[0]} fill={tone} />
+      <path d={S_EARS[1]} fill={tone} />
+      <path d={S_HEAD} fill={tone} />
+      <path d={S_SHADES} fill={glass} />
+      {lens}
+    </svg>
+  );
+}
+
+export function MaoAvatar({
+  state = "idle",
+  size = 40,
+  variant,
+  color,
+  earTwitch = true,
+  className,
+  "aria-label": ariaLabel,
+}: MaoAvatarProps) {
+  const weight = variant ?? (size < 28 ? "solid" : "line");
+  return (
+    <span
+      role="img"
+      aria-label={ariaLabel ?? STATE_META[state].label}
+      className={className}
+      style={{ display: "inline-flex", width: size, height: size }}
+    >
+      {weight === "solid" ? (
+        <MaoSolid state={state} size={size} color={color} />
+      ) : (
+        <MaoLine state={state} size={size} earTwitch={earTwitch} />
+      )}
+    </span>
+  );
+}

--- a/client/src/components/RequestDetailDialog.tsx
+++ b/client/src/components/RequestDetailDialog.tsx
@@ -22,7 +22,8 @@ import {
 } from "lucide-react";
 import { clsx } from "clsx";
 import { ThemeLoaderSpinner } from "./ThemeLoader";
-import { ExecutedAnimation, ReviewAnimation, RejectedAnimation } from "./animations/StatusAnimation";
+import { ExecutedAnimation, RejectedAnimation } from "./animations/StatusAnimation";
+import { MaoAvatar } from "./MaoAvatar";
 
 interface RequestDetailDialogProps {
   request: QueuedRequest | null;
@@ -47,8 +48,10 @@ type ScreeningPhase =
 function StatusAnimation({ status }: { status: QueuedRequest["status"] }) {
   switch (status) {
     case "queued":
+      // The agent prepared this and is waiting on YOUR call.
+      return <MaoAvatar state="asking" size={80} />;
     case "approved":
-      return <ReviewAnimation size={80} />;
+      return <MaoAvatar state="scanning" size={80} />;
     case "executed":
       return <ExecutedAnimation size={80} />;
     case "rejected":
@@ -570,10 +573,12 @@ function ScreeningView({
   return (
     <div className="space-y-6">
       <div className="flex flex-col items-center gap-3 text-center">
-        {isLoading ? (
+        {phase === "proposing" ? (
           <ThemeLoaderSpinner motion="scan" />
+        ) : phase === "screening" ? (
+          <MaoAvatar state="scanning" size={80} />
         ) : phase === "review" ? (
-          <ReviewAnimation size={80} />
+          <MaoAvatar state="asking" size={80} />
         ) : phase === "executed" ? (
           <ExecutedAnimation size={80} />
         ) : (

--- a/client/src/components/RightRail.tsx
+++ b/client/src/components/RightRail.tsx
@@ -112,11 +112,19 @@ function LiveReadout({ isActive }: { isActive: boolean }) {
               </>
             )}
             {/* The rail is Mao's home — the hero face (smile) while on watch,
-                not the mouthless status readout the dialogs use. */}
+                not the mouthless status readout the dialogs use. While
+                waiting he stays alive on the neutral gesture pool; shake,
+                nod and double-take are event gestures and stay out of it,
+                and glint stays out while the sweep owns the lens. */}
             <MaoAvatar
               state={isActive ? "scanning" : "resting"}
               size={56}
               mouth={isActive ? "smile" : undefined}
+              ambient={
+                isActive
+                  ? ["ear-flick", "perk", "tilt", "stretch", "pounce", "shades-down"]
+                  : undefined
+              }
               className="relative"
             />
           </div>

--- a/client/src/components/RightRail.tsx
+++ b/client/src/components/RightRail.tsx
@@ -115,7 +115,9 @@ function LiveReadout({ isActive }: { isActive: boolean }) {
                 not the mouthless status readout the dialogs use. While
                 waiting he stays alive on the neutral gesture pool; shake,
                 nod and double-take are event gestures and stay out of it,
-                and glint stays out while the sweep owns the lens. */}
+                and glint stays out while the sweep owns the lens. Poking
+                him plays one on demand (the click never reaches the card's
+                settings Link). */}
             <MaoAvatar
               state={isActive ? "scanning" : "resting"}
               size={56}
@@ -125,6 +127,7 @@ function LiveReadout({ isActive }: { isActive: boolean }) {
                   ? ["ear-flick", "perk", "tilt", "stretch", "pounce", "shades-down"]
                   : undefined
               }
+              interactive={isActive}
               className="relative"
             />
           </div>

--- a/client/src/components/RightRail.tsx
+++ b/client/src/components/RightRail.tsx
@@ -5,9 +5,7 @@ import Link from "next/link";
 import { motion, AnimatePresence } from "framer-motion";
 import { clsx } from "clsx";
 import {
-  Bot,
   User,
-  Activity,
   CheckCircle2,
   AlertTriangle,
   ArrowUpRight,
@@ -16,7 +14,7 @@ import {
 import { useScreeningStatus } from "@/app/context/ScreeningStatusContext";
 import { useActivityData } from "@/app/context/ActivityDataContext";
 import { truncateAddress, timeAgo, formatTokenAmount } from "@/lib/format";
-import { TwinTick } from "@/components/BrandMark";
+import { MaoAvatar } from "@/components/MaoAvatar";
 import { TransactionDetailDialog } from "@/components/TransactionDetailDialog";
 import { RequestDetailDialog } from "@/components/RequestDetailDialog";
 import { useRequestActions } from "@/hooks/useRequestActions";
@@ -104,7 +102,7 @@ function LiveReadout({ isActive }: { isActive: boolean }) {
         />
 
         <div className="h-full flex flex-col items-center justify-center py-9 px-5">
-          {/* Zhentan scanner — sonar sweep */}
+          {/* Mao on watch — sonar sweep around the agent */}
           <div className="relative mb-7 flex items-center justify-center w-[72px] h-[72px]">
             {isActive && (
               <>
@@ -113,16 +111,11 @@ function LiveReadout({ isActive }: { isActive: boolean }) {
                 <span className="absolute inset-0 rounded-full border-[1.5px] border-gold/70 [animation:sonar_2.4s_ease-out_1.6s_infinite]" />
               </>
             )}
-            <div
-              className={clsx(
-                "relative w-10 h-10 rounded-full flex items-center justify-center",
-                isActive
-                  ? "bg-gold/10 [animation:signal-pulse_2.4s_ease-in-out_infinite]"
-                  : "bg-foreground/6 grayscale opacity-60"
-              )}
-            >
-              <TwinTick size={22} halo="none" />
-            </div>
+            <MaoAvatar
+              state={isActive ? "scanning" : "resting"}
+              size={56}
+              className="relative"
+            />
           </div>
 
           {/* Rolling agent text */}
@@ -195,7 +188,11 @@ function PendingCard({
               isQueued ? "text-watch" : "text-gold"
             )}
           >
-            {isQueued ? <Bot className="h-3 w-3" /> : <User className="h-3 w-3" />}
+            {isQueued ? (
+              <MaoAvatar state="idle" size={13} variant="solid" color="currentColor" />
+            ) : (
+              <User className="h-3 w-3" />
+            )}
             {isQueued ? "Agent proposed" : "You proposed"}
           </span>
           <span className="font-mono text-[10px] text-muted-foreground/55">
@@ -310,19 +307,21 @@ export function RightRail() {
           <div className="relative w-10 h-10 shrink-0 flex items-center justify-center">
             {isScreeningActive && (
               <>
-                <span className="absolute inset-0 rounded-md border border-safe/50 [animation:sonar_2.6s_ease-out_infinite]" />
-                <span className="absolute inset-0 rounded-md border border-safe/50 [animation:sonar_2.6s_ease-out_1.3s_infinite]" />
+                <span className="absolute inset-0 rounded-md border border-gold/50 [animation:sonar_2.6s_ease-out_infinite]" />
+                <span className="absolute inset-0 rounded-md border border-gold/50 [animation:sonar_2.6s_ease-out_1.3s_infinite]" />
               </>
             )}
             <div
               className={clsx(
                 "relative w-10 h-10 rounded-md flex items-center justify-center",
-                isScreeningActive
-                  ? "bg-safe/12 text-safe"
-                  : "bg-foreground/6 text-muted-foreground"
+                isScreeningActive ? "bg-gold/10" : "bg-foreground/6"
               )}
             >
-              <Bot className="h-5 w-5" />
+              <MaoAvatar
+                state={isScreeningActive ? "scanning" : "resting"}
+                size={24}
+                variant="solid"
+              />
             </div>
           </div>
           <div className="flex-1 min-w-0">

--- a/client/src/components/RightRail.tsx
+++ b/client/src/components/RightRail.tsx
@@ -111,9 +111,12 @@ function LiveReadout({ isActive }: { isActive: boolean }) {
                 <span className="absolute inset-0 rounded-full border-[1.5px] border-gold/70 [animation:sonar_2.4s_ease-out_1.6s_infinite]" />
               </>
             )}
+            {/* The rail is Mao's home — the hero face (smile) while on watch,
+                not the mouthless status readout the dialogs use. */}
             <MaoAvatar
               state={isActive ? "scanning" : "resting"}
               size={56}
+              mouth={isActive ? "smile" : undefined}
               className="relative"
             />
           </div>

--- a/client/src/components/SendPanel.tsx
+++ b/client/src/components/SendPanel.tsx
@@ -13,6 +13,7 @@ import { CoSignButton } from "@/components/CoSignButton";
 import { UsdcIcon } from "./icons/UsdcIcon";
 import { ThemeLoaderSpinner } from "./ThemeLoader";
 import { ExecutedAnimation, ReviewAnimation, RejectedAnimation } from "./animations/StatusAnimation";
+import { MaoAvatar } from "./MaoAvatar";
 import { ChevronDown, ArrowUpRight, CheckCircle2, ExternalLink, Clock, Coins, Loader2, MessageCircle, X, UserRound, Zap } from "lucide-react";
 import { useForceExecuteSetting } from "@/lib/useForceExecute";
 import { truncateAddress, formatDate, statusLabel, formatTokenAmount } from "@/lib/format";
@@ -430,7 +431,11 @@ export function SendPanel({ onSuccess, onClose, onRefreshActivities, tokens, scr
     return (
       <div className="space-y-6">
         <div className="flex flex-col items-center gap-3">
-          <ReviewAnimation size={80} />
+          {tx.status === "in_review" ? (
+            <MaoAvatar state="asking" size={80} />
+          ) : (
+            <MaoAvatar state="scanning" size={80} />
+          )}
           <span className="text-sm font-semibold text-watch">{statusLabel(tx.status)}</span>
         </div>
         <div className="flex items-center gap-3 rounded-2xl bg-foreground/6 p-4">

--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -3,10 +3,11 @@
 import { useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Shield, ShieldOff, ChevronRight } from "lucide-react";
+import { ChevronRight } from "lucide-react";
 import { clsx } from "clsx";
 import { motion } from "framer-motion";
 import { BrandMark } from "@/components/BrandMark";
+import { MaoAvatar } from "@/components/MaoAvatar";
 import { AccountDialog } from "@/components/AccountDialog";
 import { navItems } from "@/components/TopBar";
 import { useAuth } from "@/app/context/AuthContext";
@@ -74,11 +75,12 @@ export function Sidebar() {
             isScreeningActive ? "bg-safe/10 text-safe" : "bg-foreground/5 text-muted-foreground"
           )}
         >
-          {isScreeningActive ? (
-            <Shield className="h-3.5 w-3.5" />
-          ) : (
-            <ShieldOff className="h-3.5 w-3.5" />
-          )}
+          <MaoAvatar
+            state={isScreeningActive ? "scanning" : "resting"}
+            size={14}
+            variant="solid"
+            color="currentColor"
+          />
           <span className="flex-1">Screening</span>
           <span className="font-semibold">{isScreeningActive ? "On" : "Off"}</span>
         </div>

--- a/client/src/components/SwapPanel.tsx
+++ b/client/src/components/SwapPanel.tsx
@@ -10,6 +10,7 @@ import { useAuth } from "@/app/context/AuthContext";
 import { ThemeLoaderSpinner } from "./ThemeLoader";
 import { TickButtonSpinner } from "./TwinTickLoader";
 import { ExecutedAnimation, ReviewAnimation } from "./animations/StatusAnimation";
+import { MaoAvatar } from "./MaoAvatar";
 import { CoSignButton } from "@/components/CoSignButton";
 import { useLiveTransaction } from "@/hooks/useLiveTransaction";
 import {
@@ -531,7 +532,13 @@ export function SwapPanel({ onSuccess, onClose, tokens }: SwapPanelProps) {
     return (
       <div className="space-y-6">
         <div className="flex flex-col items-center gap-3">
-          <ReviewAnimation size={80} />
+          {screeningOff ? (
+            <ReviewAnimation size={80} />
+          ) : inReview ? (
+            <MaoAvatar state="asking" size={80} />
+          ) : (
+            <MaoAvatar state="scanning" size={80} />
+          )}
           <span className="text-sm font-semibold text-watch">{heading}</span>
           <p className="text-xs text-muted-foreground/80 text-center leading-relaxed max-w-xs">
             {caption}

--- a/client/src/components/TopBar.tsx
+++ b/client/src/components/TopBar.tsx
@@ -2,11 +2,12 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Home, Settings, User, Bell, Shield, ShieldOff, type LucideIcon } from "lucide-react";
+import { Home, Settings, User, Bell, type LucideIcon } from "lucide-react";
 import { clsx } from "clsx";
 import { useScreeningStatus } from "@/app/context/ScreeningStatusContext";
 import { useActivityData } from "@/app/context/ActivityDataContext";
 import { BrandMark } from "@/components/BrandMark";
+import { MaoAvatar } from "@/components/MaoAvatar";
 
 export const navItems: {
   href: string;
@@ -42,11 +43,12 @@ export function TopBar() {
                 : "bg-foreground/6 text-muted-foreground"
             )}
           >
-            {isScreeningActive ? (
-              <Shield className="h-3.5 w-3.5" />
-            ) : (
-              <ShieldOff className="h-3.5 w-3.5" />
-            )}
+            <MaoAvatar
+              state={isScreeningActive ? "scanning" : "resting"}
+              size={14}
+              variant="solid"
+              color="currentColor"
+            />
             {isScreeningActive ? "Watching" : "Paused"}
           </div>
         </div>

--- a/client/src/components/TransactionDetailDialog.tsx
+++ b/client/src/components/TransactionDetailDialog.tsx
@@ -10,6 +10,7 @@ import { useAuth } from "@/app/context/AuthContext";
 import { truncateAddress, formatDate, statusLabel, formatTokenAmount } from "@/lib/format";
 import { Dialog } from "./ui/Dialog";
 import { ExecutedAnimation, ReviewAnimation, RejectedAnimation } from "./animations/StatusAnimation";
+import { MaoAvatar } from "./MaoAvatar";
 import {
   ArrowUpRight,
   ArrowDownLeft,
@@ -416,11 +417,21 @@ function CoSignSection({ tx }: { tx: TransactionWithStatus }) {
 
 // ── Status animation ──────────────────────────────────────────────────────────
 
-function StatusAnimation({ status }: { status: TransactionWithStatus["status"] }) {
+function StatusAnimation({
+  status,
+  screening,
+}: {
+  status: TransactionWithStatus["status"];
+  /** Whether the agent is screening this tx — Mao only appears for agent work. */
+  screening: boolean;
+}) {
   switch (status) {
     case "pending":
+      // Screening on: Mao is reading it. Off: a plain wait for the backup key.
+      return screening ? <MaoAvatar state="scanning" size={80} /> : <ReviewAnimation size={80} />;
     case "in_review":
-      return <ReviewAnimation size={80} />;
+      // The agent paused ON PURPOSE — the decision is yours now.
+      return <MaoAvatar state="asking" size={80} />;
     case "executed":
       return <ExecutedAnimation size={80} />;
     case "rejected":
@@ -485,7 +496,7 @@ export function TransactionDetailDialog({ tx: txProp, open, onClose }: Transacti
             exit={{ opacity: 0, scale: 0.92 }}
             transition={{ duration: 0.28, ease: "easeOut" }}
           >
-            <StatusAnimation status={tx.status} />
+            <StatusAnimation status={tx.status} screening={tx.screeningDisabled !== true} />
             <span
               className={`text-sm font-semibold ${
                 tx.status === "executed"


### PR DESCRIPTION
## What

Introduces **Mao**, the Zhentan agent character (design: *Zhentan Mao.dc.html* on claude.ai/design), and swaps him in for every generic agent mark in the app. The shades are the status screen — every agent state is drawn inside the glass, so agent work is never a spinner somewhere else on the page.

**New component** — `client/src/components/MaoAvatar.tsx` *(updated to the revised one-weight spec in the second commit)*
- **One weight**: solid gold cat, ink details, knocked-out glass at every size — details drop down the ladder (whiskers/mouth ≥48px, inner ears ≥96px); below 28px the simplified chip mark takes the whole-cat tint (or `currentColor`)
- 7 states: `idle` (glints + soft sweep), `scanning` (bright sweep), `thinking` (ears back, dots), `cleared` (green rim + ticks), `flagged` (red rim + alert bars), `resting` (dim rim + z), `asking` (?? — paused on your decision)
- The body stays **gold in every state** — cleared/flagged speak through the glass rim, the mouth, and the light inside the lens
- Occasional random ear flick (awake states, ≥48px — CSS keyframe, JS only picks the moment)
- `prefers-reduced-motion`: all animation stops; the sweep bar rests at centre-glass so the state still reads
- Keyframes in `globals.css` (`mao-*`)

**Where he now appears (agentic surfaces only)**
| Surface | Before | After |
|---|---|---|
| Right rail empty state | Twin Tick logo in sonar | Mao `scanning` (56px) in the sonar; `resting` when screening is off |
| Right rail header | lucide `Bot` icon (green box) | solid Mao 24px, gold box + gold sonar rings; muted `resting` when off |
| "Agent proposed" chip | lucide `Bot` 12px | solid Mao 13px `currentColor` |
| Send/Swap/TxDetail pending (screening ON) | amber hourglass | Mao `scanning` 80px |
| Send/Swap/TxDetail `in_review` | amber hourglass | Mao `asking` 80px |
| RequestDetail queued / screening / review | hourglass / generic spinner | `asking` / `scanning` / `asking` |
| TopBar + Sidebar screening chips | `Shield` / `ShieldOff` | solid Mao 14px `currentColor` (`scanning` / `resting`) |
| Settings "Zhentan Guard" card | `ShieldCheck` / `ShieldOff` | solid Mao 20px `currentColor` |
| GuardianCard (login) sonar centre | Twin Tick | Mao `scanning` 50px |

**Deliberately untouched** (not agent work): the Twin Tick brand mark and page loaders, "awaiting your signature" propose phases, the screening-OFF backup-key queue (hourglass stays — relay-only, no agent), executed/rejected result animations, WalletConnect signing phase.

**Live preview** (SSR output of the real component, all states + surfaces): https://claude.ai/code/artifact/504d9049-97cb-49ea-b80c-eb119d2cc5f7

## Manual UI tests

1. **Right rail, screening on** — empty state shows gold Mao with sweep inside gold sonar rings; header shows small gold Mao with sweep; rotating messages unchanged.
2. **Right rail, screening off** — Mao dims (dim gold rim), z floats; header Mao goes muted/static; "Off" pill unchanged.
3. **Send a tx (screening on)** — after signing, the pending screen shows scanning Mao; if flagged, it flips to the ?? asking Mao in place (live transition).
4. **Send with screening off (protected)** — queued screen still shows the amber hourglass (no Mao).
5. **Open a pending/in-review tx from history** — scanning/asking Mao respectively; executed/rejected still show the green check / red X animations.
6. **Agent-proposed request (invoice)** — detail dialog shows asking Mao; "Screen & accept" flow shows scanning Mao during the screening phase.
7. **TopBar (mobile) + Sidebar chips** — cat glyph in the pill, colored by the chip (green watching / muted paused).
8. **Settings → Zhentan Guard** — gold cat with sweep when active, muted when paused; toggle transitions colors.
9. **Login page** — GuardianCard idle phase shows Mao scanning inside the sonar.
10. **Reduced motion (OS setting)** — nothing moves; sweep bar rests mid-glass, states still distinguishable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
