### PR TITLE
Onboarding/upgrade journey fixes: structural screening, transition auto-approve, honest agent status, resolution errors (#136)

### DIFF
--- a/client/src/app/(app)/home/page.tsx
+++ b/client/src/app/(app)/home/page.tsx
@@ -237,7 +237,7 @@ function Dashboard() {
           {/* Segment tab bar */}
           <div className="flex items-center gap-7 border-b border-border">
             {([
-              { key: "tokens", label: "Assets", count: tokens.length },
+              { key: "tokens", label: "Assets", count: tokens.filter((t) => !t.placeholder).length },
               { key: "activity", label: "Activity", count: transactions.length },
             ] as const).map((tab) => {
               const active = listTab === tab.key;

--- a/client/src/app/(app)/settings/page.tsx
+++ b/client/src/app/(app)/settings/page.tsx
@@ -28,6 +28,7 @@ import { BackupAddressPicker } from "@/components/BackupAddressPicker";
 import { truncateAddress } from "@/lib/format";
 import { UpgradeBanner } from "@/components/UpgradeBanner";
 import { useSafeTransitions } from "@/lib/useSafeUpgrade";
+import { readPendingTransition } from "@/lib/pendingTransition";
 import { useForceExecuteSetting } from "@/lib/useForceExecute";
 import { useTour } from "@/components/tour/TourProvider";
 import { mainTour, upgradeTour } from "@/lib/tours";
@@ -102,8 +103,21 @@ function SettingsRow({
  */
 function BackupKeyRow() {
   const { swapBackup, busy, error, profile } = useSafeTransitions();
-  const { externalWalletAddress } = useAuth();
+  const { externalWalletAddress, safeConfig } = useAuth();
   const [open, setOpen] = useState(false);
+  // Pending swap (accepted, executing async): the record already names the
+  // NEW key, but the OLD one stays live on-chain until the transition lands
+  // — say so instead of silently claiming the swap is done.
+  const [pendingSwap, setPendingSwap] = useState(false);
+  useEffect(() => {
+    const sync = () => {
+      const marker = readPendingTransition();
+      setPendingSwap(!!marker?.expectedOwners);
+    };
+    sync();
+    window.addEventListener("zhentan:pending-transition", sync);
+    return () => window.removeEventListener("zhentan:pending-transition", sync);
+  }, [safeConfig?.owners]);
 
   if (profile !== "protected" || !externalWalletAddress) return null;
 
@@ -115,9 +129,17 @@ function BackupKeyRow() {
         iconTint="bg-foreground/5 text-muted-foreground"
         title="Backup key"
         desc={
-          <span className="font-mono text-[11px] truncate block" title={externalWalletAddress}>
-            {truncateAddress(externalWalletAddress, 13)}
-          </span>
+          <>
+            <span className="font-mono text-[11px] truncate block" title={externalWalletAddress}>
+              {truncateAddress(externalWalletAddress, 13)}
+            </span>
+            {pendingSwap && (
+              <span className="block text-[11px] text-watch/90 mt-0.5">
+                Swap in progress — the previous key stays active until it
+                completes on-chain.
+              </span>
+            )}
+          </>
         }
         action={
           <button
@@ -156,8 +178,9 @@ function BackupKeyRow() {
             <BackupAddressPicker
               onSelect={async (addr) => {
                 try {
-                  await swapBackup(addr);
+                  const result = await swapBackup(addr);
                   setOpen(false);
+                  setPendingSwap(result.pending);
                 } catch {
                   // error surfaced by the hook
                 }

--- a/client/src/app/(app)/settings/page.tsx
+++ b/client/src/app/(app)/settings/page.tsx
@@ -419,7 +419,9 @@ function SettingsPageContent() {
                           ? isScreeningActive
                             ? "AI screening every signature — pause it and the agent still co-signs"
                             : "Screening off — the agent co-signs without risk analysis"
-                          : "Screening is always on — add a backup key to control it"
+                          : telegramLinked
+                            ? "Screening is always on — add a backup key to control it"
+                            : "Screening is always on — reviews reach you by email until Telegram is connected"
                         : profile === "starter" || profile === "detached"
                           ? "No agent on this wallet — activate protection to enable screening"
                           : isScreeningActive
@@ -432,7 +434,20 @@ function SettingsPageContent() {
                       <button
                         onClick={handleToggle}
                         disabled={toggling || !screeningTogglable}
-                        aria-label="Toggle screening"
+                        aria-label={
+                          screeningTogglable
+                            ? "Toggle screening"
+                            : profile === "guarded"
+                              ? "Screening is locked on — your key alone can't meet the signing threshold; add a backup key to control it"
+                              : "Screening unavailable — no agent on this wallet"
+                        }
+                        title={
+                          screeningTogglable
+                            ? undefined
+                            : profile === "guarded"
+                              ? "Locked on: add a backup key to control screening"
+                              : "No agent on this wallet"
+                        }
                         className={clsx(
                           "relative w-12 h-6 rounded-pill transition-colors focus:outline-none focus:ring-2 focus:ring-gold/30 shrink-0 cursor-pointer disabled:cursor-default",
                           isScreeningActive ? "bg-gold" : "bg-foreground/12"

--- a/client/src/app/context/AuthContext.tsx
+++ b/client/src/app/context/AuthContext.tsx
@@ -133,6 +133,13 @@ export interface AuthContextType {
   backupAddressLocked: boolean;
   /** Confirms the backup-key choice — allows the user record (safe_address PK + owner set) to persist */
   commitSafe: () => void;
+  /**
+   * A backend record already exists for this signer — the Safe address (and
+   * its creation profile) is fixed, so onboarding's profile choice is moot:
+   * the record always wins over pendingProfile (#136 follow-up: without this
+   * signal, step 0 waited forever for a derivation that can never run).
+   */
+  hasExistingWallet: boolean;
   /** Creation profile chosen during onboarding (drives new-user derivation) */
   pendingProfile: WalletProfile | null;
   setPendingProfile: (p: WalletProfile | null) => void;
@@ -630,6 +637,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setBackupAddress,
       backupAddressLocked,
       commitSafe,
+      hasExistingWallet: !!safeRecord,
       pendingProfile,
       setPendingProfile,
       safeConfig,

--- a/client/src/app/context/AuthContext.tsx
+++ b/client/src/app/context/AuthContext.tsx
@@ -96,6 +96,12 @@ export interface AuthContextType {
   /** Whether the Safe address is still being computed */
   safeLoading: boolean;
   /**
+   * Non-null after repeated Safe-resolution failures (#136.4): the backend is
+   * unreachable. Retries continue in the background — surfaces so gates and
+   * onboarding can say so instead of spinning forever.
+   */
+  safeError: string | null;
+  /**
    * Brand of the connected signing wallet (name/icon) for wallet-login users.
    * Null for embedded signers (Google) and until the wallet (re)connects.
    */
@@ -227,7 +233,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const user: AuthUser | null = useMemo(() => {
     if (!privyUser) return null;
     const google = (privyUser as { google?: { email?: string; name?: string; picture?: string } }).google;
-    console.log("privyUser", privyUser);
     return {
       email: google?.email,
       name: google?.name,
@@ -381,6 +386,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const {
     safeAddress,
     loading: safeLoading,
+    error: safeError,
     record: safeRecord,
     derived: safeDerived,
     derivationVersion,
@@ -615,6 +621,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       getBackupAccount,
       safeAddress,
       safeLoading,
+      safeError,
       signerWalletMeta: displayedSignerMeta,
       signerMismatch,
       signerDisplay,
@@ -631,7 +638,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       privyUser: privyUser ?? null,
       identityToken: identityToken ?? null,
     }),
-    [user, wallet, loading, login, logout, getOwnerAccount, getBackupAccount, safeAddress, safeLoading, displayedSignerMeta, signerMismatch, signerDisplay, requestSignerSwitch, externalWalletAddress, setBackupAddress, backupAddressLocked, commitSafe, pendingProfile, safeConfig, refreshSafe, safeRecord, privyUser, identityToken]
+    [user, wallet, loading, login, logout, getOwnerAccount, getBackupAccount, safeAddress, safeLoading, safeError, displayedSignerMeta, signerMismatch, signerDisplay, requestSignerSwitch, externalWalletAddress, setBackupAddress, backupAddressLocked, commitSafe, pendingProfile, safeConfig, refreshSafe, safeRecord, privyUser, identityToken]
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/client/src/app/context/ScreeningStatusContext.tsx
+++ b/client/src/app/context/ScreeningStatusContext.tsx
@@ -16,6 +16,14 @@ import { useAuth } from "./AuthContext";
 
 interface ScreeningStatusContextType {
   screeningMode: boolean;
+  /** Guarded wallets: screening is structural — the toggle is locked ON (#136.1). */
+  screeningLocked: boolean;
+  /**
+   * Runtime liveness from the server (#136.5). null while unknown (first
+   * load) — treat as "don't claim online". Every "Monitoring"/"Watching"
+   * surface must consult this, never configuration alone.
+   */
+  agentOnline: boolean | null;
   /** Server-truth Telegram binding (#134) — the ONLY link signal. */
   telegramLinked: boolean;
   telegramIdentity: TelegramIdentity | null;
@@ -33,6 +41,8 @@ export function ScreeningStatusProvider({ children }: { children: ReactNode }) {
   const { safeAddress } = useAuth();
   const api = useApiClient();
   const [screeningMode, setScreeningMode] = useState(false);
+  const [screeningLocked, setScreeningLocked] = useState(false);
+  const [agentOnline, setAgentOnline] = useState<boolean | null>(null);
   const [telegramLinked, setTelegramLinked] = useState(false);
   const [telegramIdentity, setTelegramIdentity] = useState<TelegramIdentity | null>(null);
   const [loading, setLoading] = useState(true);
@@ -42,6 +52,10 @@ export function ScreeningStatusProvider({ children }: { children: ReactNode }) {
     try {
       const data = await api.status.get(safeAddress);
       setScreeningMode(data.screeningMode ?? false);
+      setScreeningLocked(data.screeningLocked ?? false);
+      // Older servers omit `agent` — stay null (unknown) rather than lying
+      // in either direction.
+      setAgentOnline(data.agent ? data.agent.online : null);
       setTelegramLinked(data.telegramLinked ?? false);
       setTelegramIdentity(data.telegram ?? null);
     } catch {
@@ -58,11 +72,16 @@ export function ScreeningStatusProvider({ children }: { children: ReactNode }) {
   useAutoRefresh(refresh, 30_000);
 
   const fullyActivated = telegramLinked;
-  const isScreeningActive = screeningMode && fullyActivated;
+  // Structurally locked screening (guarded v2) is ACTIVE even without the
+  // Telegram channel — the server screens every proposal regardless; reviews
+  // reach email + dashboard. Claiming "Paused" there was a lie (#136.1/.6).
+  const isScreeningActive = screeningMode && (fullyActivated || screeningLocked);
 
   const value = useMemo(
     () => ({
       screeningMode,
+      screeningLocked,
+      agentOnline,
       telegramLinked,
       telegramIdentity,
       fullyActivated,
@@ -71,7 +90,7 @@ export function ScreeningStatusProvider({ children }: { children: ReactNode }) {
       setScreeningMode,
       refresh,
     }),
-    [screeningMode, telegramLinked, telegramIdentity, fullyActivated, isScreeningActive, loading, refresh]
+    [screeningMode, screeningLocked, agentOnline, telegramLinked, telegramIdentity, fullyActivated, isScreeningActive, loading, refresh]
   );
 
   return (

--- a/client/src/app/login/page.tsx
+++ b/client/src/app/login/page.tsx
@@ -12,6 +12,33 @@ import { useAuth } from "@/app/context/AuthContext";
 import { useOnboarding } from "@/lib/useOnboarding";
 import { useScreeningStatus } from "@/app/context/ScreeningStatusContext";
 import { useLoginWithOAuth, usePrivy } from "@privy-io/react-auth";
+import { BACKEND_BASE } from "@/lib/api/client";
+
+/**
+ * Real agent liveness for the hero badge (#136.5): GET /health reports the
+ * runtime's poll status. null = unknown (loading or unreachable) — the badge
+ * then makes no online/offline claim at all.
+ */
+function useAgentHealth(): boolean | null {
+  const [online, setOnline] = useState<boolean | null>(null);
+  useEffect(() => {
+    const ctrl = new AbortController();
+    const t = setTimeout(() => ctrl.abort(), 4000);
+    fetch(`${BACKEND_BASE}/health`, { signal: ctrl.signal })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d: { runtime?: string } | null) => {
+        if (d?.runtime === "online") setOnline(true);
+        else if (d?.runtime === "offline") setOnline(false);
+      })
+      .catch(() => {})
+      .finally(() => clearTimeout(t));
+    return () => {
+      clearTimeout(t);
+      ctrl.abort();
+    };
+  }, []);
+  return online;
+}
 
 /* ── Supported-wallet brand marks ── */
 
@@ -29,6 +56,7 @@ function RabbyIcon({ className }: { className?: string }) {
 
 export default function LoginPage() {
   const { user, wallet, loading, safeAddress, safeLoading, recordOnboardingCompleted } = useAuth();
+  const agentOnline = useAgentHealth();
   const { telegramLinked } = useScreeningStatus();
   const { initOAuth, loading: oauthLoading } = useLoginWithOAuth();
   const { login } = usePrivy();
@@ -110,13 +138,23 @@ export default function LoginPage() {
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.55, type: "spring", bounce: 0.15 }}
         >
-          {/* Agent-id badge */}
+          {/* Agent-id badge — liveness from /health, never hardcoded (#136.5) */}
           <span className="inline-flex items-center gap-3 px-3.5 py-2 rounded-pill bg-gold/[0.06] border border-gold/20 font-mono text-[11px] tracking-[0.14em] uppercase text-gold-300">
             <span className="w-[18px] h-[18px] rounded-pill bg-gold/15 flex items-center justify-center p-0.5">
               <TwinTick size={13} halo="none" />
             </span>
-            Agent · online
-            <span className="w-1.5 h-1.5 rounded-pill bg-gold-400 animate-signal-pulse" />
+            {agentOnline === null
+              ? "Zhentan Agent"
+              : agentOnline
+                ? "Agent · online"
+                : "Agent · offline"}
+            <span
+              className={
+                agentOnline
+                  ? "w-1.5 h-1.5 rounded-pill bg-gold-400 animate-signal-pulse"
+                  : "w-1.5 h-1.5 rounded-pill bg-gold-400/40"
+              }
+            />
           </span>
 
           <h1 className="mt-6 font-bold text-[40px] sm:text-5xl lg:text-6xl leading-[1.02] tracking-[-0.04em] max-w-[15ch] text-foreground">

--- a/client/src/app/onboarding/page.tsx
+++ b/client/src/app/onboarding/page.tsx
@@ -138,6 +138,7 @@ function ProtectionStep({ onContinue }: { onContinue: () => void }) {
     safeError,
     safeConfig,
     refreshSafe,
+    hasExistingWallet,
   } = useAuth();
 
   // Two screens: "protect" (screening choice) then "backup" (override key).
@@ -163,6 +164,23 @@ function ProtectionStep({ onContinue }: { onContinue: () => void }) {
   // that window persists a row for the stale address (the duplicate-row bug).
   const derived = !!safeAddress && !safeLoading && !!safeConfig;
   const resolvedProfile = safeConfig?.profile ?? null;
+
+  // Returning signer with an abandoned earlier attempt: the record fixes the
+  // address AND the profile — no selection can re-derive it. Freeze the
+  // choice on the existing profile and let Continue proceed; without this,
+  // picking a different profile waited forever on "Creating your vault..."
+  // for a derivation the record-first resolution will never run.
+  useEffect(() => {
+    if (!hasExistingWallet || !resolvedProfile) return;
+    if (
+      (resolvedProfile === "starter" ||
+        resolvedProfile === "guarded" ||
+        resolvedProfile === "protected") &&
+      pendingProfile !== resolvedProfile
+    ) {
+      setPendingProfile(resolvedProfile);
+    }
+  }, [hasExistingWallet, resolvedProfile, pendingProfile, setPendingProfile]);
   const guardedSelected = pendingProfile === "guarded" || pendingProfile === "protected";
   const starterSelected = pendingProfile === "starter";
   const starterReady = starterSelected && derived && resolvedProfile === "starter";
@@ -190,9 +208,11 @@ function ProtectionStep({ onContinue }: { onContinue: () => void }) {
   }, [screen, externalWalletAddress, pendingProfile, setPendingProfile]);
 
   const pickGuarded = () => {
+    if (hasExistingWallet) return;
     if (pendingProfile !== "protected") setPendingProfile("guarded");
   };
   const pickStarter = () => {
+    if (hasExistingWallet) return;
     setBackupAddress(null);
     setPendingProfile("starter");
   };
@@ -212,13 +232,17 @@ function ProtectionStep({ onContinue }: { onContinue: () => void }) {
     setPendingProfile("guarded");
   };
 
-  const protectCta: Cta = !pendingProfile
-    ? { label: "Choose an option", enabled: false, onClick: () => {} }
-    : starterSelected
-      ? starterReady
-        ? { label: "Create my wallet", enabled: true, onClick: onContinue }
-        : { label: "Creating your vault...", enabled: false, onClick: () => {} }
-      : { label: "Turn on screening", enabled: true, onClick: () => setScreen("backup") };
+  const protectCta: Cta = hasExistingWallet
+    ? derived
+      ? { label: "Continue with my vault", enabled: true, onClick: onContinue }
+      : { label: "Loading your vault...", enabled: false, onClick: () => {} }
+    : !pendingProfile
+      ? { label: "Choose an option", enabled: false, onClick: () => {} }
+      : starterSelected
+        ? starterReady
+          ? { label: "Create my wallet", enabled: true, onClick: onContinue }
+          : { label: "Creating your vault...", enabled: false, onClick: () => {} }
+        : { label: "Turn on screening", enabled: true, onClick: () => setScreen("backup") };
 
   const creating: Cta = { label: "Creating your vault...", enabled: false, onClick: () => {} };
   const backupCta: Cta = cand.candidate
@@ -294,11 +318,19 @@ function ProtectionStep({ onContinue }: { onContinue: () => void }) {
 
           <PrimaryCta cta={protectCta} />
           {safeError && <ResolutionErrorNote onRetry={refreshSafe} />}
-          {starterSelected && (
+          {hasExistingWallet ? (
             <p className="text-[11px] leading-relaxed text-muted-foreground/60 text-center mt-3">
-              Your vault address is minted on creation — adding protection
-              later never changes it.
+              This wallet was already created with the protection shown above —
+              its address never changes. You can adjust protection any time in
+              Settings.
             </p>
+          ) : (
+            starterSelected && (
+              <p className="text-[11px] leading-relaxed text-muted-foreground/60 text-center mt-3">
+                Your vault address is minted on creation — adding protection
+                later never changes it.
+              </p>
+            )
           )}
         </>
       ) : (

--- a/client/src/app/onboarding/page.tsx
+++ b/client/src/app/onboarding/page.tsx
@@ -33,6 +33,7 @@ import {
   markOnboardingUsernameSkipped,
   markOnboardingUsernameSet,
   markOnboardingTelegramDone,
+  markOnboardingDone,
   readOnboardingStep,
 } from "@/lib/useOnboarding";
 import { queueTour } from "@/lib/tours";
@@ -1010,20 +1011,29 @@ function OnboardingContent() {
     setStep(1);
   };
 
+  // Telegram directly follows the wallet-shape step (#136 follow-up): for
+  // guarded creations it's the approval channel for the screening the user
+  // just turned on — connecting it before anything else is the natural
+  // continuation. (It cannot precede the backup screen: the binding and the
+  // record are keyed by the Safe ADDRESS, which the backup key determines.)
+  const handleTelegramDone = () => {
+    if (!wallet?.address) return;
+    markOnboardingTelegramDone(wallet.address);
+    setStep(2);
+  };
+
   const handleSaveUsername = async (username: string) => {
     if (!safeAddress || !wallet?.address) throw new Error("Wallet not ready");
     await api.users.upsert({ safeAddress, username });
     markOnboardingUsernameSet(wallet.address);
-    setStep(2);
+    setStep(3);
   };
 
   const handleSkipUsername = () => {
     if (!wallet?.address) return;
     markOnboardingUsernameSkipped(wallet.address);
-    setStep(2);
+    setStep(3);
   };
-
-  const handleTelegramDone = () => setStep(3);
 
   const handleFinish = async () => {
     if (!safeAddress || !wallet?.address) return;
@@ -1051,7 +1061,7 @@ function OnboardingContent() {
           console.error("Eager Safe deploy failed (will retry on first tx):", err);
         });
     }
-    markOnboardingTelegramDone(wallet.address);
+    markOnboardingDone(wallet.address);
     // Queue the first-time tour for arrival on /home — TourLauncher consumes
     // this marker; it never infers "new user" from account state.
     queueTour("main");
@@ -1087,14 +1097,14 @@ function OnboardingContent() {
 
         <AnimatePresence mode="wait">
           {step === 0 && <ProtectionStep onContinue={handleBackupKeyDone} />}
-          {step === 1 && (
+          {step === 1 && safeAddress && <ConnectStep onFinish={handleTelegramDone} />}
+          {step === 2 && safeAddress && (
             <UsernameStep
               onSave={handleSaveUsername}
               onSkip={handleSkipUsername}
             />
           )}
-          {step === 2 && safeAddress && <ConnectStep onFinish={handleTelegramDone} />}
-          {step === 2 && !safeAddress && (
+          {(step === 1 || step === 2) && !safeAddress && (
             /* Resumed session still resolving the Safe — a visible wait state,
                not a blank card (the step-0 fallback effect handles the
                genuinely-missing case). */

--- a/client/src/app/onboarding/page.tsx
+++ b/client/src/app/onboarding/page.tsx
@@ -540,6 +540,9 @@ function UsernameStep({
   const [error, setError] = useState<string | null>(null);
   const [checking, setChecking] = useState(false);
   const [taken, setTaken] = useState(false);
+  // Availability lookup failed (network) — don't claim "Available" (#136.9);
+  // the save itself still enforces uniqueness server-side.
+  const [checkFailed, setCheckFailed] = useState(false);
   const api = useApiClient();
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -551,6 +554,7 @@ function UsernameStep({
     setUsername(clean);
     setError(null);
     setTaken(false);
+    setCheckFailed(false);
     if (debounceRef.current) clearTimeout(debounceRef.current);
     if (clean.length >= 3) {
       setChecking(true);
@@ -559,7 +563,7 @@ function UsernameStep({
           const ok = await api.users.checkUsername(clean);
           setTaken(!ok);
         } catch {
-          setTaken(false);
+          setCheckFailed(true);
         } finally {
           setChecking(false);
         }
@@ -587,10 +591,17 @@ function UsernameStep({
       ? "That username is taken."
       : username.length > 0 && username.length < 3
         ? "At least 3 characters."
-        : available
-          ? `Available — friends can pay you at @${username}`
-          : "";
-  const hintColor = error || taken ? "text-danger" : available ? "text-safe" : "text-muted-foreground/80";
+        : checkFailed && isValid
+          ? "Couldn't check availability — you can still continue."
+          : available
+            ? `Available — friends can pay you at @${username}`
+            : "";
+  const hintColor =
+    error || taken
+      ? "text-danger"
+      : available && !checkFailed
+        ? "text-safe"
+        : "text-muted-foreground/80";
 
   return (
     <motion.div

--- a/client/src/app/onboarding/page.tsx
+++ b/client/src/app/onboarding/page.tsx
@@ -13,12 +13,13 @@ import {
   Loader2,
   Minus,
   ShieldCheck,
+  Wallet,
   X,
 } from "lucide-react";
 import { clsx } from "clsx";
 import { Button } from "@/components/ui/Button";
 import { AuthGuard } from "@/components/AuthGuard";
-import { BackupAddressPicker } from "@/components/BackupAddressPicker";
+import { useBackupCandidate } from "@/components/BackupAddressPicker";
 import { BrandMark } from "@/components/BrandMark";
 import { useAuth } from "@/app/context/AuthContext";
 import { useApiClient } from "@/lib/api/client";
@@ -32,11 +33,9 @@ import {
   markOnboardingUsernameSkipped,
   markOnboardingUsernameSet,
   markOnboardingTelegramDone,
-  markOnboardingBackupDone,
   markOnboardingDone,
   readOnboardingStep,
 } from "@/lib/useOnboarding";
-import { useSafeTransitions } from "@/lib/useSafeUpgrade";
 import { queueTour } from "@/lib/tours";
 
 /* ─── Progress header: step dashes + label ───────────────────────── */
@@ -44,7 +43,7 @@ import { queueTour } from "@/lib/tours";
 function ProgressHeader({ step }: { step: number }) {
   return (
     <div className="flex items-center gap-[7px] mb-6">
-      {[0, 1, 2, 3, 4].map((i) => (
+      {[0, 1, 2, 3].map((i) => (
         <span
           key={i}
           className={clsx(
@@ -55,7 +54,7 @@ function ProgressHeader({ step }: { step: number }) {
       ))}
       <span className="flex-1" />
       <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground/70">
-        Step {step + 1} of 5
+        Step {step + 1} of 4
       </span>
     </div>
   );
@@ -105,6 +104,12 @@ const optionClass = (selected: boolean) =>
       : "border-foreground/8 bg-foreground/[0.025] hover:bg-foreground/[0.045]"
   );
 
+const segClass = (on: boolean) =>
+  clsx(
+    "flex-1 py-[9px] rounded-[11px] text-xs font-semibold transition-all duration-200 cursor-pointer",
+    on ? "bg-gold/16 text-gold" : "text-muted-foreground hover:text-foreground"
+  );
+
 interface Cta {
   label: string;
   enabled: boolean;
@@ -124,9 +129,11 @@ function PrimaryCta({ cta }: { cta: Cta }) {
 
 function ProtectionStep({ onContinue }: { onContinue: () => void }) {
   const {
+    externalWalletAddress,
+    setBackupAddress,
+    backupAddressLocked,
     pendingProfile,
     setPendingProfile,
-    setBackupAddress,
     safeAddress,
     safeLoading,
     safeError,
@@ -135,11 +142,27 @@ function ProtectionStep({ onContinue }: { onContinue: () => void }) {
     hasExistingWallet,
   } = useAuth();
 
-  // ONE screen: the protection choice IS the creation. Choosing screening
-  // creates the vault as GUARDED right away — Telegram (the screening
-  // channel) comes next, and the backup key is added AFTER creation as an
-  // on-chain upgrade (BackupStep). This is what lets Telegram precede the
-  // backup flow: the address exists before either.
+  // Two screens: "protect" (screening choice) then "backup" (override key).
+  // The end profile is wherever the user stops — each is a valid creation
+  // profile and upgrades later never change the address.
+  const [screen, setScreen] = useState<"protect" | "backup">("protect");
+  const [mode, setMode] = useState<"connect" | "address">("connect");
+  const [skipPanel, setSkipPanel] = useState(false);
+  // Skipping through the warning panel IS the lockout-risk acknowledgment
+  // (replaces the old consent checkbox).
+  const [skipped, setSkipped] = useState(false);
+  // Candidate confirmed via the primary CTA — auto-advance once the
+  // protected derivation lands ("Use this key & create my vault" is one tap).
+  const [advancePending, setAdvancePending] = useState(false);
+
+  const cand = useBackupCandidate();
+
+  // Readiness gates check the RESOLVED derivation (safeConfig.profile is
+  // classified from the derived owner set), never just the pending inputs:
+  // right after a choice changes, safeAddress/safeConfig still describe the
+  // PREVIOUS derivation for a render or two — and the auto-advance effect
+  // runs before the provider effect that flips safeLoading. Committing in
+  // that window persists a row for the stale address (the duplicate-row bug).
   const derived = !!safeAddress && !safeLoading && !!safeConfig;
   const resolvedProfile = safeConfig?.profile ?? null;
 
@@ -159,26 +182,55 @@ function ProtectionStep({ onContinue }: { onContinue: () => void }) {
       setPendingProfile(resolvedProfile);
     }
   }, [hasExistingWallet, resolvedProfile, pendingProfile, setPendingProfile]);
-
-  // "protected" appears here only for resumed legacy sessions — the option
-  // itself now always creates guarded (backup key rides the later step).
   const guardedSelected = pendingProfile === "guarded" || pendingProfile === "protected";
   const starterSelected = pendingProfile === "starter";
   const starterReady = starterSelected && derived && resolvedProfile === "starter";
-  const screeningReady =
-    guardedSelected &&
+  const protectedReady =
+    pendingProfile === "protected" &&
+    !!externalWalletAddress &&
     derived &&
-    (resolvedProfile === "guarded" || resolvedProfile === "protected");
+    resolvedProfile === "protected";
+  const guardedReady =
+    pendingProfile === "guarded" && derived && resolvedProfile === "guarded";
+
+  useEffect(() => {
+    if (advancePending && protectedReady) {
+      setAdvancePending(false);
+      onContinue();
+    }
+  }, [advancePending, protectedReady, onContinue]);
+
+  // A backup key that already exists (resumed session, pre-linked wallet)
+  // makes the wallet protected — without this the ready-gate can never pass.
+  useEffect(() => {
+    if (screen === "backup" && externalWalletAddress && pendingProfile === "guarded") {
+      setPendingProfile("protected");
+    }
+  }, [screen, externalWalletAddress, pendingProfile, setPendingProfile]);
 
   const pickGuarded = () => {
     if (hasExistingWallet) return;
-    setBackupAddress(null);
-    setPendingProfile("guarded");
+    if (pendingProfile !== "protected") setPendingProfile("guarded");
   };
   const pickStarter = () => {
     if (hasExistingWallet) return;
     setBackupAddress(null);
     setPendingProfile("starter");
+  };
+
+  const confirmCandidate = () => {
+    if (!cand.candidate) return;
+    setBackupAddress(cand.candidate.address);
+    setPendingProfile("protected");
+    cand.clearCandidate();
+    setSkipped(false);
+    setSkipPanel(false);
+    setAdvancePending(true);
+  };
+
+  const clearBackup = () => {
+    setBackupAddress(null);
+    setPendingProfile("guarded");
   };
 
   const protectCta: Cta = hasExistingWallet
@@ -191,9 +243,20 @@ function ProtectionStep({ onContinue }: { onContinue: () => void }) {
         ? starterReady
           ? { label: "Create my wallet", enabled: true, onClick: onContinue }
           : { label: "Creating your vault...", enabled: false, onClick: () => {} }
-        : screeningReady
-          ? { label: "Create my vault", enabled: true, onClick: onContinue }
-          : { label: "Creating your vault...", enabled: false, onClick: () => {} };
+        : { label: "Turn on screening", enabled: true, onClick: () => setScreen("backup") };
+
+  const creating: Cta = { label: "Creating your vault...", enabled: false, onClick: () => {} };
+  const backupCta: Cta = cand.candidate
+    ? { label: "Use this key & create my vault", enabled: true, onClick: confirmCandidate }
+    : externalWalletAddress
+      ? advancePending || !protectedReady
+        ? creating
+        : { label: "Create my vault", enabled: true, onClick: onContinue }
+      : skipped
+        ? guardedReady
+          ? { label: "Create vault anyway", enabled: true, onClick: onContinue }
+          : creating
+        : { label: "Add a key", enabled: false, onClick: () => {} };
 
   return (
     <motion.div
@@ -204,281 +267,294 @@ function ProtectionStep({ onContinue }: { onContinue: () => void }) {
       transition={{ type: "spring", bounce: 0.15 }}
       className="w-full"
     >
-      <h2 className="text-[23px] font-bold tracking-tight mb-2">
-        How should this wallet be protected?
-      </h2>
-      <p className="text-[13.5px] leading-relaxed text-muted-foreground mb-5">
-        Pick one now — you can switch anytime in Settings and your wallet
-        address never changes.
-      </p>
+      {screen === "protect" ? (
+        /* ── 1a: how should this wallet be protected? ── */
+        <>
+          <h2 className="text-[23px] font-bold tracking-tight mb-2">
+            How should this wallet be protected?
+          </h2>
+          <p className="text-[13.5px] leading-relaxed text-muted-foreground mb-5">
+            Pick one now — you can switch anytime in Settings and your wallet
+            address never changes.
+          </p>
 
-      <div className="flex flex-col gap-2.5">
-        <button type="button" onClick={pickGuarded} className={optionClass(guardedSelected)}>
-          <span className="flex items-start gap-3">
-            <span className="w-[34px] h-[34px] rounded-xl shrink-0 flex items-center justify-center bg-gold/12">
-              <ShieldCheck className="h-[17px] w-[17px] text-gold" />
-            </span>
-            <span className="flex-1 min-w-0">
-              <span className="flex items-center gap-2 flex-wrap">
-                <span className="text-[14.5px] font-bold tracking-tight">AI screening on</span>
-                <span className="font-mono text-[9.5px] uppercase tracking-[0.1em] px-2 py-[3px] rounded-pill bg-gold/14 text-gold">
-                  Recommended
+          <div className="flex flex-col gap-2.5">
+            <button type="button" onClick={pickGuarded} className={optionClass(guardedSelected)}>
+              <span className="flex items-start gap-3">
+                <span className="w-[34px] h-[34px] rounded-xl shrink-0 flex items-center justify-center bg-gold/12">
+                  <ShieldCheck className="h-[17px] w-[17px] text-gold" />
+                </span>
+                <span className="flex-1 min-w-0">
+                  <span className="flex items-center gap-2 flex-wrap">
+                    <span className="text-[14.5px] font-bold tracking-tight">AI screening on</span>
+                    <span className="font-mono text-[9.5px] uppercase tracking-[0.1em] px-2 py-[3px] rounded-pill bg-gold/14 text-gold">
+                      Recommended
+                    </span>
+                  </span>
+                  <span className="block text-xs leading-relaxed text-muted-foreground mt-1">
+                    Zhentan reviews and co-signs every transaction, catching
+                    scams and mistakes before they land.
+                  </span>
+                </span>
+                <Tick selected={guardedSelected} />
+              </span>
+            </button>
+
+            <button type="button" onClick={pickStarter} className={optionClass(starterSelected)}>
+              <span className="flex items-start gap-3">
+                <span className="w-[34px] h-[34px] rounded-xl shrink-0 flex items-center justify-center bg-foreground/6">
+                  <KeyRound className="h-[17px] w-[17px] text-muted-foreground" />
+                </span>
+                <span className="flex-1 min-w-0">
+                  <span className="text-[14.5px] font-bold tracking-tight">Just my key</span>
+                  <span className="block text-xs leading-relaxed text-muted-foreground mt-1">
+                    A standard wallet with no screening. Zhentan still relays
+                    your transactions gas-free.
+                  </span>
+                </span>
+                <Tick selected={starterSelected} />
+              </span>
+            </button>
+          </div>
+
+          <PrimaryCta cta={protectCta} />
+          {safeError && <ResolutionErrorNote onRetry={refreshSafe} />}
+          {hasExistingWallet ? (
+            <p className="text-[11px] leading-relaxed text-muted-foreground/60 text-center mt-3">
+              This wallet was already created with the protection shown above —
+              its address never changes. You can adjust protection any time in
+              Settings.
+            </p>
+          ) : (
+            starterSelected && (
+              <p className="text-[11px] leading-relaxed text-muted-foreground/60 text-center mt-3">
+                Your vault address is minted on creation — adding protection
+                later never changes it.
+              </p>
+            )
+          )}
+        </>
+      ) : (
+        /* ── 1b: add the override key ── */
+        <>
+          <h2 className="text-[23px] font-bold tracking-tight mb-2">Add your override key</h2>
+          <p className="text-[13.5px] leading-relaxed text-muted-foreground mb-[18px]">
+            A second wallet you control, so you can always move funds yourself
+            at <span className="text-foreground/75">app.safe.global</span> — even
+            if Zhentan is offline. It is never asked to sign during setup.
+          </p>
+
+          {externalWalletAddress ? (
+            /* Saved override key */
+            <div className="flex items-center gap-2.5 p-3.5 rounded-2xl bg-safe/[0.07] border border-safe/20">
+              <span className="w-[30px] h-[30px] rounded-[10px] shrink-0 flex items-center justify-center bg-safe/14">
+                <Check className="h-[15px] w-[15px] text-safe" strokeWidth={2.6} />
+              </span>
+              <span className="flex-1 min-w-0">
+                <span className="block text-[13px] font-semibold">Override key set</span>
+                <span className="block font-mono text-[11px] text-muted-foreground mt-0.5 truncate">
+                  {externalWalletAddress}
                 </span>
               </span>
-              <span className="block text-xs leading-relaxed text-muted-foreground mt-1">
-                Zhentan reviews and co-signs every transaction, catching
-                scams and mistakes before they land.
-              </span>
-            </span>
-            <Tick selected={guardedSelected} />
-          </span>
-        </button>
-
-        <button type="button" onClick={pickStarter} className={optionClass(starterSelected)}>
-          <span className="flex items-start gap-3">
-            <span className="w-[34px] h-[34px] rounded-xl shrink-0 flex items-center justify-center bg-foreground/6">
-              <KeyRound className="h-[17px] w-[17px] text-muted-foreground" />
-            </span>
-            <span className="flex-1 min-w-0">
-              <span className="text-[14.5px] font-bold tracking-tight">Just my key</span>
-              <span className="block text-xs leading-relaxed text-muted-foreground mt-1">
-                A standard wallet with no screening. Zhentan still relays
-                your transactions gas-free.
-              </span>
-            </span>
-            <Tick selected={starterSelected} />
-          </span>
-        </button>
-      </div>
-
-      <PrimaryCta cta={protectCta} />
-      {safeError && <ResolutionErrorNote onRetry={refreshSafe} />}
-      {hasExistingWallet ? (
-        <p className="text-[11px] leading-relaxed text-muted-foreground/60 text-center mt-3">
-          This wallet was already created with the protection shown above —
-          its address never changes. You can adjust protection any time in
-          Settings.
-        </p>
-      ) : guardedSelected ? (
-        <p className="text-[11px] leading-relaxed text-muted-foreground/60 text-center mt-3">
-          Next: connect Telegram for approvals, then add a backup key you
-          control — your address never changes.
-        </p>
-      ) : (
-        starterSelected && (
-          <p className="text-[11px] leading-relaxed text-muted-foreground/60 text-center mt-3">
-            Your vault address is minted on creation — adding protection
-            later never changes it.
-          </p>
-        )
-      )}
-    </motion.div>
-  );
-}
-
-/* ─── Step 3: Backup key (post-creation upgrade) ───────────────── */
-
-function BackupStep({ onContinue }: { onContinue: () => void }) {
-  // The vault already exists (created guarded) — adding the override key is
-  // the guarded→protected TRANSITION: an owner-management SafeTx on the same
-  // address, screened + auto-approved server-side. The Safe must be deployed
-  // first (transitions execute on-chain), so the eager deploy fires on entry.
-  const { safeConfig, externalWalletAddress, setBackupAddress, refreshSafe } = useAuth();
-  const { addBackup, busy, error } = useSafeTransitions();
-  const api = useApiClient();
-
-  const [skipPanel, setSkipPanel] = useState(false);
-  const [pendingUpgrade, setPendingUpgrade] = useState(false);
-  const [deployError, setDeployError] = useState<string | null>(null);
-  const deployStartedRef = useRef(false);
-
-  const deployed = safeConfig?.deployed ?? false;
-  useEffect(() => {
-    if (deployed || deployStartedRef.current || !safeConfig) return;
-    deployStartedRef.current = true;
-    setDeployError(null);
-    api.safe
-      .deploy(safeConfig.owners, safeConfig.threshold)
-      .then(() => refreshSafe())
-      .catch((err) => {
-        deployStartedRef.current = false;
-        setDeployError(err instanceof Error ? err.message : "Deploy failed");
-      });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [deployed, safeConfig?.owners?.length]);
-
-  const handleAdd = async () => {
-    try {
-      const result = await addBackup();
-      if (result.pending) setPendingUpgrade(true);
-      else onContinue();
-    } catch {
-      /* error surfaced by the hook */
-    }
-  };
-
-  if (pendingUpgrade) {
-    return (
-      <motion.div
-        key="backup-pending"
-        initial={{ opacity: 0, scale: 0.96 }}
-        animate={{ opacity: 1, scale: 1 }}
-        className="w-full flex flex-col items-center py-6 text-center"
-      >
-        <MaoAvatar state="thinking" size={56} />
-        <h2 className="mt-4 text-[19px] font-bold tracking-tight">Adding your key</h2>
-        <p className="mt-2 text-[12.5px] leading-relaxed text-muted-foreground max-w-[300px]">
-          The upgrade is signed and completes automatically in a moment — no
-          need to wait here.
-        </p>
-        <Button onClick={onContinue} className="w-full mt-6">
-          Continue
-          <ArrowRight className="w-4 h-4" />
-        </Button>
-      </motion.div>
-    );
-  }
-
-  return (
-    <motion.div
-      key="backup"
-      initial={{ opacity: 0, x: 40 }}
-      animate={{ opacity: 1, x: 0 }}
-      exit={{ opacity: 0, x: -40 }}
-      transition={{ type: "spring", bounce: 0.15 }}
-      className="w-full"
-    >
-      <h2 className="text-[23px] font-bold tracking-tight mb-2">Add your override key</h2>
-      <p className="text-[13.5px] leading-relaxed text-muted-foreground mb-[18px]">
-        A second wallet you control, so you can always move funds yourself
-        at <span className="text-foreground/75">app.safe.global</span> — even
-        if Zhentan is offline. It is never asked to sign during setup.
-      </p>
-
-      {externalWalletAddress ? (
-        <div className="flex items-center gap-2.5 p-3.5 rounded-2xl bg-safe/[0.07] border border-safe/20">
-          <span className="w-[30px] h-[30px] rounded-[10px] shrink-0 flex items-center justify-center bg-safe/14">
-            <Check className="h-[15px] w-[15px] text-safe" strokeWidth={2.6} />
-          </span>
-          <span className="flex-1 min-w-0">
-            <span className="block text-[13px] font-semibold">Override key</span>
-            <span className="block font-mono text-[11px] text-muted-foreground mt-0.5 truncate">
-              {externalWalletAddress}
-            </span>
-          </span>
-          <button
-            type="button"
-            onClick={() => setBackupAddress(null)}
-            className="shrink-0 p-1 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
-          >
-            Change
-          </button>
-        </div>
-      ) : (
-        !skipPanel && <BackupAddressPicker onSelect={setBackupAddress} />
-      )}
-
-      {error && (
-        <p className="flex items-start gap-1.5 text-[11.5px] leading-relaxed text-danger mt-3">
-          <AlertTriangle className="h-[13px] w-[13px] shrink-0 mt-0.5" />
-          {error}
-        </p>
-      )}
-      {deployError && (
-        <div className="mt-3 p-3 rounded-2xl bg-danger/[0.06] border border-danger/20 flex items-start gap-2.5">
-          <AlertTriangle className="h-3.5 w-3.5 text-danger shrink-0 mt-0.5" />
-          <p className="flex-1 text-[11.5px] leading-relaxed text-danger/90">
-            Couldn&apos;t put your vault on-chain yet — it retries on your
-            first transaction too.
-          </p>
-          <button
-            type="button"
-            onClick={() => {
-              deployStartedRef.current = false;
-              setDeployError(null);
-              refreshSafe();
-            }}
-            className="shrink-0 text-[11.5px] font-semibold text-danger hover:opacity-80 transition-opacity cursor-pointer"
-          >
-            Retry
-          </button>
-        </div>
-      )}
-
-      {/* Skip warning — accepting it acknowledges the lockout risk */}
-      <AnimatePresence>
-        {skipPanel && (
-          <motion.div
-            initial={{ opacity: 0, y: 6 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: -6 }}
-            className="mt-3 p-[15px] rounded-2xl bg-watch/[0.06] border border-watch/18"
-          >
-            <p className="flex items-center gap-2 text-[13px] font-semibold text-watch mb-1.5">
-              <AlertTriangle className="h-3.5 w-3.5" />
-              Continue without an override key?
-            </p>
-            <p className="text-xs leading-relaxed text-watch/85 mb-3">
-              Zhentan must co-sign every transaction. If its agent is ever
-              offline, your funds sit safe but wait. Adding a key later
-              takes one tap in Settings.
-            </p>
-            <div className="flex gap-2">
-              <button
-                type="button"
-                onClick={onContinue}
-                className="flex-1 py-2.5 rounded-xl border border-watch/35 text-watch text-xs font-semibold hover:bg-watch/10 transition-colors cursor-pointer"
-              >
-                Skip for now
-              </button>
-              <button
-                type="button"
-                onClick={() => setSkipPanel(false)}
-                className="flex-1 py-2.5 rounded-xl bg-gold text-ink-900 text-xs font-bold hover:bg-gold/90 transition-colors cursor-pointer"
-              >
-                Add a key
-              </button>
+              {!backupAddressLocked && (
+                <button
+                  type="button"
+                  onClick={clearBackup}
+                  className="shrink-0 p-1 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+                >
+                  Change
+                </button>
+              )}
             </div>
-          </motion.div>
-        )}
-      </AnimatePresence>
-
-      {externalWalletAddress && (
-        <Button onClick={handleAdd} disabled={busy || !deployed} className="w-full mt-4">
-          {busy ? (
-            <>
-              <Loader2 className="w-4 h-4 animate-spin" />
-              Adding your key...
-            </>
-          ) : !deployed ? (
-            "Preparing your vault..."
           ) : (
-            <>
-              Add key & upgrade
-              <ArrowRight className="w-4 h-4" />
-            </>
+            !skipped && (
+              <div>
+                {/* Segmented: connect / enter address */}
+                <div className="flex gap-1 p-1 rounded-[14px] bg-foreground/4 mb-3">
+                  <button type="button" onClick={() => { setMode("connect"); cand.clearError(); }} className={segClass(mode === "connect")}>
+                    Connect a wallet
+                  </button>
+                  <button type="button" onClick={() => setMode("address")} className={segClass(mode === "address")}>
+                    Enter an address
+                  </button>
+                </div>
+
+                {mode === "connect" ? (
+                  <button
+                    type="button"
+                    onClick={cand.connect}
+                    disabled={cand.connecting}
+                    className="w-full flex items-center gap-3 text-left p-3.5 rounded-2xl border border-foreground/8 bg-foreground/[0.035] hover:bg-foreground/6 hover:border-foreground/14 transition-all duration-200 disabled:opacity-60 disabled:cursor-default cursor-pointer"
+                  >
+                    <span className="w-8 h-8 rounded-[10px] shrink-0 flex items-center justify-center bg-foreground/6">
+                      {cand.connecting ? (
+                        <Loader2 className="h-4 w-4 text-muted-foreground animate-spin" />
+                      ) : (
+                        <Wallet className="h-4 w-4 text-muted-foreground" />
+                      )}
+                    </span>
+                    <span className="flex-1">
+                      <span className="block text-[13.5px] font-semibold">Connect a wallet</span>
+                      <span className="block text-[11.5px] text-muted-foreground mt-0.5">
+                        {cand.connecting ? "Opening your wallet…" : "Read-only — no signature asked"}
+                      </span>
+                    </span>
+                    <ChevronRight className="h-[15px] w-[15px] text-muted-foreground/80 shrink-0" />
+                  </button>
+                ) : (
+                  <div>
+                    <div className="flex gap-2">
+                      <input
+                        type="text"
+                        value={cand.input}
+                        onChange={(e) => cand.updateInput(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") cand.resolveInput();
+                        }}
+                        placeholder="0x address, name.eth or name.bnb"
+                        spellCheck={false}
+                        autoComplete="off"
+                        className="flex-1 min-w-0 bg-foreground/4 border border-foreground/10 rounded-[13px] px-3.5 py-[11px] font-mono text-[12.5px] text-foreground placeholder:font-sans placeholder:text-muted-foreground/50 focus:outline-none focus:border-gold/50"
+                      />
+                      <button
+                        type="button"
+                        onClick={cand.resolveInput}
+                        disabled={cand.resolving || !cand.input.trim()}
+                        className="shrink-0 px-[15px] rounded-[13px] border border-gold/30 text-gold text-xs font-semibold hover:bg-gold/10 transition-colors disabled:opacity-45 disabled:cursor-default cursor-pointer"
+                      >
+                        {cand.resolving ? "Checking…" : "Use"}
+                      </button>
+                    </div>
+                    {cand.error && (
+                      <p className="flex items-start gap-1.5 text-[11.5px] leading-relaxed text-danger mt-2">
+                        <AlertTriangle className="h-[13px] w-[13px] shrink-0 mt-0.5" />
+                        {cand.error}
+                      </p>
+                    )}
+                  </div>
+                )}
+
+                {/* Candidate preview — confirmed by the primary CTA below */}
+                <AnimatePresence>
+                  {cand.candidate && (
+                    <motion.div
+                      initial={{ opacity: 0, y: 6 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      exit={{ opacity: 0, y: -6 }}
+                      className="mt-3 p-3.5 rounded-2xl border border-gold/25 bg-gold/[0.06]"
+                    >
+                      <p className="text-[13px] font-semibold">
+                        {cand.candidate.label ?? "Pasted address"}
+                      </p>
+                      <p className="font-mono text-[11px] text-muted-foreground mt-1 break-all">
+                        {cand.candidate.address}
+                      </p>
+                      <div className="flex items-start gap-2.5 mt-2.5">
+                        <p className="flex-1 text-[11.5px] leading-relaxed text-muted-foreground/90">
+                          Confirm you control this wallet. It becomes a permanent
+                          owner of your vault and can&apos;t be swapped casually
+                          later.
+                        </p>
+                        <button
+                          type="button"
+                          onClick={cand.clearCandidate}
+                          className="shrink-0 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+                        >
+                          Clear
+                        </button>
+                      </div>
+                    </motion.div>
+                  )}
+                </AnimatePresence>
+              </div>
+            )
           )}
-        </Button>
+
+          {/* Skip warning panel — accepting it acknowledges the lockout risk */}
+          <AnimatePresence>
+            {skipPanel && (
+              <motion.div
+                initial={{ opacity: 0, y: 6 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -6 }}
+                className="mt-3 p-[15px] rounded-2xl bg-watch/[0.06] border border-watch/18"
+              >
+                <p className="flex items-center gap-2 text-[13px] font-semibold text-watch mb-1.5">
+                  <AlertTriangle className="h-3.5 w-3.5" />
+                  Continue without an override key?
+                </p>
+                <p className="text-xs leading-relaxed text-watch/85 mb-3">
+                  Zhentan must co-sign every transaction. If its agent is ever
+                  offline, your funds sit safe but wait. Adding a key later
+                  takes one tap in Settings.
+                </p>
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setSkipped(true);
+                      setSkipPanel(false);
+                      cand.clearCandidate();
+                    }}
+                    className="flex-1 py-2.5 rounded-xl border border-watch/35 text-watch text-xs font-semibold hover:bg-watch/10 transition-colors cursor-pointer"
+                  >
+                    Skip for now
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setSkipPanel(false);
+                      setSkipped(false);
+                    }}
+                    className="flex-1 py-2.5 rounded-xl bg-gold text-ink-900 text-xs font-bold hover:bg-gold/90 transition-colors cursor-pointer"
+                  >
+                    Add a key
+                  </button>
+                </div>
+              </motion.div>
+            )}
+          </AnimatePresence>
+
+          <PrimaryCta cta={backupCta} />
+          {safeError && <ResolutionErrorNote onRetry={refreshSafe} />}
+
+          {/* Finality note: the CTA below mints the address / locks the key */}
+          {(cand.candidate || externalWalletAddress || skipped) && (
+            <p className="text-[11px] leading-relaxed text-muted-foreground/60 text-center mt-3">
+              {skipped && !cand.candidate && !externalWalletAddress
+                ? "Your vault address is minted on creation — adding an override key later never changes it."
+                : "Creating your vault makes this key a permanent owner — changing it later is an on-chain owner swap in Settings."}
+            </p>
+          )}
+
+          <div className="flex items-center justify-between mt-3">
+            <button
+              type="button"
+              onClick={() => setScreen("protect")}
+              className="inline-flex items-center gap-1.5 py-1 text-xs text-muted-foreground/75 hover:text-foreground transition-colors cursor-pointer"
+            >
+              <ArrowLeft className="h-[13px] w-[13px]" />
+              Back
+            </button>
+            {!externalWalletAddress && !skipPanel && !skipped && (
+              <button
+                type="button"
+                onClick={() => setSkipPanel(true)}
+                className="py-1 text-xs text-muted-foreground/75 hover:text-foreground transition-colors cursor-pointer"
+              >
+                I&apos;ll add this later
+              </button>
+            )}
+          </div>
+
+          <p className="text-[11px] leading-relaxed text-muted-foreground/60 text-center mt-[18px]">
+            With an override key your vault is a 2-of-3 Safe — your key, your
+            override key, the screening agent. Any two move funds, so
+            you&apos;re never locked out and Zhentan alone can never move a
+            cent.
+          </p>
+        </>
       )}
-
-      <div className="flex items-center justify-center mt-3">
-        {!externalWalletAddress && !skipPanel && (
-          <button
-            type="button"
-            onClick={() => setSkipPanel(true)}
-            className="py-1 text-xs text-muted-foreground/75 hover:text-foreground transition-colors cursor-pointer"
-          >
-            I&apos;ll add this later
-          </button>
-        )}
-      </div>
-
-      <p className="text-[11px] leading-relaxed text-muted-foreground/60 text-center mt-[18px]">
-        With an override key your vault is a 2-of-3 Safe — your key, your
-        override key, the screening agent. Any two move funds, so
-        you&apos;re never locked out and Zhentan alone can never move a
-        cent.
-      </p>
     </motion.div>
   );
 }
@@ -946,34 +1022,17 @@ function OnboardingContent() {
     setStep(2);
   };
 
-  const handleBackupDone = () => {
-    if (!wallet?.address) return;
-    markOnboardingBackupDone(wallet.address);
-    setStep(3);
-  };
-
-  // The backup step is the guarded→protected upgrade — only guarded wallets
-  // have it; starter (no agent) and already-protected resumes skip through.
-  const resolvedProfile = safeConfig?.profile ?? null;
-  useEffect(() => {
-    if (step !== 2 || !stepReady || !wallet?.address) return;
-    if (resolvedProfile && resolvedProfile !== "guarded") {
-      markOnboardingBackupDone(wallet.address);
-      setStep(3);
-    }
-  }, [step, stepReady, resolvedProfile, wallet?.address]);
-
   const handleSaveUsername = async (username: string) => {
     if (!safeAddress || !wallet?.address) throw new Error("Wallet not ready");
     await api.users.upsert({ safeAddress, username });
     markOnboardingUsernameSet(wallet.address);
-    setStep(4);
+    setStep(3);
   };
 
   const handleSkipUsername = () => {
     if (!wallet?.address) return;
     markOnboardingUsernameSkipped(wallet.address);
-    setStep(4);
+    setStep(3);
   };
 
   const handleFinish = async () => {
@@ -1039,16 +1098,13 @@ function OnboardingContent() {
         <AnimatePresence mode="wait">
           {step === 0 && <ProtectionStep onContinue={handleBackupKeyDone} />}
           {step === 1 && safeAddress && <ConnectStep onFinish={handleTelegramDone} />}
-          {step === 2 && safeAddress && resolvedProfile === "guarded" && (
-            <BackupStep onContinue={handleBackupDone} />
-          )}
-          {step === 3 && safeAddress && (
+          {step === 2 && safeAddress && (
             <UsernameStep
               onSave={handleSaveUsername}
               onSkip={handleSkipUsername}
             />
           )}
-          {(step === 1 || step === 2 || step === 3) && !safeAddress && (
+          {(step === 1 || step === 2) && !safeAddress && (
             /* Resumed session still resolving the Safe — a visible wait state,
                not a blank card (the step-0 fallback effect handles the
                genuinely-missing case). */
@@ -1062,7 +1118,7 @@ function OnboardingContent() {
               <p className="text-xs text-muted-foreground">Preparing your vault…</p>
             </motion.div>
           )}
-          {step === 4 && (
+          {step === 3 && (
             <DoneStep
               screeningOn={(safeConfig?.profile ?? pendingProfile) !== "starter"}
               backupSet={!!externalWalletAddress}

--- a/client/src/app/onboarding/page.tsx
+++ b/client/src/app/onboarding/page.tsx
@@ -13,13 +13,12 @@ import {
   Loader2,
   Minus,
   ShieldCheck,
-  Wallet,
   X,
 } from "lucide-react";
 import { clsx } from "clsx";
 import { Button } from "@/components/ui/Button";
 import { AuthGuard } from "@/components/AuthGuard";
-import { useBackupCandidate } from "@/components/BackupAddressPicker";
+import { BackupAddressPicker } from "@/components/BackupAddressPicker";
 import { BrandMark } from "@/components/BrandMark";
 import { useAuth } from "@/app/context/AuthContext";
 import { useApiClient } from "@/lib/api/client";
@@ -33,9 +32,11 @@ import {
   markOnboardingUsernameSkipped,
   markOnboardingUsernameSet,
   markOnboardingTelegramDone,
+  markOnboardingBackupDone,
   markOnboardingDone,
   readOnboardingStep,
 } from "@/lib/useOnboarding";
+import { useSafeTransitions } from "@/lib/useSafeUpgrade";
 import { queueTour } from "@/lib/tours";
 
 /* ─── Progress header: step dashes + label ───────────────────────── */
@@ -43,7 +44,7 @@ import { queueTour } from "@/lib/tours";
 function ProgressHeader({ step }: { step: number }) {
   return (
     <div className="flex items-center gap-[7px] mb-6">
-      {[0, 1, 2, 3].map((i) => (
+      {[0, 1, 2, 3, 4].map((i) => (
         <span
           key={i}
           className={clsx(
@@ -54,7 +55,7 @@ function ProgressHeader({ step }: { step: number }) {
       ))}
       <span className="flex-1" />
       <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground/70">
-        Step {step + 1} of 4
+        Step {step + 1} of 5
       </span>
     </div>
   );
@@ -104,12 +105,6 @@ const optionClass = (selected: boolean) =>
       : "border-foreground/8 bg-foreground/[0.025] hover:bg-foreground/[0.045]"
   );
 
-const segClass = (on: boolean) =>
-  clsx(
-    "flex-1 py-[9px] rounded-[11px] text-xs font-semibold transition-all duration-200 cursor-pointer",
-    on ? "bg-gold/16 text-gold" : "text-muted-foreground hover:text-foreground"
-  );
-
 interface Cta {
   label: string;
   enabled: boolean;
@@ -129,11 +124,9 @@ function PrimaryCta({ cta }: { cta: Cta }) {
 
 function ProtectionStep({ onContinue }: { onContinue: () => void }) {
   const {
-    externalWalletAddress,
-    setBackupAddress,
-    backupAddressLocked,
     pendingProfile,
     setPendingProfile,
+    setBackupAddress,
     safeAddress,
     safeLoading,
     safeError,
@@ -142,27 +135,11 @@ function ProtectionStep({ onContinue }: { onContinue: () => void }) {
     hasExistingWallet,
   } = useAuth();
 
-  // Two screens: "protect" (screening choice) then "backup" (override key).
-  // The end profile is wherever the user stops — each is a valid creation
-  // profile and upgrades later never change the address.
-  const [screen, setScreen] = useState<"protect" | "backup">("protect");
-  const [mode, setMode] = useState<"connect" | "address">("connect");
-  const [skipPanel, setSkipPanel] = useState(false);
-  // Skipping through the warning panel IS the lockout-risk acknowledgment
-  // (replaces the old consent checkbox).
-  const [skipped, setSkipped] = useState(false);
-  // Candidate confirmed via the primary CTA — auto-advance once the
-  // protected derivation lands ("Use this key & create my vault" is one tap).
-  const [advancePending, setAdvancePending] = useState(false);
-
-  const cand = useBackupCandidate();
-
-  // Readiness gates check the RESOLVED derivation (safeConfig.profile is
-  // classified from the derived owner set), never just the pending inputs:
-  // right after a choice changes, safeAddress/safeConfig still describe the
-  // PREVIOUS derivation for a render or two — and the auto-advance effect
-  // runs before the provider effect that flips safeLoading. Committing in
-  // that window persists a row for the stale address (the duplicate-row bug).
+  // ONE screen: the protection choice IS the creation. Choosing screening
+  // creates the vault as GUARDED right away — Telegram (the screening
+  // channel) comes next, and the backup key is added AFTER creation as an
+  // on-chain upgrade (BackupStep). This is what lets Telegram precede the
+  // backup flow: the address exists before either.
   const derived = !!safeAddress && !safeLoading && !!safeConfig;
   const resolvedProfile = safeConfig?.profile ?? null;
 
@@ -182,55 +159,26 @@ function ProtectionStep({ onContinue }: { onContinue: () => void }) {
       setPendingProfile(resolvedProfile);
     }
   }, [hasExistingWallet, resolvedProfile, pendingProfile, setPendingProfile]);
+
+  // "protected" appears here only for resumed legacy sessions — the option
+  // itself now always creates guarded (backup key rides the later step).
   const guardedSelected = pendingProfile === "guarded" || pendingProfile === "protected";
   const starterSelected = pendingProfile === "starter";
   const starterReady = starterSelected && derived && resolvedProfile === "starter";
-  const protectedReady =
-    pendingProfile === "protected" &&
-    !!externalWalletAddress &&
+  const screeningReady =
+    guardedSelected &&
     derived &&
-    resolvedProfile === "protected";
-  const guardedReady =
-    pendingProfile === "guarded" && derived && resolvedProfile === "guarded";
-
-  useEffect(() => {
-    if (advancePending && protectedReady) {
-      setAdvancePending(false);
-      onContinue();
-    }
-  }, [advancePending, protectedReady, onContinue]);
-
-  // A backup key that already exists (resumed session, pre-linked wallet)
-  // makes the wallet protected — without this the ready-gate can never pass.
-  useEffect(() => {
-    if (screen === "backup" && externalWalletAddress && pendingProfile === "guarded") {
-      setPendingProfile("protected");
-    }
-  }, [screen, externalWalletAddress, pendingProfile, setPendingProfile]);
+    (resolvedProfile === "guarded" || resolvedProfile === "protected");
 
   const pickGuarded = () => {
     if (hasExistingWallet) return;
-    if (pendingProfile !== "protected") setPendingProfile("guarded");
+    setBackupAddress(null);
+    setPendingProfile("guarded");
   };
   const pickStarter = () => {
     if (hasExistingWallet) return;
     setBackupAddress(null);
     setPendingProfile("starter");
-  };
-
-  const confirmCandidate = () => {
-    if (!cand.candidate) return;
-    setBackupAddress(cand.candidate.address);
-    setPendingProfile("protected");
-    cand.clearCandidate();
-    setSkipped(false);
-    setSkipPanel(false);
-    setAdvancePending(true);
-  };
-
-  const clearBackup = () => {
-    setBackupAddress(null);
-    setPendingProfile("guarded");
   };
 
   const protectCta: Cta = hasExistingWallet
@@ -243,20 +191,9 @@ function ProtectionStep({ onContinue }: { onContinue: () => void }) {
         ? starterReady
           ? { label: "Create my wallet", enabled: true, onClick: onContinue }
           : { label: "Creating your vault...", enabled: false, onClick: () => {} }
-        : { label: "Turn on screening", enabled: true, onClick: () => setScreen("backup") };
-
-  const creating: Cta = { label: "Creating your vault...", enabled: false, onClick: () => {} };
-  const backupCta: Cta = cand.candidate
-    ? { label: "Use this key & create my vault", enabled: true, onClick: confirmCandidate }
-    : externalWalletAddress
-      ? advancePending || !protectedReady
-        ? creating
-        : { label: "Create my vault", enabled: true, onClick: onContinue }
-      : skipped
-        ? guardedReady
-          ? { label: "Create vault anyway", enabled: true, onClick: onContinue }
-          : creating
-        : { label: "Add a key", enabled: false, onClick: () => {} };
+        : screeningReady
+          ? { label: "Create my vault", enabled: true, onClick: onContinue }
+          : { label: "Creating your vault...", enabled: false, onClick: () => {} };
 
   return (
     <motion.div
@@ -267,294 +204,281 @@ function ProtectionStep({ onContinue }: { onContinue: () => void }) {
       transition={{ type: "spring", bounce: 0.15 }}
       className="w-full"
     >
-      {screen === "protect" ? (
-        /* ── 1a: how should this wallet be protected? ── */
-        <>
-          <h2 className="text-[23px] font-bold tracking-tight mb-2">
-            How should this wallet be protected?
-          </h2>
-          <p className="text-[13.5px] leading-relaxed text-muted-foreground mb-5">
-            Pick one now — you can switch anytime in Settings and your wallet
-            address never changes.
-          </p>
+      <h2 className="text-[23px] font-bold tracking-tight mb-2">
+        How should this wallet be protected?
+      </h2>
+      <p className="text-[13.5px] leading-relaxed text-muted-foreground mb-5">
+        Pick one now — you can switch anytime in Settings and your wallet
+        address never changes.
+      </p>
 
-          <div className="flex flex-col gap-2.5">
-            <button type="button" onClick={pickGuarded} className={optionClass(guardedSelected)}>
-              <span className="flex items-start gap-3">
-                <span className="w-[34px] h-[34px] rounded-xl shrink-0 flex items-center justify-center bg-gold/12">
-                  <ShieldCheck className="h-[17px] w-[17px] text-gold" />
+      <div className="flex flex-col gap-2.5">
+        <button type="button" onClick={pickGuarded} className={optionClass(guardedSelected)}>
+          <span className="flex items-start gap-3">
+            <span className="w-[34px] h-[34px] rounded-xl shrink-0 flex items-center justify-center bg-gold/12">
+              <ShieldCheck className="h-[17px] w-[17px] text-gold" />
+            </span>
+            <span className="flex-1 min-w-0">
+              <span className="flex items-center gap-2 flex-wrap">
+                <span className="text-[14.5px] font-bold tracking-tight">AI screening on</span>
+                <span className="font-mono text-[9.5px] uppercase tracking-[0.1em] px-2 py-[3px] rounded-pill bg-gold/14 text-gold">
+                  Recommended
                 </span>
-                <span className="flex-1 min-w-0">
-                  <span className="flex items-center gap-2 flex-wrap">
-                    <span className="text-[14.5px] font-bold tracking-tight">AI screening on</span>
-                    <span className="font-mono text-[9.5px] uppercase tracking-[0.1em] px-2 py-[3px] rounded-pill bg-gold/14 text-gold">
-                      Recommended
-                    </span>
-                  </span>
-                  <span className="block text-xs leading-relaxed text-muted-foreground mt-1">
-                    Zhentan reviews and co-signs every transaction, catching
-                    scams and mistakes before they land.
-                  </span>
-                </span>
-                <Tick selected={guardedSelected} />
               </span>
-            </button>
-
-            <button type="button" onClick={pickStarter} className={optionClass(starterSelected)}>
-              <span className="flex items-start gap-3">
-                <span className="w-[34px] h-[34px] rounded-xl shrink-0 flex items-center justify-center bg-foreground/6">
-                  <KeyRound className="h-[17px] w-[17px] text-muted-foreground" />
-                </span>
-                <span className="flex-1 min-w-0">
-                  <span className="text-[14.5px] font-bold tracking-tight">Just my key</span>
-                  <span className="block text-xs leading-relaxed text-muted-foreground mt-1">
-                    A standard wallet with no screening. Zhentan still relays
-                    your transactions gas-free.
-                  </span>
-                </span>
-                <Tick selected={starterSelected} />
+              <span className="block text-xs leading-relaxed text-muted-foreground mt-1">
+                Zhentan reviews and co-signs every transaction, catching
+                scams and mistakes before they land.
               </span>
-            </button>
-          </div>
+            </span>
+            <Tick selected={guardedSelected} />
+          </span>
+        </button>
 
-          <PrimaryCta cta={protectCta} />
-          {safeError && <ResolutionErrorNote onRetry={refreshSafe} />}
-          {hasExistingWallet ? (
-            <p className="text-[11px] leading-relaxed text-muted-foreground/60 text-center mt-3">
-              This wallet was already created with the protection shown above —
-              its address never changes. You can adjust protection any time in
-              Settings.
-            </p>
-          ) : (
-            starterSelected && (
-              <p className="text-[11px] leading-relaxed text-muted-foreground/60 text-center mt-3">
-                Your vault address is minted on creation — adding protection
-                later never changes it.
-              </p>
-            )
-          )}
-        </>
+        <button type="button" onClick={pickStarter} className={optionClass(starterSelected)}>
+          <span className="flex items-start gap-3">
+            <span className="w-[34px] h-[34px] rounded-xl shrink-0 flex items-center justify-center bg-foreground/6">
+              <KeyRound className="h-[17px] w-[17px] text-muted-foreground" />
+            </span>
+            <span className="flex-1 min-w-0">
+              <span className="text-[14.5px] font-bold tracking-tight">Just my key</span>
+              <span className="block text-xs leading-relaxed text-muted-foreground mt-1">
+                A standard wallet with no screening. Zhentan still relays
+                your transactions gas-free.
+              </span>
+            </span>
+            <Tick selected={starterSelected} />
+          </span>
+        </button>
+      </div>
+
+      <PrimaryCta cta={protectCta} />
+      {safeError && <ResolutionErrorNote onRetry={refreshSafe} />}
+      {hasExistingWallet ? (
+        <p className="text-[11px] leading-relaxed text-muted-foreground/60 text-center mt-3">
+          This wallet was already created with the protection shown above —
+          its address never changes. You can adjust protection any time in
+          Settings.
+        </p>
+      ) : guardedSelected ? (
+        <p className="text-[11px] leading-relaxed text-muted-foreground/60 text-center mt-3">
+          Next: connect Telegram for approvals, then add a backup key you
+          control — your address never changes.
+        </p>
       ) : (
-        /* ── 1b: add the override key ── */
-        <>
-          <h2 className="text-[23px] font-bold tracking-tight mb-2">Add your override key</h2>
-          <p className="text-[13.5px] leading-relaxed text-muted-foreground mb-[18px]">
-            A second wallet you control, so you can always move funds yourself
-            at <span className="text-foreground/75">app.safe.global</span> — even
-            if Zhentan is offline. It is never asked to sign during setup.
+        starterSelected && (
+          <p className="text-[11px] leading-relaxed text-muted-foreground/60 text-center mt-3">
+            Your vault address is minted on creation — adding protection
+            later never changes it.
           </p>
+        )
+      )}
+    </motion.div>
+  );
+}
 
-          {externalWalletAddress ? (
-            /* Saved override key */
-            <div className="flex items-center gap-2.5 p-3.5 rounded-2xl bg-safe/[0.07] border border-safe/20">
-              <span className="w-[30px] h-[30px] rounded-[10px] shrink-0 flex items-center justify-center bg-safe/14">
-                <Check className="h-[15px] w-[15px] text-safe" strokeWidth={2.6} />
-              </span>
-              <span className="flex-1 min-w-0">
-                <span className="block text-[13px] font-semibold">Override key set</span>
-                <span className="block font-mono text-[11px] text-muted-foreground mt-0.5 truncate">
-                  {externalWalletAddress}
-                </span>
-              </span>
-              {!backupAddressLocked && (
-                <button
-                  type="button"
-                  onClick={clearBackup}
-                  className="shrink-0 p-1 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
-                >
-                  Change
-                </button>
-              )}
-            </div>
-          ) : (
-            !skipped && (
-              <div>
-                {/* Segmented: connect / enter address */}
-                <div className="flex gap-1 p-1 rounded-[14px] bg-foreground/4 mb-3">
-                  <button type="button" onClick={() => { setMode("connect"); cand.clearError(); }} className={segClass(mode === "connect")}>
-                    Connect a wallet
-                  </button>
-                  <button type="button" onClick={() => setMode("address")} className={segClass(mode === "address")}>
-                    Enter an address
-                  </button>
-                </div>
+/* ─── Step 3: Backup key (post-creation upgrade) ───────────────── */
 
-                {mode === "connect" ? (
-                  <button
-                    type="button"
-                    onClick={cand.connect}
-                    disabled={cand.connecting}
-                    className="w-full flex items-center gap-3 text-left p-3.5 rounded-2xl border border-foreground/8 bg-foreground/[0.035] hover:bg-foreground/6 hover:border-foreground/14 transition-all duration-200 disabled:opacity-60 disabled:cursor-default cursor-pointer"
-                  >
-                    <span className="w-8 h-8 rounded-[10px] shrink-0 flex items-center justify-center bg-foreground/6">
-                      {cand.connecting ? (
-                        <Loader2 className="h-4 w-4 text-muted-foreground animate-spin" />
-                      ) : (
-                        <Wallet className="h-4 w-4 text-muted-foreground" />
-                      )}
-                    </span>
-                    <span className="flex-1">
-                      <span className="block text-[13.5px] font-semibold">Connect a wallet</span>
-                      <span className="block text-[11.5px] text-muted-foreground mt-0.5">
-                        {cand.connecting ? "Opening your wallet…" : "Read-only — no signature asked"}
-                      </span>
-                    </span>
-                    <ChevronRight className="h-[15px] w-[15px] text-muted-foreground/80 shrink-0" />
-                  </button>
-                ) : (
-                  <div>
-                    <div className="flex gap-2">
-                      <input
-                        type="text"
-                        value={cand.input}
-                        onChange={(e) => cand.updateInput(e.target.value)}
-                        onKeyDown={(e) => {
-                          if (e.key === "Enter") cand.resolveInput();
-                        }}
-                        placeholder="0x address, name.eth or name.bnb"
-                        spellCheck={false}
-                        autoComplete="off"
-                        className="flex-1 min-w-0 bg-foreground/4 border border-foreground/10 rounded-[13px] px-3.5 py-[11px] font-mono text-[12.5px] text-foreground placeholder:font-sans placeholder:text-muted-foreground/50 focus:outline-none focus:border-gold/50"
-                      />
-                      <button
-                        type="button"
-                        onClick={cand.resolveInput}
-                        disabled={cand.resolving || !cand.input.trim()}
-                        className="shrink-0 px-[15px] rounded-[13px] border border-gold/30 text-gold text-xs font-semibold hover:bg-gold/10 transition-colors disabled:opacity-45 disabled:cursor-default cursor-pointer"
-                      >
-                        {cand.resolving ? "Checking…" : "Use"}
-                      </button>
-                    </div>
-                    {cand.error && (
-                      <p className="flex items-start gap-1.5 text-[11.5px] leading-relaxed text-danger mt-2">
-                        <AlertTriangle className="h-[13px] w-[13px] shrink-0 mt-0.5" />
-                        {cand.error}
-                      </p>
-                    )}
-                  </div>
-                )}
+function BackupStep({ onContinue }: { onContinue: () => void }) {
+  // The vault already exists (created guarded) — adding the override key is
+  // the guarded→protected TRANSITION: an owner-management SafeTx on the same
+  // address, screened + auto-approved server-side. The Safe must be deployed
+  // first (transitions execute on-chain), so the eager deploy fires on entry.
+  const { safeConfig, externalWalletAddress, setBackupAddress, refreshSafe } = useAuth();
+  const { addBackup, busy, error } = useSafeTransitions();
+  const api = useApiClient();
 
-                {/* Candidate preview — confirmed by the primary CTA below */}
-                <AnimatePresence>
-                  {cand.candidate && (
-                    <motion.div
-                      initial={{ opacity: 0, y: 6 }}
-                      animate={{ opacity: 1, y: 0 }}
-                      exit={{ opacity: 0, y: -6 }}
-                      className="mt-3 p-3.5 rounded-2xl border border-gold/25 bg-gold/[0.06]"
-                    >
-                      <p className="text-[13px] font-semibold">
-                        {cand.candidate.label ?? "Pasted address"}
-                      </p>
-                      <p className="font-mono text-[11px] text-muted-foreground mt-1 break-all">
-                        {cand.candidate.address}
-                      </p>
-                      <div className="flex items-start gap-2.5 mt-2.5">
-                        <p className="flex-1 text-[11.5px] leading-relaxed text-muted-foreground/90">
-                          Confirm you control this wallet. It becomes a permanent
-                          owner of your vault and can&apos;t be swapped casually
-                          later.
-                        </p>
-                        <button
-                          type="button"
-                          onClick={cand.clearCandidate}
-                          className="shrink-0 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
-                        >
-                          Clear
-                        </button>
-                      </div>
-                    </motion.div>
-                  )}
-                </AnimatePresence>
-              </div>
-            )
-          )}
+  const [skipPanel, setSkipPanel] = useState(false);
+  const [pendingUpgrade, setPendingUpgrade] = useState(false);
+  const [deployError, setDeployError] = useState<string | null>(null);
+  const deployStartedRef = useRef(false);
 
-          {/* Skip warning panel — accepting it acknowledges the lockout risk */}
-          <AnimatePresence>
-            {skipPanel && (
-              <motion.div
-                initial={{ opacity: 0, y: 6 }}
-                animate={{ opacity: 1, y: 0 }}
-                exit={{ opacity: 0, y: -6 }}
-                className="mt-3 p-[15px] rounded-2xl bg-watch/[0.06] border border-watch/18"
-              >
-                <p className="flex items-center gap-2 text-[13px] font-semibold text-watch mb-1.5">
-                  <AlertTriangle className="h-3.5 w-3.5" />
-                  Continue without an override key?
-                </p>
-                <p className="text-xs leading-relaxed text-watch/85 mb-3">
-                  Zhentan must co-sign every transaction. If its agent is ever
-                  offline, your funds sit safe but wait. Adding a key later
-                  takes one tap in Settings.
-                </p>
-                <div className="flex gap-2">
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setSkipped(true);
-                      setSkipPanel(false);
-                      cand.clearCandidate();
-                    }}
-                    className="flex-1 py-2.5 rounded-xl border border-watch/35 text-watch text-xs font-semibold hover:bg-watch/10 transition-colors cursor-pointer"
-                  >
-                    Skip for now
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setSkipPanel(false);
-                      setSkipped(false);
-                    }}
-                    className="flex-1 py-2.5 rounded-xl bg-gold text-ink-900 text-xs font-bold hover:bg-gold/90 transition-colors cursor-pointer"
-                  >
-                    Add a key
-                  </button>
-                </div>
-              </motion.div>
-            )}
-          </AnimatePresence>
+  const deployed = safeConfig?.deployed ?? false;
+  useEffect(() => {
+    if (deployed || deployStartedRef.current || !safeConfig) return;
+    deployStartedRef.current = true;
+    setDeployError(null);
+    api.safe
+      .deploy(safeConfig.owners, safeConfig.threshold)
+      .then(() => refreshSafe())
+      .catch((err) => {
+        deployStartedRef.current = false;
+        setDeployError(err instanceof Error ? err.message : "Deploy failed");
+      });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [deployed, safeConfig?.owners?.length]);
 
-          <PrimaryCta cta={backupCta} />
-          {safeError && <ResolutionErrorNote onRetry={refreshSafe} />}
+  const handleAdd = async () => {
+    try {
+      const result = await addBackup();
+      if (result.pending) setPendingUpgrade(true);
+      else onContinue();
+    } catch {
+      /* error surfaced by the hook */
+    }
+  };
 
-          {/* Finality note: the CTA below mints the address / locks the key */}
-          {(cand.candidate || externalWalletAddress || skipped) && (
-            <p className="text-[11px] leading-relaxed text-muted-foreground/60 text-center mt-3">
-              {skipped && !cand.candidate && !externalWalletAddress
-                ? "Your vault address is minted on creation — adding an override key later never changes it."
-                : "Creating your vault makes this key a permanent owner — changing it later is an on-chain owner swap in Settings."}
+  if (pendingUpgrade) {
+    return (
+      <motion.div
+        key="backup-pending"
+        initial={{ opacity: 0, scale: 0.96 }}
+        animate={{ opacity: 1, scale: 1 }}
+        className="w-full flex flex-col items-center py-6 text-center"
+      >
+        <MaoAvatar state="thinking" size={56} />
+        <h2 className="mt-4 text-[19px] font-bold tracking-tight">Adding your key</h2>
+        <p className="mt-2 text-[12.5px] leading-relaxed text-muted-foreground max-w-[300px]">
+          The upgrade is signed and completes automatically in a moment — no
+          need to wait here.
+        </p>
+        <Button onClick={onContinue} className="w-full mt-6">
+          Continue
+          <ArrowRight className="w-4 h-4" />
+        </Button>
+      </motion.div>
+    );
+  }
+
+  return (
+    <motion.div
+      key="backup"
+      initial={{ opacity: 0, x: 40 }}
+      animate={{ opacity: 1, x: 0 }}
+      exit={{ opacity: 0, x: -40 }}
+      transition={{ type: "spring", bounce: 0.15 }}
+      className="w-full"
+    >
+      <h2 className="text-[23px] font-bold tracking-tight mb-2">Add your override key</h2>
+      <p className="text-[13.5px] leading-relaxed text-muted-foreground mb-[18px]">
+        A second wallet you control, so you can always move funds yourself
+        at <span className="text-foreground/75">app.safe.global</span> — even
+        if Zhentan is offline. It is never asked to sign during setup.
+      </p>
+
+      {externalWalletAddress ? (
+        <div className="flex items-center gap-2.5 p-3.5 rounded-2xl bg-safe/[0.07] border border-safe/20">
+          <span className="w-[30px] h-[30px] rounded-[10px] shrink-0 flex items-center justify-center bg-safe/14">
+            <Check className="h-[15px] w-[15px] text-safe" strokeWidth={2.6} />
+          </span>
+          <span className="flex-1 min-w-0">
+            <span className="block text-[13px] font-semibold">Override key</span>
+            <span className="block font-mono text-[11px] text-muted-foreground mt-0.5 truncate">
+              {externalWalletAddress}
+            </span>
+          </span>
+          <button
+            type="button"
+            onClick={() => setBackupAddress(null)}
+            className="shrink-0 p-1 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+          >
+            Change
+          </button>
+        </div>
+      ) : (
+        !skipPanel && <BackupAddressPicker onSelect={setBackupAddress} />
+      )}
+
+      {error && (
+        <p className="flex items-start gap-1.5 text-[11.5px] leading-relaxed text-danger mt-3">
+          <AlertTriangle className="h-[13px] w-[13px] shrink-0 mt-0.5" />
+          {error}
+        </p>
+      )}
+      {deployError && (
+        <div className="mt-3 p-3 rounded-2xl bg-danger/[0.06] border border-danger/20 flex items-start gap-2.5">
+          <AlertTriangle className="h-3.5 w-3.5 text-danger shrink-0 mt-0.5" />
+          <p className="flex-1 text-[11.5px] leading-relaxed text-danger/90">
+            Couldn&apos;t put your vault on-chain yet — it retries on your
+            first transaction too.
+          </p>
+          <button
+            type="button"
+            onClick={() => {
+              deployStartedRef.current = false;
+              setDeployError(null);
+              refreshSafe();
+            }}
+            className="shrink-0 text-[11.5px] font-semibold text-danger hover:opacity-80 transition-opacity cursor-pointer"
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      {/* Skip warning — accepting it acknowledges the lockout risk */}
+      <AnimatePresence>
+        {skipPanel && (
+          <motion.div
+            initial={{ opacity: 0, y: 6 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -6 }}
+            className="mt-3 p-[15px] rounded-2xl bg-watch/[0.06] border border-watch/18"
+          >
+            <p className="flex items-center gap-2 text-[13px] font-semibold text-watch mb-1.5">
+              <AlertTriangle className="h-3.5 w-3.5" />
+              Continue without an override key?
             </p>
-          )}
-
-          <div className="flex items-center justify-between mt-3">
-            <button
-              type="button"
-              onClick={() => setScreen("protect")}
-              className="inline-flex items-center gap-1.5 py-1 text-xs text-muted-foreground/75 hover:text-foreground transition-colors cursor-pointer"
-            >
-              <ArrowLeft className="h-[13px] w-[13px]" />
-              Back
-            </button>
-            {!externalWalletAddress && !skipPanel && !skipped && (
+            <p className="text-xs leading-relaxed text-watch/85 mb-3">
+              Zhentan must co-sign every transaction. If its agent is ever
+              offline, your funds sit safe but wait. Adding a key later
+              takes one tap in Settings.
+            </p>
+            <div className="flex gap-2">
               <button
                 type="button"
-                onClick={() => setSkipPanel(true)}
-                className="py-1 text-xs text-muted-foreground/75 hover:text-foreground transition-colors cursor-pointer"
+                onClick={onContinue}
+                className="flex-1 py-2.5 rounded-xl border border-watch/35 text-watch text-xs font-semibold hover:bg-watch/10 transition-colors cursor-pointer"
               >
-                I&apos;ll add this later
+                Skip for now
               </button>
-            )}
-          </div>
+              <button
+                type="button"
+                onClick={() => setSkipPanel(false)}
+                className="flex-1 py-2.5 rounded-xl bg-gold text-ink-900 text-xs font-bold hover:bg-gold/90 transition-colors cursor-pointer"
+              >
+                Add a key
+              </button>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
 
-          <p className="text-[11px] leading-relaxed text-muted-foreground/60 text-center mt-[18px]">
-            With an override key your vault is a 2-of-3 Safe — your key, your
-            override key, the screening agent. Any two move funds, so
-            you&apos;re never locked out and Zhentan alone can never move a
-            cent.
-          </p>
-        </>
+      {externalWalletAddress && (
+        <Button onClick={handleAdd} disabled={busy || !deployed} className="w-full mt-4">
+          {busy ? (
+            <>
+              <Loader2 className="w-4 h-4 animate-spin" />
+              Adding your key...
+            </>
+          ) : !deployed ? (
+            "Preparing your vault..."
+          ) : (
+            <>
+              Add key & upgrade
+              <ArrowRight className="w-4 h-4" />
+            </>
+          )}
+        </Button>
       )}
+
+      <div className="flex items-center justify-center mt-3">
+        {!externalWalletAddress && !skipPanel && (
+          <button
+            type="button"
+            onClick={() => setSkipPanel(true)}
+            className="py-1 text-xs text-muted-foreground/75 hover:text-foreground transition-colors cursor-pointer"
+          >
+            I&apos;ll add this later
+          </button>
+        )}
+      </div>
+
+      <p className="text-[11px] leading-relaxed text-muted-foreground/60 text-center mt-[18px]">
+        With an override key your vault is a 2-of-3 Safe — your key, your
+        override key, the screening agent. Any two move funds, so
+        you&apos;re never locked out and Zhentan alone can never move a
+        cent.
+      </p>
     </motion.div>
   );
 }
@@ -1022,17 +946,34 @@ function OnboardingContent() {
     setStep(2);
   };
 
+  const handleBackupDone = () => {
+    if (!wallet?.address) return;
+    markOnboardingBackupDone(wallet.address);
+    setStep(3);
+  };
+
+  // The backup step is the guarded→protected upgrade — only guarded wallets
+  // have it; starter (no agent) and already-protected resumes skip through.
+  const resolvedProfile = safeConfig?.profile ?? null;
+  useEffect(() => {
+    if (step !== 2 || !stepReady || !wallet?.address) return;
+    if (resolvedProfile && resolvedProfile !== "guarded") {
+      markOnboardingBackupDone(wallet.address);
+      setStep(3);
+    }
+  }, [step, stepReady, resolvedProfile, wallet?.address]);
+
   const handleSaveUsername = async (username: string) => {
     if (!safeAddress || !wallet?.address) throw new Error("Wallet not ready");
     await api.users.upsert({ safeAddress, username });
     markOnboardingUsernameSet(wallet.address);
-    setStep(3);
+    setStep(4);
   };
 
   const handleSkipUsername = () => {
     if (!wallet?.address) return;
     markOnboardingUsernameSkipped(wallet.address);
-    setStep(3);
+    setStep(4);
   };
 
   const handleFinish = async () => {
@@ -1098,13 +1039,16 @@ function OnboardingContent() {
         <AnimatePresence mode="wait">
           {step === 0 && <ProtectionStep onContinue={handleBackupKeyDone} />}
           {step === 1 && safeAddress && <ConnectStep onFinish={handleTelegramDone} />}
-          {step === 2 && safeAddress && (
+          {step === 2 && safeAddress && resolvedProfile === "guarded" && (
+            <BackupStep onContinue={handleBackupDone} />
+          )}
+          {step === 3 && safeAddress && (
             <UsernameStep
               onSave={handleSaveUsername}
               onSkip={handleSkipUsername}
             />
           )}
-          {(step === 1 || step === 2) && !safeAddress && (
+          {(step === 1 || step === 2 || step === 3) && !safeAddress && (
             /* Resumed session still resolving the Safe — a visible wait state,
                not a blank card (the step-0 fallback effect handles the
                genuinely-missing case). */
@@ -1118,7 +1062,7 @@ function OnboardingContent() {
               <p className="text-xs text-muted-foreground">Preparing your vault…</p>
             </motion.div>
           )}
-          {step === 3 && (
+          {step === 4 && (
             <DoneStep
               screeningOn={(safeConfig?.profile ?? pendingProfile) !== "starter"}
               backupSet={!!externalWalletAddress}

--- a/client/src/app/onboarding/page.tsx
+++ b/client/src/app/onboarding/page.tsx
@@ -74,6 +74,27 @@ function Tick({ selected }: { selected: boolean }) {
   );
 }
 
+/** Repeated Safe-resolution failures (#136.4): stop pretending "Creating your
+ *  vault..." is progress — say so, keep auto-retrying, offer a manual kick. */
+function ResolutionErrorNote({ onRetry }: { onRetry: () => void }) {
+  return (
+    <div className="mt-3 p-3 rounded-2xl bg-danger/[0.06] border border-danger/20 flex items-start gap-2.5">
+      <AlertTriangle className="h-3.5 w-3.5 text-danger shrink-0 mt-0.5" />
+      <p className="flex-1 text-[11.5px] leading-relaxed text-danger/90">
+        Can&apos;t reach Zhentan right now — retrying automatically. Your
+        wallet isn&apos;t affected.
+      </p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="shrink-0 text-[11.5px] font-semibold text-danger hover:opacity-80 transition-opacity cursor-pointer"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}
+
 const optionClass = (selected: boolean) =>
   clsx(
     "w-full text-left p-[15px] rounded-[18px] cursor-pointer transition-all duration-200 border",
@@ -114,7 +135,9 @@ function ProtectionStep({ onContinue }: { onContinue: () => void }) {
     setPendingProfile,
     safeAddress,
     safeLoading,
+    safeError,
     safeConfig,
+    refreshSafe,
   } = useAuth();
 
   // Two screens: "protect" (screening choice) then "backup" (override key).
@@ -270,6 +293,7 @@ function ProtectionStep({ onContinue }: { onContinue: () => void }) {
           </div>
 
           <PrimaryCta cta={protectCta} />
+          {safeError && <ResolutionErrorNote onRetry={refreshSafe} />}
           {starterSelected && (
             <p className="text-[11px] leading-relaxed text-muted-foreground/60 text-center mt-3">
               Your vault address is minted on creation — adding protection
@@ -459,6 +483,7 @@ function ProtectionStep({ onContinue }: { onContinue: () => void }) {
           </AnimatePresence>
 
           <PrimaryCta cta={backupCta} />
+          {safeError && <ResolutionErrorNote onRetry={refreshSafe} />}
 
           {/* Finality note: the CTA below mints the address / locks the key */}
           {(cand.candidate || externalWalletAddress || skipped) && (
@@ -635,18 +660,16 @@ function UsernameStep({
 
 /* ─── Step 3: Telegram alerts ────────────────────────────────────── */
 
-function ConnectStep({
-  onFinish,
-  onSkip,
-}: {
-  onFinish: () => void;
-  onSkip: () => void;
-}) {
+function ConnectStep({ onFinish }: { onFinish: () => void }) {
   // One step (#134): open the bot chat, say hi, tap the secure link it sends
   // back. The step watches the server-truth binding the whole time it is on
   // screen, so a link completed from ANY device is picked up — the tap below
   // is a pure open-the-chat link.
   const { linked, identity, unlinking, openBot, setWatching, unlink } = useTelegramLink();
+  // Guarded creations keep screening structurally ON (#136.1) — skipping
+  // Telegram means reviews reach email + dashboard only. Say so at the skip.
+  const { safeConfig, pendingProfile } = useAuth();
+  const guardedCreation = (safeConfig?.profile ?? pendingProfile) === "guarded";
   const photoUrl = useTelegramPhoto({ enabled: linked });
   const [opened, setOpened] = useState(false);
   // Cross-device path (RFC 8628): type the bot's short code right here.
@@ -771,17 +794,16 @@ function ConnectStep({
           </button>
         ))}
 
-      <Button onClick={onFinish} className="w-full mt-4">
-        Continue
+      {!linked && guardedCreation && (
+        <p className="text-[11px] leading-relaxed text-watch/90 text-center mt-3.5">
+          Screening stays on either way — without Telegram, review alerts
+          reach your email and dashboard only.
+        </p>
+      )}
+      <Button onClick={onFinish} className={clsx("w-full", linked || guardedCreation ? "mt-3.5" : "mt-4")}>
+        {linked ? "Continue" : "Continue without Telegram"}
         <ArrowRight className="w-4 h-4" />
       </Button>
-      <button
-        type="button"
-        onClick={onSkip}
-        className="w-full mt-2.5 py-1.5 text-xs text-muted-foreground/70 hover:text-foreground transition-colors cursor-pointer"
-      >
-        Skip for now
-      </button>
     </motion.div>
   );
 }
@@ -960,8 +982,6 @@ function OnboardingContent() {
 
   const handleTelegramDone = () => setStep(3);
 
-  const handleSkipTelegram = () => setStep(3);
-
   const handleFinish = async () => {
     if (!safeAddress || !wallet?.address) return;
     // Persist on the server first — we want onboarding_completed set even if the
@@ -1030,11 +1050,20 @@ function OnboardingContent() {
               onSkip={handleSkipUsername}
             />
           )}
-          {step === 2 && safeAddress && (
-            <ConnectStep
-              onFinish={handleTelegramDone}
-              onSkip={handleSkipTelegram}
-            />
+          {step === 2 && safeAddress && <ConnectStep onFinish={handleTelegramDone} />}
+          {step === 2 && !safeAddress && (
+            /* Resumed session still resolving the Safe — a visible wait state,
+               not a blank card (the step-0 fallback effect handles the
+               genuinely-missing case). */
+            <motion.div
+              key="connect-loading"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              className="flex flex-col items-center gap-3 py-10"
+            >
+              <MaoAvatar state="thinking" size={44} />
+              <p className="text-xs text-muted-foreground">Preparing your vault…</p>
+            </motion.div>
           )}
           {step === 3 && (
             <DoneStep

--- a/client/src/components/ActivationDialog.tsx
+++ b/client/src/components/ActivationDialog.tsx
@@ -2,11 +2,10 @@
 
 import { useEffect, useRef, useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { ExternalLink, Loader2, XIcon } from "lucide-react";
+import { Loader2, XIcon } from "lucide-react";
 import { Dialog } from "./ui/Dialog";
-import { TELEGRAM_BOT_USERNAME } from "@/lib/constants";
 import { useTelegramPhoto } from "@/hooks/useTelegramPhoto";
-import { TelegramLinkFlow } from "./TelegramLinkFlow";
+import { TelegramConnectCard } from "./TelegramConnectCard";
 import { MaoAvatar } from "./MaoAvatar";
 
 /**
@@ -82,15 +81,12 @@ export function ActivationDialog({
 }: ActivationDialogProps) {
   const wasInitiallyCompleteRef = useRef(false);
   const [showSuccess, setShowSuccess] = useState(false);
-  // Cross-device path (RFC 8628): type the bot's short code right here.
-  const [showCodeEntry, setShowCodeEntry] = useState(false);
   const photoUrl = useTelegramPhoto({ enabled: open && telegramLinked });
 
   useEffect(() => {
     if (open) {
       wasInitiallyCompleteRef.current = telegramLinked;
       setShowSuccess(false);
-      setShowCodeEntry(false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
@@ -164,55 +160,7 @@ export function ActivationDialog({
                   and your chat can approve or reject reviews.
                 </p>
 
-                <div className="p-4 rounded-2xl border bg-gold/5 border-gold/20">
-                  <div className="flex items-start gap-3">
-                    <div className="relative w-11 h-11 shrink-0 flex items-center justify-center">
-                      <motion.div
-                        className="absolute inset-0 rounded-2xl border-2 border-gold/40"
-                        animate={{ scale: [1, 1.25], opacity: [0.6, 0] }}
-                        transition={{ duration: 1.4, repeat: Infinity, ease: "easeOut" }}
-                      />
-                      <div className="relative w-11 h-11 rounded-2xl bg-gold/10 flex items-center justify-center">
-                        {/* Mao is already on watch while this dialog is open —
-                            the sweep across his shades IS the listening state. */}
-                        <MaoAvatar state="scanning" size={34} variant="detail" />
-                      </div>
-                    </div>
-                    <div className="flex-1 min-w-0 flex flex-row justify-between items-start gap-3">
-                      <div className="flex flex-col gap-1">
-                        <h4 className="text-sm font-semibold text-foreground">
-                          Say hi to @{TELEGRAM_BOT_USERNAME}
-                        </h4>
-                        <div className="text-[11px] text-muted-foreground leading-relaxed max-w-56">
-                          Send any message, then tap the secure link the bot
-                          replies with — this connects the moment you do.
-                        </div>
-                      </div>
-                      <button
-                        onClick={onOpenBot}
-                        className="px-3 py-1.5 text-[11px] font-medium rounded-lg bg-gold/10 text-gold hover:bg-gold/15 transition-all cursor-pointer inline-flex items-center gap-1.5 shrink-0"
-                      >
-                        <ExternalLink className="h-3 w-3" />
-                        Open bot
-                      </button>
-                    </div>
-                  </div>
-                </div>
-
-                {showCodeEntry ? (
-                  <div className="p-4 rounded-2xl border bg-foreground/2 border-foreground/6">
-                    <TelegramLinkFlow variant="embedded" />
-                  </div>
-                ) : (
-                  <button
-                    type="button"
-                    onClick={() => setShowCodeEntry(true)}
-                    className="w-full text-[11px] text-muted-foreground/80 hover:text-gold leading-relaxed text-center pt-1 transition-colors cursor-pointer"
-                  >
-                    Got a code from Telegram?{" "}
-                    <span className="text-gold/90">Enter the short code here →</span>
-                  </button>
-                )}
+                <TelegramConnectCard onOpenBot={onOpenBot} />
               </>
             )}
           </motion.div>

--- a/client/src/components/AuthGuard.tsx
+++ b/client/src/components/AuthGuard.tsx
@@ -8,7 +8,8 @@ import { useOnboarding } from "@/lib/useOnboarding";
 import { useScreeningStatus } from "@/app/context/ScreeningStatusContext";
 
 export function AuthGuard({ children }: { children: React.ReactNode }) {
-  const { user, wallet, loading, safeAddress, safeLoading, recordOnboardingCompleted } = useAuth();
+  const { user, wallet, loading, safeAddress, safeLoading, safeError, recordOnboardingCompleted } =
+    useAuth();
   const { telegramLinked } = useScreeningStatus();
   const pathname = usePathname();
   const router = useRouter();
@@ -37,7 +38,15 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
   }, [loading, user, wallet, safeLoading, onboardingLoading, complete, skipOnboardingCheck, router]);
 
   if (loading || (!skipOnboardingCheck && (safeLoading || onboardingLoading))) {
-    return (
+    // Repeated resolution failures (#136.4): say so instead of pretending
+    // this is a normal load. Retries keep running underneath.
+    return safeError ? (
+      <ThemeLoader
+        variant="auth"
+        message="Can't reach Zhentan"
+        subtext="Connection trouble — retrying automatically"
+      />
+    ) : (
       <ThemeLoader
         variant="auth"
         message="Loading Zhentan"

--- a/client/src/components/BalanceCard.tsx
+++ b/client/src/components/BalanceCard.tsx
@@ -73,9 +73,9 @@ export function BalanceCard({
 
   const greeting = name?.trim() ? `gm, ${name.trim()}` : "gm";
 
-  const actions: { label: string; icon: LucideIcon; onClick: () => void; active: boolean }[] = [
+  const actions: { label: string; icon: LucideIcon; onClick: () => void; active: boolean; tour?: string }[] = [
     { label: "Send", icon: ArrowUpRight, onClick: onToggleSend, active: sendOpen },
-    { label: "Receive", icon: ArrowDownLeft, onClick: onToggleReceive, active: receiveOpen },
+    { label: "Receive", icon: ArrowDownLeft, onClick: onToggleReceive, active: receiveOpen, tour: "receive" },
     ...(onToggleSwap
       ? [{ label: "Swap", icon: ArrowLeftRight, onClick: onToggleSwap, active: !!swapOpen }]
       : []),
@@ -131,6 +131,21 @@ export function BalanceCard({
           </motion.div>
         )}
 
+        {!loading && (portfolioTotalUsd ?? 0) === 0 && (
+          /* Fresh vault (#136.7): the one moment the page should say HOW to
+             fund it — Receive holds the address + QR. */
+          <motion.button
+            type="button"
+            onClick={onToggleReceive}
+            className="mt-3.5 flex items-center gap-2 font-mono text-xs text-gold/90 hover:text-gold transition-colors cursor-pointer"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ delay: 0.25 }}
+          >
+            <ArrowDownLeft className="h-3.5 w-3.5" />
+            Fund your vault — tap Receive for your deposit address
+          </motion.button>
+        )}
         {hasDelta && (
           <motion.div
             className="mt-3.5 flex items-center gap-3 font-mono text-xs"
@@ -159,6 +174,7 @@ export function BalanceCard({
           <button
             key={action.label}
             type="button"
+            data-tour={action.tour}
             onClick={action.onClick}
             className={clsx(
               "group flex flex-col items-center gap-2.5 py-4 px-2 transition-colors touch-manipulation cursor-pointer",

--- a/client/src/components/RightRail.tsx
+++ b/client/src/components/RightRail.tsx
@@ -263,7 +263,12 @@ function PendingCard({
 /* ── Rail ────────────────────────────────────────────────────────── */
 
 export function RightRail() {
-  const { isScreeningActive } = useScreeningStatus();
+  const { isScreeningActive, agentOnline } = useScreeningStatus();
+  // Screening configured on but the runtime is not polling (#136.5): every
+  // screened proposal will sit queued (fail-closed). Say so — never show the
+  // green "Monitoring" dot on configuration alone. null (unknown) keeps the
+  // optimistic rendering so older servers don't read as an outage.
+  const agentOffline = isScreeningActive && agentOnline === false;
   const { requests, transactions } = useActivityData();
   const { handleApprove, handleReject, refresh } = useRequestActions();
   const [selectedTx, setSelectedTx] = useState<TransactionWithStatus | null>(null);
@@ -319,7 +324,7 @@ export function RightRail() {
       >
         <div className="flex items-center gap-3">
           <div className="relative w-10 h-10 shrink-0 flex items-center justify-center">
-            {isScreeningActive && (
+            {isScreeningActive && !agentOffline && (
               <>
                 <span className="absolute inset-0 rounded-md border border-gold/50 [animation:sonar_2.6s_ease-out_infinite]" />
                 <span className="absolute inset-0 rounded-md border border-gold/50 [animation:sonar_2.6s_ease-out_1.3s_infinite]" />
@@ -332,7 +337,7 @@ export function RightRail() {
               )}
             >
               <MaoAvatar
-                state={isScreeningActive ? "scanning" : "resting"}
+                state={isScreeningActive && !agentOffline ? "scanning" : "resting"}
                 size={24}
                 variant="solid"
               />
@@ -344,25 +349,31 @@ export function RightRail() {
               <span
                 className={clsx(
                   "h-1.5 w-1.5 rounded-pill signal-dot",
-                  isScreeningActive
-                    ? "bg-safe animate-signal-pulse"
-                    : "bg-muted-foreground"
+                  agentOffline
+                    ? "bg-watch"
+                    : isScreeningActive
+                      ? "bg-safe animate-signal-pulse"
+                      : "bg-muted-foreground"
                 )}
               />
-              {isScreeningActive
-                ? "Monitoring · screening on"
-                : "Paused · screening off"}
+              {agentOffline
+                ? "Agent offline · screening delayed"
+                : isScreeningActive
+                  ? "Monitoring · screening on"
+                  : "Paused · screening off"}
             </p>
           </div>
           <span
             className={clsx(
               "shrink-0 font-mono uppercase tracking-wider text-[10px] font-semibold px-2.5 py-1 rounded-pill",
-              isScreeningActive
-                ? "bg-safe/10 text-safe"
-                : "bg-foreground/8 text-muted-foreground"
+              agentOffline
+                ? "bg-watch/10 text-watch"
+                : isScreeningActive
+                  ? "bg-safe/10 text-safe"
+                  : "bg-foreground/8 text-muted-foreground"
             )}
           >
-            {isScreeningActive ? "Live" : "Off"}
+            {agentOffline ? "Away" : isScreeningActive ? "Live" : "Off"}
           </span>
         </div>
       </Link>

--- a/client/src/components/SendPanel.tsx
+++ b/client/src/components/SendPanel.tsx
@@ -36,7 +36,7 @@ interface SendPanelProps {
 
 export function SendPanel({ onSuccess, onClose, onRefreshActivities, tokens, screeningMode = true }: SendPanelProps) {
   const { user, wallet, getOwnerAccount, identityToken, safeAddress, safeConfig } = useAuth();
-  const { telegramLinked } = useScreeningStatus();
+  const { telegramLinked, agentOnline } = useScreeningStatus();
   const api = useApiClient();
   const { addOptimisticTransaction, transactions } = useActivityData();
   const router = useRouter();
@@ -261,11 +261,18 @@ export function SendPanel({ onSuccess, onClose, onRefreshActivities, tokens, scr
       return;
     }
 
+    // Soft gate (#136.6): screening without Telegram still WORKS — reviews
+    // reach email and the dashboard — it's just slower. Warn once per submit
+    // attempt instead of hard-blocking the send.
     if (screeningMode && !telegramLinked) {
       setShowTgRequiredModal(true);
       return;
     }
 
+    await submitTransaction(address);
+  };
+
+  const submitTransaction = async (address: string) => {
     setLoading(true);
     setError(null);
     if (screeningMode) setSendPhase("proposing");
@@ -465,12 +472,20 @@ export function SendPanel({ onSuccess, onClose, onRefreshActivities, tokens, scr
             </dd>
           </div>
         </dl>
+        {agentOnline === false && tx.status !== "in_review" && (
+          <p className="text-xs text-watch/90 text-center leading-relaxed">
+            The screening agent is offline right now — your transaction stays
+            safely queued and screens the moment it&apos;s back.
+          </p>
+        )}
         {canCoSign && (
           <div className="space-y-2.5">
             <p className="text-xs text-muted-foreground/80 text-center">
               {tx.status === "in_review"
                 ? "Flagged for your review — signing with your backup key executes it anyway."
-                : "Zhentan is screening — signing with your backup key executes it right away."}
+                : agentOnline === false
+                  ? "No need to wait — signing with your backup key executes it right away."
+                  : "Zhentan is screening — signing with your backup key executes it right away."}
             </p>
             <CoSignButton
               tx={tx}
@@ -739,7 +754,7 @@ export function SendPanel({ onSuccess, onClose, onRefreshActivities, tokens, scr
     <Dialog
       open={showTgRequiredModal}
       onClose={() => setShowTgRequiredModal(false)}
-      title="Telegram Required"
+      title="Connect Telegram?"
       sheetOnMobile
     >
       <div className="flex flex-col items-center gap-5 py-2">
@@ -748,7 +763,9 @@ export function SendPanel({ onSuccess, onClose, onRefreshActivities, tokens, scr
         </div>
         <div className="text-center space-y-2">
           <p className="text-sm text-foreground/80 leading-relaxed">
-            AI screening is active. Telegram must be connected so the agent can notify you when a transaction needs review.
+            AI screening is on, but Telegram isn&apos;t connected — if this
+            transaction needs your review, the alert reaches you by email and
+            the dashboard only, so approving it can be slower.
           </p>
           <p className="text-xs text-muted-foreground/80">
             Say hi to{" "}
@@ -771,8 +788,21 @@ export function SendPanel({ onSuccess, onClose, onRefreshActivities, tokens, scr
             router.push("/settings");
           }}
         >
-          Go to Settings
+          Connect Telegram
         </Button>
+        <button
+          type="button"
+          onClick={() => {
+            setShowTgRequiredModal(false);
+            const address =
+              resolvedAddress ||
+              (recipient.startsWith("0x") && recipient.length === 42 ? recipient : null);
+            if (address) void submitTransaction(address);
+          }}
+          className="w-full py-2.5 rounded-2xl border border-foreground/10 text-sm text-foreground/80 hover:bg-foreground/5 transition-colors cursor-pointer"
+        >
+          Send anyway — alert me by email
+        </button>
         <button
           type="button"
           onClick={() => setShowTgRequiredModal(false)}

--- a/client/src/components/TelegramConnectCard.tsx
+++ b/client/src/components/TelegramConnectCard.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useState } from "react";
+import { motion } from "framer-motion";
+import { ExternalLink } from "lucide-react";
+import { TELEGRAM_BOT_USERNAME } from "@/lib/constants";
+import { MaoAvatar } from "./MaoAvatar";
+import { TelegramLinkFlow } from "./TelegramLinkFlow";
+
+/**
+ * The ONE Telegram connect card (#136.2) — shared by the settings
+ * ActivationDialog and the UpgradeDialog so the flow can never drift again:
+ * Mao is already listening (the parent owns the watch poll), "Open bot" is a
+ * pure t.me link with no side effects, and the RFC 8628 short-code entry is
+ * one disclosure tap away.
+ *
+ * Render it only while NOT linked; the parent renders its own connected
+ * state. The parent must also keep the binding watch running while this is
+ * on screen (useTelegramLink().setWatching).
+ */
+export function TelegramConnectCard({ onOpenBot }: { onOpenBot: () => void }) {
+  // Cross-device path (RFC 8628): type the bot's short code right here.
+  const [showCodeEntry, setShowCodeEntry] = useState(false);
+
+  return (
+    <div className="space-y-3 w-full">
+      <div className="p-4 rounded-2xl border bg-gold/5 border-gold/20">
+        <div className="flex items-start gap-3">
+          <div className="relative w-11 h-11 shrink-0 flex items-center justify-center">
+            <motion.div
+              className="absolute inset-0 rounded-2xl border-2 border-gold/40"
+              animate={{ scale: [1, 1.25], opacity: [0.6, 0] }}
+              transition={{ duration: 1.4, repeat: Infinity, ease: "easeOut" }}
+            />
+            <div className="relative w-11 h-11 rounded-2xl bg-gold/10 flex items-center justify-center">
+              {/* Mao is already on watch while this card is visible — the
+                  sweep across his shades IS the listening state. */}
+              <MaoAvatar state="scanning" size={34} variant="detail" />
+            </div>
+          </div>
+          <div className="flex-1 min-w-0 flex flex-row justify-between items-start gap-3">
+            <div className="flex flex-col gap-1">
+              <h4 className="text-sm font-semibold text-foreground">
+                Say hi to @{TELEGRAM_BOT_USERNAME}
+              </h4>
+              <div className="text-[11px] text-muted-foreground leading-relaxed max-w-56">
+                Send any message, then tap the secure link the bot replies
+                with — this connects the moment you do.
+              </div>
+            </div>
+            <button
+              onClick={onOpenBot}
+              className="px-3 py-1.5 text-[11px] font-medium rounded-lg bg-gold/10 text-gold hover:bg-gold/15 transition-all cursor-pointer inline-flex items-center gap-1.5 shrink-0"
+            >
+              <ExternalLink className="h-3 w-3" />
+              Open bot
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {showCodeEntry ? (
+        <div className="p-4 rounded-2xl border bg-foreground/2 border-foreground/6">
+          <TelegramLinkFlow variant="embedded" />
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={() => setShowCodeEntry(true)}
+          className="w-full text-[11px] text-muted-foreground/80 hover:text-gold leading-relaxed text-center pt-1 transition-colors cursor-pointer"
+        >
+          Got a code from Telegram?{" "}
+          <span className="text-gold/90">Enter the short code here →</span>
+        </button>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/TokenList.tsx
+++ b/client/src/components/TokenList.tsx
@@ -70,7 +70,7 @@ export function TokenList({ tokens, loading, embedded }: TokenListProps) {
               key={token.id}
               token={token}
               index={i}
-              onClick={token.tokenId ? () => setSelected(token) : undefined}
+              onClick={token.tokenId && !token.placeholder ? () => setSelected(token) : undefined}
             />
           ))}
         </motion.div>

--- a/client/src/components/TopBar.tsx
+++ b/client/src/components/TopBar.tsx
@@ -25,7 +25,10 @@ export const navItems: {
 
 export function TopBar() {
   const pathname = usePathname();
-  const { isScreeningActive } = useScreeningStatus();
+  const { isScreeningActive, agentOnline } = useScreeningStatus();
+  // #136.5: never show "Watching" on configuration alone — the runtime must
+  // actually be polling. null (unknown) stays optimistic.
+  const agentOffline = isScreeningActive && agentOnline === false;
   const { queuedCount } = useActivityData();
 
   return (
@@ -38,18 +41,20 @@ export function TopBar() {
             data-tour="agent-status"
             className={clsx(
               "inline-flex items-center gap-1.5 rounded-pill px-2.5 py-1.5 text-[11px] font-mono uppercase tracking-wider transition-colors",
-              isScreeningActive
-                ? "bg-safe/12 text-safe"
-                : "bg-foreground/6 text-muted-foreground"
+              agentOffline
+                ? "bg-watch/12 text-watch"
+                : isScreeningActive
+                  ? "bg-safe/12 text-safe"
+                  : "bg-foreground/6 text-muted-foreground"
             )}
           >
             <MaoAvatar
-              state={isScreeningActive ? "scanning" : "resting"}
+              state={isScreeningActive && !agentOffline ? "scanning" : "resting"}
               size={14}
               variant="solid"
               color="currentColor"
             />
-            {isScreeningActive ? "Watching" : "Paused"}
+            {agentOffline ? "Away" : isScreeningActive ? "Watching" : "Paused"}
           </div>
         </div>
       </header>

--- a/client/src/components/UpgradeBanner.tsx
+++ b/client/src/components/UpgradeBanner.tsx
@@ -31,7 +31,7 @@ export function UpgradeBanner({
   variant?: "banner" | "row";
 }) {
   const { profile } = useSafeTransitions();
-  const { refreshSafe } = useAuth();
+  const { refreshSafe, safeConfig } = useAuth();
   const [open, setOpen] = useState(false);
   // In-flight screened transition (#136.8): the dialog may be long closed
   // while the transition executes server-side — this banner is the always-
@@ -47,9 +47,20 @@ export function UpgradeBanner({
     return () => window.removeEventListener("zhentan:pending-transition", sync);
   }, []);
 
+  // Same-profile transitions (backup swap) complete only when the OWNER SET
+  // matches the expected end state — the profile never changes for them.
+  const ownersMatch = (marker: { expectedOwners?: string[] }): boolean => {
+    if (!marker.expectedOwners) return true;
+    const live = (safeConfig?.owners ?? []).map((o) => o.toLowerCase());
+    return (
+      live.length === marker.expectedOwners.length &&
+      marker.expectedOwners.every((o) => live.includes(o))
+    );
+  };
+
   useEffect(() => {
     if (!pending) return;
-    if (profile === pending.target) {
+    if (profile === pending.target && ownersMatch(pending)) {
       clearPendingTransition();
       setPending(null);
       return;
@@ -59,22 +70,25 @@ export function UpgradeBanner({
       if (!readPendingTransition()) setPending(null); // marker expired
     }, 5000);
     return () => clearInterval(t);
-  }, [pending, profile, refreshSafe]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pending, profile, safeConfig?.owners, refreshSafe]);
 
   const isStarter = profile === "starter";
   const isGuarded = profile === "guarded";
-  const upgrading = !!pending && profile !== pending.target;
+  const upgrading = !!pending && !(profile === pending.target && ownersMatch(pending));
   const showNudge = isStarter || isGuarded;
 
   // Keep the dialog mounted while it's open even after the transition upgrades
   // the profile past starter/guarded — otherwise the success step is unmounted
   // out from under the user the instant the Safe refreshes.
-  if (!showNudge && !open) return null;
+  // A pending transition renders the in-progress card for ANY profile —
+  // swap/detach start from protected, where the nudge itself never shows.
+  if (!showNudge && !open && !upgrading) return null;
 
   return (
     <>
       <AnimatePresence>
-        {showNudge && (
+        {(showNudge || upgrading) && (
           <motion.div
             initial={{ opacity: 0, y: -8 }}
             animate={{ opacity: 1, y: 0 }}

--- a/client/src/components/UpgradeBanner.tsx
+++ b/client/src/components/UpgradeBanner.tsx
@@ -1,11 +1,17 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
-import { AlertTriangle, KeyRound, ShieldCheck } from "lucide-react";
+import { AlertTriangle, KeyRound, Loader2, ShieldCheck } from "lucide-react";
 
+import { useAuth } from "@/app/context/AuthContext";
 import { useSafeTransitions } from "@/lib/useSafeUpgrade";
 import { UpgradeDialog } from "@/components/UpgradeDialog";
+import {
+  clearPendingTransition,
+  readPendingTransition,
+  type PendingTransitionMarker,
+} from "@/lib/pendingTransition";
 
 /**
  * Wallet-profile prompt that opens the upgrade wizard (UpgradeDialog):
@@ -25,10 +31,39 @@ export function UpgradeBanner({
   variant?: "banner" | "row";
 }) {
   const { profile } = useSafeTransitions();
+  const { refreshSafe } = useAuth();
   const [open, setOpen] = useState(false);
+  // In-flight screened transition (#136.8): the dialog may be long closed
+  // while the transition executes server-side — this banner is the always-
+  // mounted surface, so IT owns the record polling and the honest
+  // "in progress" state (instead of nudging to start an upgrade that is
+  // already running).
+  const [pending, setPending] = useState<PendingTransitionMarker | null>(null);
+
+  useEffect(() => {
+    const sync = () => setPending(readPendingTransition());
+    sync();
+    window.addEventListener("zhentan:pending-transition", sync);
+    return () => window.removeEventListener("zhentan:pending-transition", sync);
+  }, []);
+
+  useEffect(() => {
+    if (!pending) return;
+    if (profile === pending.target) {
+      clearPendingTransition();
+      setPending(null);
+      return;
+    }
+    const t = setInterval(() => {
+      refreshSafe();
+      if (!readPendingTransition()) setPending(null); // marker expired
+    }, 5000);
+    return () => clearInterval(t);
+  }, [pending, profile, refreshSafe]);
 
   const isStarter = profile === "starter";
   const isGuarded = profile === "guarded";
+  const upgrading = !!pending && profile !== pending.target;
   const showNudge = isStarter || isGuarded;
 
   // Keep the dialog mounted while it's open even after the transition upgrades
@@ -46,7 +81,27 @@ export function UpgradeBanner({
             exit={{ opacity: 0, height: 0 }}
             className={className}
           >
-            {variant === "row" ? (
+            {upgrading ? (
+              /* ── Transition executing server-side — not a nudge moment ── */
+              <div
+                className={
+                  variant === "row"
+                    ? "flex items-center gap-3.5 p-[18px] border-t border-border"
+                    : "rounded-xl border border-gold/25 bg-gold/[0.04] flex items-center gap-3 px-4 py-3.5"
+                }
+              >
+                <div className="w-9 h-9 rounded-xl bg-gold/10 flex items-center justify-center shrink-0">
+                  <Loader2 className="h-[17px] w-[17px] text-gold animate-spin" />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="text-[13px] font-semibold text-foreground">Upgrade in progress</p>
+                  <p className="text-[11px] text-muted-foreground mt-0.5 leading-relaxed">
+                    Your transition is signed and executing — this updates by
+                    itself in a moment.
+                  </p>
+                </div>
+              </div>
+            ) : variant === "row" ? (
               /* ── Settings Protection-card row ── */
               isGuarded ? (
                 <div className="flex items-center gap-3.5 p-[18px] border-t border-border bg-watch/5">

--- a/client/src/components/UpgradeDialog.tsx
+++ b/client/src/components/UpgradeDialog.tsx
@@ -26,11 +26,16 @@ import { useTelegramLink } from "@/hooks/useTelegramLink";
  * the user's choices and executes a SINGLE owner-management transition at the
  * end (no chained txs, so there's no stale-owner-set race between them):
  *
- *   starter  → [enable agent] → [add backup?] → [telegram] → done
+ *   starter  → [enable agent] → [telegram] → [add backup?] → done
  *              add backup  ⇒ activateProtection (starter → protected, atomic)
  *              skip backup ⇒ enableAgentOnly     (starter → guarded)
- *   guarded  → [add backup] → [telegram] → done
+ *   guarded  → [telegram] → [add backup] → done
  *              add backup  ⇒ addBackup           (guarded → protected)
+ *
+ * Telegram comes RIGHT AFTER enabling the agent (#136 follow-up): it is the
+ * approval channel for the screening being turned on. Possible here (unlike
+ * onboarding, where the backup key still determines the address) because the
+ * wallet already exists — linking binds to the existing Safe.
  *
  * Renders nothing meaningful for protected/detached — the banner that opens it
  * only shows for starter/guarded.
@@ -54,6 +59,10 @@ export function UpgradeDialog({
     profile === "starter" ? "starter" : "guarded"
   );
   const [step, setStep] = useState<Step>(profile === "starter" ? "agent" : "backup");
+  // Telegram (#134/#136.2): identical semantics to onboarding and the
+  // settings ActivationDialog — the binding watch runs the whole time the
+  // step is on screen; "Open bot" is a pure link.
+  const { linked: telegramLinked, openBot, setWatching } = useTelegramLink();
   // Consent parity with onboarding (#136.8): skipping the backup key on the
   // starter flow accepts the guarded lockout trade-off — disclose it first.
   const [skipWarning, setSkipWarning] = useState(false);
@@ -64,24 +73,20 @@ export function UpgradeDialog({
     if (!open) return;
     const starter = profile === "starter";
     setFlow(starter ? "starter" : "guarded");
-    setStep(starter ? "agent" : "backup");
+    setStep(starter ? "agent" : telegramLinked ? "backup" : "telegram");
     setSkipWarning(false);
     setExpectedProfile(null);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
-  // Telegram (#134/#136.2): identical semantics to onboarding and the
-  // settings ActivationDialog — the binding watch runs the whole time the
-  // step is on screen; "Open bot" is a pure link.
-  const { linked: telegramLinked, openBot, setWatching } = useTelegramLink();
   useEffect(() => {
     if (!open || step !== "telegram") return;
     setWatching(!telegramLinked);
     return () => setWatching(false);
   }, [open, step, telegramLinked, setWatching]);
 
-  // After the transition lands: offer Telegram (both flows) unless linked.
-  const afterUpgrade = () => setStep(telegramLinked ? "done" : "telegram");
+  // Telegram was offered BEFORE the transition ran — done directly.
+  const afterUpgrade = () => setStep("done");
 
   // Screened-path transitions (#136.3) execute asynchronously: poll the
   // record until the profile flips instead of declaring success early.
@@ -135,7 +140,10 @@ export function UpgradeDialog({
             title="Enable AI screening"
             subtitle="Zhentan reviews every transaction before it executes — catching scams and mistakes. Next you can add a backup key so you always keep control."
           >
-            <Button onClick={() => setStep("backup")} className="w-full">
+            <Button
+              onClick={() => setStep(telegramLinked ? "backup" : "telegram")}
+              className="w-full"
+            >
               Enable the agent
               <ArrowRight className="ml-2 h-4 w-4" />
             </Button>
@@ -234,7 +242,7 @@ export function UpgradeDialog({
 
             {flow === "starter" && (
               <button
-                onClick={() => setStep("agent")}
+                onClick={() => setStep(telegramLinked ? "agent" : "telegram")}
                 className="w-full inline-flex items-center justify-center gap-1.5 text-xs text-muted-foreground/50 hover:text-muted-foreground py-1 transition-colors"
               >
                 <ArrowLeft className="h-3.5 w-3.5" />
@@ -272,7 +280,7 @@ export function UpgradeDialog({
             key="telegram"
             icon={<MaoAvatar state="scanning" size={30} variant="detail" />}
             title="Connect Telegram"
-            subtitle="Get notified the moment a transaction needs your review, and approve or reject from anywhere."
+            subtitle="Screening needs a way to reach you — connect Telegram to approve or reject reviews from anywhere. Skipping keeps alerts on email only."
           >
             {telegramLinked ? (
               <div className="w-full flex items-center gap-3 rounded-2xl px-4 py-3 border border-safe/25 bg-safe/6">
@@ -283,10 +291,19 @@ export function UpgradeDialog({
               <TelegramConnectCard onOpenBot={openBot} />
             )}
 
-            <Button onClick={() => setStep("done")} className="w-full">
+            <Button onClick={() => setStep("backup")} className="w-full">
               {telegramLinked ? "Continue" : "Skip for now"}
               <ArrowRight className="ml-2 h-4 w-4" />
             </Button>
+            {flow === "starter" && (
+              <button
+                onClick={() => setStep("agent")}
+                className="w-full inline-flex items-center justify-center gap-1.5 text-xs text-muted-foreground/50 hover:text-muted-foreground py-1 transition-colors"
+              >
+                <ArrowLeft className="h-3.5 w-3.5" />
+                Back
+              </button>
+            )}
           </StepShell>
         )}
 

--- a/client/src/components/UpgradeDialog.tsx
+++ b/client/src/components/UpgradeDialog.tsx
@@ -3,17 +3,19 @@
 import { useState, useEffect } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import {
+  AlertTriangle,
   ArrowLeft,
   ArrowRight,
   Check,
   KeyRound,
   Loader2,
-  MessageCircle,
   ShieldCheck,
 } from "lucide-react";
 import { Dialog } from "@/components/ui/Dialog";
 import { Button } from "@/components/ui/Button";
 import { BackupAddressPicker } from "@/components/BackupAddressPicker";
+import { MaoAvatar } from "@/components/MaoAvatar";
+import { TelegramConnectCard } from "@/components/TelegramConnectCard";
 import { useAuth } from "@/app/context/AuthContext";
 import { useSafeTransitions } from "@/lib/useSafeUpgrade";
 import { useTelegramLink } from "@/hooks/useTelegramLink";
@@ -27,13 +29,13 @@ import { useTelegramLink } from "@/hooks/useTelegramLink";
  *   starter  → [enable agent] → [add backup?] → [telegram] → done
  *              add backup  ⇒ activateProtection (starter → protected, atomic)
  *              skip backup ⇒ enableAgentOnly     (starter → guarded)
- *   guarded  → [add backup] → done
+ *   guarded  → [add backup] → [telegram] → done
  *              add backup  ⇒ addBackup           (guarded → protected)
  *
  * Renders nothing meaningful for protected/detached — the banner that opens it
  * only shows for starter/guarded.
  */
-type Step = "agent" | "backup" | "telegram" | "done";
+type Step = "agent" | "backup" | "pending" | "telegram" | "done";
 
 export function UpgradeDialog({
   open,
@@ -44,7 +46,7 @@ export function UpgradeDialog({
 }) {
   const { profile, busy, error, activateProtection, enableAgentOnly, addBackup } =
     useSafeTransitions();
-  const { externalWalletAddress, setBackupAddress } = useAuth();
+  const { externalWalletAddress, setBackupAddress, refreshSafe } = useAuth();
 
   // The flow is fixed from the profile at open time — running a transition
   // flips the live profile mid-wizard, so we must not re-derive from it.
@@ -52,48 +54,74 @@ export function UpgradeDialog({
     profile === "starter" ? "starter" : "guarded"
   );
   const [step, setStep] = useState<Step>(profile === "starter" ? "agent" : "backup");
+  // Consent parity with onboarding (#136.8): skipping the backup key on the
+  // starter flow accepts the guarded lockout trade-off — disclose it first.
+  const [skipWarning, setSkipWarning] = useState(false);
+  // The profile the running transition ends in — drives the pending step.
+  const [expectedProfile, setExpectedProfile] = useState<"guarded" | "protected" | null>(null);
 
   useEffect(() => {
     if (!open) return;
     const starter = profile === "starter";
     setFlow(starter ? "starter" : "guarded");
     setStep(starter ? "agent" : "backup");
+    setSkipWarning(false);
+    setExpectedProfile(null);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
-  // Telegram: the one-step bot-chat flow (#134) — mirrors onboarding's step.
-  const {
-    linked: telegramLinked,
-    waiting: linkingTg,
-    start: startTelegramLink,
-  } = useTelegramLink();
+  // Telegram (#134/#136.2): identical semantics to onboarding and the
+  // settings ActivationDialog — the binding watch runs the whole time the
+  // step is on screen; "Open bot" is a pure link.
+  const { linked: telegramLinked, openBot, setWatching } = useTelegramLink();
+  useEffect(() => {
+    if (!open || step !== "telegram") return;
+    setWatching(!telegramLinked);
+    return () => setWatching(false);
+  }, [open, step, telegramLinked, setWatching]);
 
-  // After the backup step's transition runs: link Telegram (starter path) if it
-  // isn't already, else finish.
-  const afterUpgrade = () =>
-    setStep(flow === "starter" && !telegramLinked ? "telegram" : "done");
+  // After the transition lands: offer Telegram (both flows) unless linked.
+  const afterUpgrade = () => setStep(telegramLinked ? "done" : "telegram");
 
-  const handleActivateWithBackup = async () => {
-    try {
-      // starter → protected (atomic) or guarded → protected
-      await (flow === "starter" ? activateProtection() : addBackup());
+  // Screened-path transitions (#136.3) execute asynchronously: poll the
+  // record until the profile flips instead of declaring success early.
+  useEffect(() => {
+    if (!open || step !== "pending" || !expectedProfile) return;
+    if (profile === expectedProfile) {
       afterUpgrade();
+      return;
+    }
+    const t = setInterval(() => refreshSafe(), 4000);
+    return () => clearInterval(t);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, step, expectedProfile, profile]);
+
+  const runTransition = async (
+    action: () => Promise<{ pending: boolean }>,
+    target: "guarded" | "protected"
+  ) => {
+    try {
+      const result = await action();
+      if (result.pending) {
+        setExpectedProfile(target);
+        setStep("pending");
+      } else {
+        afterUpgrade();
+      }
     } catch {
       /* error surfaced by the hook */
     }
   };
+
+  const handleActivateWithBackup = () =>
+    runTransition(flow === "starter" ? activateProtection : addBackup, "protected");
 
   const handleSkipBackup = async () => {
     if (flow === "guarded") {
       onClose();
       return;
     }
-    try {
-      await enableAgentOnly(); // starter → guarded
-      afterUpgrade();
-    } catch {
-      /* error surfaced by the hook */
-    }
+    await runTransition(enableAgentOnly, "guarded");
   };
 
   return (
@@ -162,9 +190,39 @@ export function UpgradeDialog({
                   </>
                 )}
               </Button>
+            ) : flow === "starter" && skipWarning ? (
+              /* Lockout disclosure — the same acknowledgment onboarding
+                 requires before creating a guarded wallet (#136.8). */
+              <div className="w-full p-[15px] rounded-2xl bg-watch/[0.06] border border-watch/18">
+                <p className="flex items-center gap-2 text-[13px] font-semibold text-watch mb-1.5">
+                  <AlertTriangle className="h-3.5 w-3.5" />
+                  Continue without a backup key?
+                </p>
+                <p className="text-xs leading-relaxed text-watch/85 mb-3">
+                  Zhentan must co-sign every transaction. If its agent is ever
+                  offline, your funds sit safe but wait. Adding a key later
+                  takes one tap in Settings.
+                </p>
+                <div className="flex gap-2">
+                  <button
+                    onClick={handleSkipBackup}
+                    disabled={busy}
+                    className="flex-1 py-2.5 rounded-xl border border-watch/35 text-watch text-xs font-semibold hover:bg-watch/10 transition-colors cursor-pointer disabled:opacity-50"
+                  >
+                    {busy ? "Enabling…" : "Enable anyway"}
+                  </button>
+                  <button
+                    onClick={() => setSkipWarning(false)}
+                    disabled={busy}
+                    className="flex-1 py-2.5 rounded-xl bg-gold text-ink-900 text-xs font-bold hover:bg-gold/90 transition-colors cursor-pointer disabled:opacity-50"
+                  >
+                    Add a key
+                  </button>
+                </div>
+              </div>
             ) : (
               <button
-                onClick={handleSkipBackup}
+                onClick={() => (flow === "starter" ? setSkipWarning(true) : onClose())}
                 disabled={busy}
                 className="w-full text-xs text-muted-foreground/60 hover:text-muted-foreground py-1.5 transition-colors disabled:opacity-50"
               >
@@ -186,52 +244,49 @@ export function UpgradeDialog({
           </StepShell>
         )}
 
-        {/* ── Step: connect Telegram (starter path) ── */}
+        {/* ── Step: transition accepted, executing asynchronously ── */}
+        {step === "pending" && (
+          <motion.div
+            key="pending"
+            initial={{ opacity: 0, scale: 0.95 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.95 }}
+            transition={{ type: "spring", bounce: 0.15 }}
+            className="flex flex-col items-center py-4"
+          >
+            <MaoAvatar state="thinking" size={64} />
+            <h3 className="mt-4 text-lg font-semibold text-foreground">Upgrading your wallet</h3>
+            <p className="text-xs text-muted-foreground mt-1.5 text-center max-w-xs leading-relaxed">
+              The transition is signed and queued — it completes automatically
+              in a moment. You can close this; your wallet updates on its own.
+            </p>
+            <Button onClick={onClose} className="mt-6 w-full max-w-xs">
+              Close
+            </Button>
+          </motion.div>
+        )}
+
+        {/* ── Step: connect Telegram — shared card (#136.2) ── */}
         {step === "telegram" && (
           <StepShell
             key="telegram"
-            icon={<MessageCircle className="w-7 h-7 text-gold" />}
+            icon={<MaoAvatar state="scanning" size={30} variant="detail" />}
             title="Connect Telegram"
             subtitle="Get notified the moment a transaction needs your review, and approve or reject from anywhere."
           >
             {telegramLinked ? (
               <div className="w-full flex items-center gap-3 rounded-2xl px-4 py-3 border border-safe/25 bg-safe/6">
-                <Check className="h-4 w-4 text-safe shrink-0" />
-                <p className="text-xs text-muted-foreground flex-1">
-                  Telegram connected
-                </p>
+                <MaoAvatar state="cleared" size={22} variant="solid" />
+                <p className="text-xs text-muted-foreground flex-1">Telegram connected</p>
               </div>
             ) : (
-              <button
-                onClick={startTelegramLink}
-                className="w-full flex items-center gap-3 rounded-2xl px-4 py-3 border border-foreground/8 bg-foreground/4 hover:bg-foreground/6 transition-all disabled:opacity-60"
-              >
-                <div className="w-8 h-8 rounded-lg bg-foreground/6 flex items-center justify-center shrink-0">
-                  {linkingTg ? (
-                    <Loader2 className="h-4 w-4 text-muted-foreground animate-spin" />
-                  ) : (
-                    <MessageCircle className="h-4 w-4 text-muted-foreground" />
-                  )}
-                </div>
-                <p className="text-sm font-semibold text-foreground flex-1 text-left">
-                  {linkingTg ? "Say hi to the bot, tap its link…" : "Open the Zhentan bot"}
-                </p>
-                <ArrowRight className="h-4 w-4 text-muted-foreground/80 shrink-0" />
-              </button>
+              <TelegramConnectCard onOpenBot={openBot} />
             )}
 
             <Button onClick={() => setStep("done")} className="w-full">
-              {telegramLinked ? "Continue" : "Done"}
+              {telegramLinked ? "Continue" : "Skip for now"}
               <ArrowRight className="ml-2 h-4 w-4" />
             </Button>
-            {!telegramLinked && (
-              <button
-                onClick={() => setStep("done")}
-                className="w-full text-xs text-muted-foreground/60 hover:text-muted-foreground py-1.5 transition-colors"
-              >
-                Skip for now
-              </button>
-            )}
           </StepShell>
         )}
 
@@ -251,7 +306,7 @@ export function UpgradeDialog({
                 transition={{ duration: 1.5, repeat: Infinity, ease: "easeOut" }}
               />
               <div className="relative w-14 h-14 rounded-full bg-safe/15 flex items-center justify-center">
-                <ShieldCheck className="h-7 w-7 text-safe" />
+                <MaoAvatar state="cleared" size={40} interactive ambient={["nod", "glint"]} />
               </div>
             </div>
             <h3 className="text-lg font-semibold text-foreground">Wallet upgraded</h3>

--- a/client/src/components/tour/TourLauncher.tsx
+++ b/client/src/components/tour/TourLauncher.tsx
@@ -23,7 +23,7 @@ import {
  * and Settings → Product tour is the on-demand replay.
  */
 export function TourLauncher() {
-  const { safeAddress } = useAuth();
+  const { safeAddress, safeConfig } = useAuth();
   const { start, active } = useTour();
   const pathname = usePathname();
   // Bumped when a flow queues a tour mid-session, so the effect re-checks.
@@ -58,12 +58,16 @@ export function TourLauncher() {
         return;
       }
       clearPendingTour();
-      start(pending === "main" ? mainTour(safeAddress) : upgradeTour(safeAddress));
+      start(
+        pending === "main"
+          ? mainTour(safeAddress, safeConfig?.profile)
+          : upgradeTour(safeAddress)
+      );
     };
     timer = setTimeout(tick, 900);
 
     return () => clearTimeout(timer);
-  }, [active, safeAddress, pathname, start, queueTick]);
+  }, [active, safeAddress, safeConfig?.profile, pathname, start, queueTick]);
 
   return null;
 }

--- a/client/src/lib/api/client.ts
+++ b/client/src/lib/api/client.ts
@@ -23,6 +23,9 @@ const BASE = (
   process.env.NEXT_PUBLIC_BACKEND_URL || "http://localhost:3001"
 ).replace(/\/$/, "");
 
+/** Public backend origin — for unauthenticated reads like GET /health. */
+export const BACKEND_BASE = BASE;
+
 async function resolveToken(token?: string | null): Promise<string | null> {
   if (token) return token;
   try {

--- a/client/src/lib/pendingTransition.ts
+++ b/client/src/lib/pendingTransition.ts
@@ -1,0 +1,58 @@
+"use client";
+
+/**
+ * Session-local marker for an in-flight wallet-profile transition (#136.8).
+ *
+ * A screened transition can outlive the propose window (runtime retries,
+ * slow RPC) and the upgrade dialog with it — the transition still executes
+ * server-side, but nothing on the client re-pulled the record, so the
+ * upgrade banner kept nudging forever. The flow that receives a
+ * `pending: true` result notes it here; UpgradeBanner (mounted on home and
+ * settings) polls the record while the marker is live and shows an honest
+ * "upgrade in progress" state instead of the nudge.
+ *
+ * sessionStorage on purpose: survives navigation, dies with the tab — a
+ * marker must never outlive the session that created the transition.
+ */
+
+const KEY = "zhentan_pending_transition";
+/** Give up watching after this long — the nudge (or reality) wins again. */
+const MAX_AGE_MS = 5 * 60_000;
+
+export interface PendingTransitionMarker {
+  /** The profile the transition ends in. */
+  target: "starter" | "guarded" | "protected" | "detached";
+  at: number;
+}
+
+export function notePendingTransition(target: PendingTransitionMarker["target"]): void {
+  try {
+    sessionStorage.setItem(KEY, JSON.stringify({ target, at: Date.now() }));
+    window.dispatchEvent(new Event("zhentan:pending-transition"));
+  } catch {
+    // no storage → the dialog's own polling remains the only watcher
+  }
+}
+
+export function readPendingTransition(): PendingTransitionMarker | null {
+  try {
+    const raw = sessionStorage.getItem(KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as PendingTransitionMarker;
+    if (!parsed?.target || Date.now() - parsed.at > MAX_AGE_MS) {
+      sessionStorage.removeItem(KEY);
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function clearPendingTransition(): void {
+  try {
+    sessionStorage.removeItem(KEY);
+  } catch {
+    // best-effort
+  }
+}

--- a/client/src/lib/pendingTransition.ts
+++ b/client/src/lib/pendingTransition.ts
@@ -22,12 +22,28 @@ const MAX_AGE_MS = 5 * 60_000;
 export interface PendingTransitionMarker {
   /** The profile the transition ends in. */
   target: "starter" | "guarded" | "protected" | "detached";
+  /**
+   * For SAME-profile transitions (backup-key swap: protected → protected),
+   * the profile alone can't tell pending from complete — completion is the
+   * owner SET matching this expected end state (lowercased).
+   */
+  expectedOwners?: string[];
   at: number;
 }
 
-export function notePendingTransition(target: PendingTransitionMarker["target"]): void {
+export function notePendingTransition(
+  target: PendingTransitionMarker["target"],
+  expectedOwners?: string[]
+): void {
   try {
-    sessionStorage.setItem(KEY, JSON.stringify({ target, at: Date.now() }));
+    sessionStorage.setItem(
+      KEY,
+      JSON.stringify({
+        target,
+        ...(expectedOwners && { expectedOwners: expectedOwners.map((o) => o.toLowerCase()) }),
+        at: Date.now(),
+      })
+    );
     window.dispatchEvent(new Event("zhentan:pending-transition"));
   } catch {
     // no storage → the dialog's own polling remains the only watcher

--- a/client/src/lib/safe/transitions.ts
+++ b/client/src/lib/safe/transitions.ts
@@ -127,7 +127,7 @@ export async function proposeTransition({
   safe: SafeProposalContext;
   getOwnerAccount: () => Promise<LocalAccount | null>;
   identityToken?: string | null;
-}): Promise<{ txHash?: string }> {
+}): Promise<{ txHash?: string; pending: boolean }> {
   const signedFields = await buildSafeTxProposal({ calls, safe, getOwnerAccount, identityToken });
 
   const txId = `tx-${crypto.randomUUID().slice(0, 8)}`;
@@ -154,5 +154,8 @@ export async function proposeTransition({
     upgraded?: boolean;
   };
   if (!res.ok) throw new Error(data.error || `${label} failed`);
-  return { txHash: data.txHash };
+  // Threshold-2 transitions route through screening server-side (#136.3):
+  // a 2xx with upgraded:false means the decision (and execution) lands
+  // asynchronously — the caller must show a pending state, not success.
+  return { txHash: data.txHash, pending: data.upgraded === false };
 }

--- a/client/src/lib/tours.ts
+++ b/client/src/lib/tours.ts
@@ -95,8 +95,14 @@ export function markTourSeen(key: string, safeAddress: string) {
 
 // ── Definitions ─────────────────────────────────────────────────────────────
 
-/** First-time walkthrough: requests → agent → settings. */
-export function mainTour(safeAddress: string): TourDefinition {
+/**
+ * First-time walkthrough: requests → agent → fund → settings. Copy is
+ * PROFILE-AWARE (#136.7): a starter wallet has no agent on it — telling its
+ * user "every signature gets screened" would be false. Default (no profile
+ * passed) keeps the screening copy for guarded/protected.
+ */
+export function mainTour(safeAddress: string, profile?: string | null): TourDefinition {
+  const starter = profile === "starter";
   return {
     key: "main",
     finishLabel: "Let's go",
@@ -105,8 +111,10 @@ export function mainTour(safeAddress: string): TourDefinition {
       {
         id: "welcome",
         brand: true,
-        title: "Meet your co-signer",
-        body: "Zhentan screens every transaction before it moves your money. Here's your wallet in thirty seconds.",
+        title: starter ? "Welcome to Zhentan" : "Meet your co-signer",
+        body: starter
+          ? "Your wallet is ready — sends relay gas-free, and AI screening is one tap away whenever you want it. Here's the thirty-second lay of the land."
+          : "Zhentan screens every transaction before it moves your money. Here's your wallet in thirty seconds.",
       },
       {
         id: "requests",
@@ -118,22 +126,36 @@ export function mainTour(safeAddress: string): TourDefinition {
         id: "agent",
         route: "/home",
         targets: ['[data-tour="agent-rail"]', '[data-tour="agent-status"]'],
-        title: "Your agent, live",
-        body: "Screening decisions and co-signs stream in here as they happen — approvals, reviews, and blocks in real time.",
-        fallbackBody:
-          "This pill is your agent's heartbeat — Watching means every signature gets screened before it executes.",
+        title: starter ? "Your agent lives here" : "Your agent, live",
+        body: starter
+          ? "This is where screening decisions will stream once you activate protection — approvals, reviews, and blocks in real time."
+          : "Screening decisions and co-signs stream in here as they happen — approvals, reviews, and blocks in real time.",
+        fallbackBody: starter
+          ? "This pill becomes your agent's heartbeat once protection is on."
+          : "This pill is your agent's heartbeat — Watching means every signature gets screened before it executes.",
+      },
+      {
+        id: "fund",
+        route: "/home",
+        targets: ['[data-tour="receive"]'],
+        title: "Fund your vault",
+        body: "Receive holds your address and QR — send BNB Chain assets there and they appear right below.",
       },
       {
         id: "settings",
         targets: ['[data-tour="nav-settings"]'],
         title: "You're always in control",
-        body: "Pause screening, manage your keys, or detach entirely — Zhentan Guard lives in Settings.",
+        body: starter
+          ? "Activate protection, add keys, claim your username — Zhentan Guard lives in Settings."
+          : "Pause screening, manage your keys, or detach entirely — Zhentan Guard lives in Settings.",
       },
       {
         id: "done",
         brand: true,
-        title: "You're guarded",
-        body: "Your agent is watching. Make your first transfer whenever you're ready.",
+        title: starter ? "You're set" : "You're guarded",
+        body: starter
+          ? "Fund your vault and make your first transfer — and turn on AI screening any time from Settings."
+          : "Your agent is watching. Make your first transfer whenever you're ready.",
       },
     ],
   };

--- a/client/src/lib/useOnboarding.ts
+++ b/client/src/lib/useOnboarding.ts
@@ -23,7 +23,7 @@ export function clearOnboardingCompleteCookie() {
 // during onboarding, but progress must persist from step 0.
 
 interface StoredState {
-  /** Current step: 0 = backup key, 1 = username, 2 = telegram, 3 = done */
+  /** Current step: 0 = wallet shape, 1 = telegram, 2 = username, 3 = done */
   step: number;
   /** Cached once confirmed by backend — avoids a round-trip on the same device */
   completed: boolean;
@@ -72,23 +72,28 @@ function patchStored(walletAddress: string, patch: Partial<StoredState>): Stored
 
 // ── Write helpers (used by onboarding page) ───────────────────────────────────
 
-/** Backup key linked → persist step 1 */
+/** Wallet shape committed → Telegram step */
 export function markOnboardingWalletLinked(walletAddress: string) {
   patchStored(walletAddress, { step: 1 });
 }
 
-/** Username skipped → persist step 2 */
-export function markOnboardingUsernameSkipped(walletAddress: string) {
-  patchStored(walletAddress, { step: 2 });
-}
-
-/** Username saved → persist step 2 */
-export function markOnboardingUsernameSet(walletAddress: string) {
-  patchStored(walletAddress, { step: 2 });
-}
-
-/** Telegram done or skipped → Done step reached, cache completed locally */
+/** Telegram done or skipped → username step */
 export function markOnboardingTelegramDone(walletAddress: string) {
+  patchStored(walletAddress, { step: 2 });
+}
+
+/** Username skipped → Done step reached, cache completed locally */
+export function markOnboardingUsernameSkipped(walletAddress: string) {
+  markOnboardingDone(walletAddress);
+}
+
+/** Username saved → Done step reached, cache completed locally */
+export function markOnboardingUsernameSet(walletAddress: string) {
+  markOnboardingDone(walletAddress);
+}
+
+/** Done step reached (also re-stamped at finish) → completed locally. */
+export function markOnboardingDone(walletAddress: string) {
   patchStored(walletAddress, { step: 3, completed: true });
   setOnboardingCompleteCookie();
 }

--- a/client/src/lib/useOnboarding.ts
+++ b/client/src/lib/useOnboarding.ts
@@ -23,7 +23,7 @@ export function clearOnboardingCompleteCookie() {
 // during onboarding, but progress must persist from step 0.
 
 interface StoredState {
-  /** Current step: 0 = wallet shape, 1 = telegram, 2 = username, 3 = done */
+  /** Current step: 0 = wallet shape, 1 = telegram, 2 = backup key, 3 = username, 4 = done */
   step: number;
   /** Cached once confirmed by backend — avoids a round-trip on the same device */
   completed: boolean;
@@ -77,9 +77,14 @@ export function markOnboardingWalletLinked(walletAddress: string) {
   patchStored(walletAddress, { step: 1 });
 }
 
-/** Telegram done or skipped → username step */
+/** Telegram done or skipped → backup-key step */
 export function markOnboardingTelegramDone(walletAddress: string) {
   patchStored(walletAddress, { step: 2 });
+}
+
+/** Backup key added or skipped (or not applicable) → username step */
+export function markOnboardingBackupDone(walletAddress: string) {
+  patchStored(walletAddress, { step: 3 });
 }
 
 /** Username skipped → Done step reached, cache completed locally */
@@ -94,14 +99,14 @@ export function markOnboardingUsernameSet(walletAddress: string) {
 
 /** Done step reached (also re-stamped at finish) → completed locally. */
 export function markOnboardingDone(walletAddress: string) {
-  patchStored(walletAddress, { step: 3, completed: true });
+  patchStored(walletAddress, { step: 4, completed: true });
   setOnboardingCompleteCookie();
 }
 
 /** Restore the persisted step for this device (0 when nothing stored). */
 export function readOnboardingStep(walletAddress: string): number {
   const s = readStored(walletAddress).step;
-  return typeof s === "number" && s >= 0 && s <= 3 ? s : 0;
+  return typeof s === "number" && s >= 0 && s <= 4 ? s : 0;
 }
 
 // ── Hook (used by AuthGuard / login page) ─────────────────────────────────────
@@ -149,7 +154,7 @@ export function useOnboarding(
     // dependency. Cache the result locally + set the cookie for the middleware
     // fast path.
     if (recordOnboardingCompleted === true) {
-      patchStored(walletAddress, { completed: true, step: 3 });
+      patchStored(walletAddress, { completed: true, step: 4 });
       setOnboardingCompleteCookie();
       setComplete(true);
       setLoading(false);
@@ -186,7 +191,7 @@ export function useOnboarding(
         const backendCompleted = data?.onboarding_completed === true;
         const naturallyComplete = !!data?.username && !!telegramLinked;
         if (backendCompleted || naturallyComplete) {
-          patchStored(walletAddress, { completed: true, step: 3 });
+          patchStored(walletAddress, { completed: true, step: 4 });
           setOnboardingCompleteCookie();
           setComplete(true);
         }

--- a/client/src/lib/useOnboarding.ts
+++ b/client/src/lib/useOnboarding.ts
@@ -23,7 +23,7 @@ export function clearOnboardingCompleteCookie() {
 // during onboarding, but progress must persist from step 0.
 
 interface StoredState {
-  /** Current step: 0 = wallet shape, 1 = telegram, 2 = backup key, 3 = username, 4 = done */
+  /** Current step: 0 = wallet shape, 1 = telegram, 2 = username, 3 = done */
   step: number;
   /** Cached once confirmed by backend — avoids a round-trip on the same device */
   completed: boolean;
@@ -77,14 +77,9 @@ export function markOnboardingWalletLinked(walletAddress: string) {
   patchStored(walletAddress, { step: 1 });
 }
 
-/** Telegram done or skipped → backup-key step */
+/** Telegram done or skipped → username step */
 export function markOnboardingTelegramDone(walletAddress: string) {
   patchStored(walletAddress, { step: 2 });
-}
-
-/** Backup key added or skipped (or not applicable) → username step */
-export function markOnboardingBackupDone(walletAddress: string) {
-  patchStored(walletAddress, { step: 3 });
 }
 
 /** Username skipped → Done step reached, cache completed locally */
@@ -99,14 +94,14 @@ export function markOnboardingUsernameSet(walletAddress: string) {
 
 /** Done step reached (also re-stamped at finish) → completed locally. */
 export function markOnboardingDone(walletAddress: string) {
-  patchStored(walletAddress, { step: 4, completed: true });
+  patchStored(walletAddress, { step: 3, completed: true });
   setOnboardingCompleteCookie();
 }
 
 /** Restore the persisted step for this device (0 when nothing stored). */
 export function readOnboardingStep(walletAddress: string): number {
   const s = readStored(walletAddress).step;
-  return typeof s === "number" && s >= 0 && s <= 4 ? s : 0;
+  return typeof s === "number" && s >= 0 && s <= 3 ? s : 0;
 }
 
 // ── Hook (used by AuthGuard / login page) ─────────────────────────────────────
@@ -154,7 +149,7 @@ export function useOnboarding(
     // dependency. Cache the result locally + set the cookie for the middleware
     // fast path.
     if (recordOnboardingCompleted === true) {
-      patchStored(walletAddress, { completed: true, step: 4 });
+      patchStored(walletAddress, { completed: true, step: 3 });
       setOnboardingCompleteCookie();
       setComplete(true);
       setLoading(false);
@@ -191,7 +186,7 @@ export function useOnboarding(
         const backendCompleted = data?.onboarding_completed === true;
         const naturallyComplete = !!data?.username && !!telegramLinked;
         if (backendCompleted || naturallyComplete) {
-          patchStored(walletAddress, { completed: true, step: 4 });
+          patchStored(walletAddress, { completed: true, step: 3 });
           setOnboardingCompleteCookie();
           setComplete(true);
         }

--- a/client/src/lib/useSafeAddress.ts
+++ b/client/src/lib/useSafeAddress.ts
@@ -26,6 +26,12 @@ const cache = new Map<string, DerivedEntry>();
 export interface SafeResolution {
   safeAddress: string | null;
   loading: boolean;
+  /**
+   * Set after several CONSECUTIVE resolution failures (#136.4) — the backend
+   * is unreachable or erroring. Retries continue regardless; surfaces so the
+   * UI can say so instead of spinning forever. Cleared on the next success.
+   */
+  error: string | null;
   /** Backend user record when the address came from the DB (legacy + returning users). */
   record: UserDetails | null;
   /** True when the address was freshly derived (new user, no backend record yet). */
@@ -75,6 +81,7 @@ export function useSafeAddress({
   const [state, setState] = useState<SafeResolution>({
     safeAddress: null,
     loading: true,
+    error: null,
     record: null,
     derived: false,
     derivationVersion: null,
@@ -82,6 +89,10 @@ export function useSafeAddress({
     derivedThreshold: null,
   });
   const computingRef = useRef<string | null>(null);
+  // Consecutive resolution failures — 3+ (~12s of 4s retries) surfaces
+  // `error` so gates can stop pretending this is a normal load (#136.4).
+  const failuresRef = useRef(0);
+  const FAILURE_THRESHOLD = 3;
   // Bumped to re-run the effect after a failed backend lookup (kept in
   // loading state) so a transient blip doesn't strand the user on a spinner.
   const [retry, setRetry] = useState(0);
@@ -91,6 +102,7 @@ export function useSafeAddress({
       setState({
         safeAddress: null,
         loading: false,
+        error: null,
         record: null,
         derived: false,
         derivationVersion: null,
@@ -125,6 +137,7 @@ export function useSafeAddress({
             : {
                 safeAddress: cachedRecord.safe_address,
                 loading: false,
+                error: null,
                 record: cachedRecord,
                 derived: false,
                 derivationVersion: cachedRecord.derivation_version ?? null,
@@ -161,6 +174,10 @@ export function useSafeAddress({
       const empty = (loading: boolean): SafeResolution => ({
         safeAddress: null,
         loading,
+        error:
+          loading && failuresRef.current >= FAILURE_THRESHOLD
+            ? "Can't reach Zhentan right now"
+            : null,
         record: null,
         derived: false,
         derivationVersion: null,
@@ -179,6 +196,7 @@ export function useSafeAddress({
         // Transient backend failure: keep loading rather than mis-deriving,
         // and retry shortly.
         console.error(`Safe address backend lookup failed: ${res.status}`);
+        failuresRef.current += 1;
         scheduleRetry();
         return empty(true);
       }
@@ -186,9 +204,11 @@ export function useSafeAddress({
       if (data.user?.safe_address) {
         // Refresh the local identity cache so the next boot hydrates instantly.
         if (privyUserId) writeIdentityCache(privyUserId, embeddedAddress, data.user);
+        failuresRef.current = 0;
         return {
           safeAddress: data.user.safe_address,
           loading: false,
+          error: null,
           record: data.user,
           derived: false,
           derivationVersion: data.user.derivation_version ?? null,
@@ -204,15 +224,18 @@ export function useSafeAddress({
       // 2. New user: server-side derivation with the chosen creation profile.
       //    The protected profile also needs the backup key address.
       if (!profile || (profile === "protected" && !externalAddress)) {
+        failuresRef.current = 0;
         return empty(false);
       }
 
       const cacheKey = `${profile}|${embeddedAddress}|${externalAddress ?? ""}`.toLowerCase();
       const cached = cache.get(cacheKey);
       if (cached) {
+        failuresRef.current = 0;
         return {
           safeAddress: cached.safeAddress,
           loading: false,
+          error: null,
           record: null,
           derived: true,
           derivationVersion: cached.derivationVersion,
@@ -236,6 +259,7 @@ export function useSafeAddress({
           "Safe derivation failed:",
           (err as { error?: string }).error ?? deriveRes.status
         );
+        failuresRef.current += 1;
         scheduleRetry();
         return empty(true);
       }
@@ -246,9 +270,11 @@ export function useSafeAddress({
         derivationVersion: number;
       };
       cache.set(cacheKey, derivedData);
+      failuresRef.current = 0;
       return {
         safeAddress: derivedData.safeAddress,
         loading: false,
+        error: null,
         record: null,
         derived: true,
         derivationVersion: derivedData.derivationVersion,
@@ -272,8 +298,11 @@ export function useSafeAddress({
         // (Background refreshes keep their last-known-good state instead.)
         console.error("Failed to resolve Safe address:", err);
         if (!cancelled) {
+          failuresRef.current += 1;
+          const error =
+            failuresRef.current >= FAILURE_THRESHOLD ? "Can't reach Zhentan right now" : null;
           setState((s) =>
-            isBackgroundRefresh(s) ? s : { ...s, safeAddress: null, loading: true }
+            isBackgroundRefresh(s) ? s : { ...s, safeAddress: null, loading: true, error }
           );
           scheduleRetry();
         }

--- a/client/src/lib/useSafeUpgrade.ts
+++ b/client/src/lib/useSafeUpgrade.ts
@@ -184,7 +184,16 @@ export function useSafeTransitions(): SafeTransitionsState {
             newBackup as Address
           )
         );
-        if (result.pending) notePendingTransition("protected");
+        if (result.pending) {
+          // Same-profile transition: completion = the owner set with the OLD
+          // backup replaced by the new one (profile stays protected).
+          notePendingTransition(
+            "protected",
+            safeConfig.owners.map((o) =>
+              o.toLowerCase() === oldBackup.toLowerCase() ? newBackup : o
+            )
+          );
+        }
         return result;
       } catch (err) {
         await api.users

--- a/client/src/lib/useSafeUpgrade.ts
+++ b/client/src/lib/useSafeUpgrade.ts
@@ -16,25 +16,30 @@ import {
 import type { WalletState } from "@/lib/safe/profiles";
 import { queueTour } from "@/lib/tours";
 
+/**
+ * `pending: true` means the transition was ACCEPTED but executes
+ * asynchronously (screened path, #136.3) — the wallet is not upgraded yet;
+ * callers must show a pending state and wait for the profile to flip.
+ */
+export interface TransitionResult {
+  pending: boolean;
+}
+
 export interface SafeTransitionsState {
   /** Current wallet state (starter/guarded/protected/detached/unknown). */
   profile: WalletState | null;
-  /** Guarded wallets are nudged to add the backup key. */
-  needsUpgrade: boolean;
-  /** Backup key chosen/registered (prerequisite for protection transitions). */
-  backupKeyLinked: boolean;
   busy: boolean;
   error: string | null;
   /** starter → protected (backup + agent, atomic). */
-  activateProtection: () => Promise<void>;
+  activateProtection: () => Promise<TransitionResult>;
   /** starter → guarded (agent only — screening becomes mandatory). */
-  enableAgentOnly: () => Promise<void>;
+  enableAgentOnly: () => Promise<TransitionResult>;
   /** guarded → protected (add backup key; the legacy upgrade). */
-  addBackup: () => Promise<void>;
+  addBackup: () => Promise<TransitionResult>;
   /** Replace the backup key with a new one (profile stays protected). */
-  swapBackup: (newBackup: string) => Promise<void>;
+  swapBackup: (newBackup: string) => Promise<TransitionResult>;
   /** protected → detached (remove the agent — the exit). */
-  detach: () => Promise<void>;
+  detach: () => Promise<TransitionResult>;
 }
 
 /**
@@ -59,16 +64,14 @@ export function useSafeTransitions(): SafeTransitionsState {
 
   const agentAddress = process.env.NEXT_PUBLIC_AGENT_ADDRESS;
   const profile = safeConfig?.profile ?? null;
-  const needsUpgrade = profile === "guarded";
-  const backupKeyLinked = !!externalWalletAddress;
 
   const run = useCallback(
     async (
       label: string,
       buildCalls: () => ReturnType<typeof activateProtectionCalls>,
       opts?: { registerBackup?: boolean }
-    ) => {
-      if (!safeAddress || !safeConfig) return;
+    ): Promise<TransitionResult> => {
+      if (!safeAddress || !safeConfig) return { pending: false };
       setBusy(true);
       setError(null);
       try {
@@ -78,7 +81,7 @@ export function useSafeTransitions(): SafeTransitionsState {
           // against it.
           await api.users.upsert({ safeAddress, externalWalletAddress });
         }
-        await proposeTransition({
+        const result = await proposeTransition({
           calls: buildCalls(),
           label,
           safe: {
@@ -91,6 +94,7 @@ export function useSafeTransitions(): SafeTransitionsState {
         });
         // Server persisted the new on-chain owner set — re-pull the record.
         refreshSafe();
+        return { pending: result.pending };
       } catch (err) {
         setError(err instanceof Error ? err.message : `${label} failed`);
         throw err;
@@ -101,12 +105,12 @@ export function useSafeTransitions(): SafeTransitionsState {
     [safeAddress, safeConfig, externalWalletAddress, api, getOwnerAccount, identityToken, refreshSafe]
   );
 
-  const activateProtection = useCallback(async () => {
+  const activateProtection = useCallback(async (): Promise<TransitionResult> => {
     if (!agentAddress || !externalWalletAddress || !safeAddress) {
       setError("Add a backup key first");
-      return;
+      return { pending: false };
     }
-    await run(
+    const result = await run(
       "Activate protection",
       () =>
         activateProtectionCalls(
@@ -119,21 +123,22 @@ export function useSafeTransitions(): SafeTransitionsState {
     // Wallet just became protected — queue the settings walkthrough
     // (TourLauncher waits for the wizard's success dialog to close).
     queueTour("upgrade");
+    return result;
   }, [run, safeAddress, externalWalletAddress, agentAddress]);
 
-  const enableAgentOnly = useCallback(async () => {
-    if (!agentAddress || !safeAddress) return;
-    await run("Enable Zhentan agent", () =>
+  const enableAgentOnly = useCallback(async (): Promise<TransitionResult> => {
+    if (!agentAddress || !safeAddress) return { pending: false };
+    return run("Enable Zhentan agent", () =>
       enableAgentCalls(safeAddress as Address, agentAddress as Address)
     );
   }, [run, safeAddress, agentAddress]);
 
-  const addBackup = useCallback(async () => {
+  const addBackup = useCallback(async (): Promise<TransitionResult> => {
     if (!externalWalletAddress || !safeAddress) {
       setError("Add a backup key first");
-      return;
+      return { pending: false };
     }
-    await run(
+    const result = await run(
       "Add backup key",
       () => addBackupCalls(safeAddress as Address, externalWalletAddress as Address),
       { registerBackup: true }
@@ -141,11 +146,12 @@ export function useSafeTransitions(): SafeTransitionsState {
     // Wallet just became protected — queue the settings walkthrough
     // (this is the legacy upgrade path as well as the v2 add-backup).
     queueTour("upgrade");
+    return result;
   }, [run, safeAddress, externalWalletAddress]);
 
   const swapBackup = useCallback(
-    async (newBackup: string) => {
-      if (!safeAddress || !safeConfig || !agentAddress) return;
+    async (newBackup: string): Promise<TransitionResult> => {
+      if (!safeAddress || !safeConfig || !agentAddress) return { pending: false };
       const agent = agentAddress.toLowerCase();
       const signer = wallet?.address?.toLowerCase() ?? "";
       // The backup slot is the user owner that is neither agent nor signer.
@@ -165,7 +171,7 @@ export function useSafeTransitions(): SafeTransitionsState {
       // record can't drift from the on-chain owner set.
       await api.users.upsert({ safeAddress, externalWalletAddress: newBackup });
       try {
-        await run("Change backup key", () =>
+        return await run("Change backup key", () =>
           swapBackupCalls(
             safeAddress as Address,
             safeConfig.owners,
@@ -183,17 +189,15 @@ export function useSafeTransitions(): SafeTransitionsState {
     [run, safeAddress, safeConfig, agentAddress, wallet?.address, api]
   );
 
-  const detach = useCallback(async () => {
-    if (!agentAddress || !safeAddress || !safeConfig) return;
-    await run("Detach Zhentan", () =>
+  const detach = useCallback(async (): Promise<TransitionResult> => {
+    if (!agentAddress || !safeAddress || !safeConfig) return { pending: false };
+    return run("Detach Zhentan", () =>
       detachAgentCalls(safeAddress as Address, safeConfig.owners, agentAddress as Address)
     );
   }, [run, safeAddress, safeConfig, agentAddress]);
 
   return {
     profile,
-    needsUpgrade,
-    backupKeyLinked,
     busy,
     error,
     activateProtection,

--- a/client/src/lib/useSafeUpgrade.ts
+++ b/client/src/lib/useSafeUpgrade.ts
@@ -15,6 +15,7 @@ import {
 } from "@/lib/safe/transitions";
 import type { WalletState } from "@/lib/safe/profiles";
 import { queueTour } from "@/lib/tours";
+import { notePendingTransition } from "@/lib/pendingTransition";
 
 /**
  * `pending: true` means the transition was ACCEPTED but executes
@@ -120,6 +121,7 @@ export function useSafeTransitions(): SafeTransitionsState {
         ),
       { registerBackup: true }
     );
+    if (result.pending) notePendingTransition("protected");
     // Wallet just became protected — queue the settings walkthrough
     // (TourLauncher waits for the wizard's success dialog to close).
     queueTour("upgrade");
@@ -128,9 +130,11 @@ export function useSafeTransitions(): SafeTransitionsState {
 
   const enableAgentOnly = useCallback(async (): Promise<TransitionResult> => {
     if (!agentAddress || !safeAddress) return { pending: false };
-    return run("Enable Zhentan agent", () =>
+    const result = await run("Enable Zhentan agent", () =>
       enableAgentCalls(safeAddress as Address, agentAddress as Address)
     );
+    if (result.pending) notePendingTransition("guarded");
+    return result;
   }, [run, safeAddress, agentAddress]);
 
   const addBackup = useCallback(async (): Promise<TransitionResult> => {
@@ -143,6 +147,7 @@ export function useSafeTransitions(): SafeTransitionsState {
       () => addBackupCalls(safeAddress as Address, externalWalletAddress as Address),
       { registerBackup: true }
     );
+    if (result.pending) notePendingTransition("protected");
     // Wallet just became protected — queue the settings walkthrough
     // (this is the legacy upgrade path as well as the v2 add-backup).
     queueTour("upgrade");
@@ -171,7 +176,7 @@ export function useSafeTransitions(): SafeTransitionsState {
       // record can't drift from the on-chain owner set.
       await api.users.upsert({ safeAddress, externalWalletAddress: newBackup });
       try {
-        return await run("Change backup key", () =>
+        const result = await run("Change backup key", () =>
           swapBackupCalls(
             safeAddress as Address,
             safeConfig.owners,
@@ -179,6 +184,8 @@ export function useSafeTransitions(): SafeTransitionsState {
             newBackup as Address
           )
         );
+        if (result.pending) notePendingTransition("protected");
+        return result;
       } catch (err) {
         await api.users
           .upsert({ safeAddress, externalWalletAddress: oldBackup })
@@ -191,9 +198,11 @@ export function useSafeTransitions(): SafeTransitionsState {
 
   const detach = useCallback(async (): Promise<TransitionResult> => {
     if (!agentAddress || !safeAddress || !safeConfig) return { pending: false };
-    return run("Detach Zhentan", () =>
+    const result = await run("Detach Zhentan", () =>
       detachAgentCalls(safeAddress as Address, safeConfig.owners, agentAddress as Address)
     );
+    if (result.pending) notePendingTransition("detached");
+    return result;
   }, [run, safeAddress, safeConfig, agentAddress]);
 
   return {

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -176,6 +176,12 @@ export interface PatternsFile {
 
 export interface StatusResponse {
   screeningMode: boolean;
+  /** Guarded wallets: screening is structural — the toggle is locked ON. */
+  screeningLocked?: boolean;
+  /** Live wallet profile computed server-side from the mirrored owner set. */
+  profile?: "starter" | "guarded" | "protected" | "detached" | "unknown";
+  /** Runtime liveness (#136.5) — the truth behind any "agent online" surface. */
+  agent?: { online: boolean; lastSeenSecondsAgo: number | null };
   lastCheck: string | null;
   totalDecisions: number;
   telegramLinked?: boolean;

--- a/screening/src/decoded.ts
+++ b/screening/src/decoded.ts
@@ -41,6 +41,15 @@ export type DecodedKind =
       amountWei: bigint;
       infinite: boolean;
     }
-  | { kind: "config" }
+  | {
+      kind: "config";
+      /**
+       * Present when the backend validated the calls as a wallet-profile
+       * transition (validateTransitionTx: whitelisted owner-management
+       * self-calls ending in a managed state). The engine auto-approves
+       * validated transitions; unvalidated config stays review-worthy.
+       */
+      transition?: { endState: string; validated: true };
+    }
   | { kind: "dapp-call"; target: string; selector: string | null }
   | { kind: "unknown" };

--- a/screening/src/risk.ts
+++ b/screening/src/risk.ts
@@ -146,6 +146,38 @@ export function analyzeRisk(
   const today = now.toISOString().split("T")[0];
 
   // ── 0. Kind-specific scoring ──────────────────────────────
+  // Owner/config management targets the Safe ITSELF — recipient trust,
+  // amount limits, velocity and time-of-day are all meaningless for it
+  // (scoring them made every profile transition a REVIEW-40 "unknown
+  // recipient"). A transition the backend VALIDATED (whitelisted calls,
+  // managed end state) auto-approves deterministically; any other config
+  // self-call scores a fixed 40 with an honest reason and maps through the
+  // user's own thresholds.
+  if (decoded?.kind === "config") {
+    if (decoded.transition?.validated) {
+      return {
+        riskScore: 0,
+        verdict: "APPROVE",
+        reasons: [
+          `Wallet-profile transition (→ ${decoded.transition.endState}) — validated owner management on this Safe`,
+        ],
+        triggeredRules: [],
+      };
+    }
+    const configScore = 40;
+    return {
+      riskScore: configScore,
+      verdict:
+        configScore < limits.riskThresholdApprove
+          ? "APPROVE"
+          : configScore < limits.riskThresholdBlock
+            ? "REVIEW"
+            : "BLOCK",
+      reasons: ["Owner/configuration change on this Safe — not a recognized profile transition"],
+      triggeredRules: [],
+    };
+  }
+
   // Swaps and standalone approvals have no payment recipient: `tx.to` is a
   // DEX router or token contract, so recipient trust/history is skipped for
   // them (it would score the router as an "unknown recipient" and pollute

--- a/server/src/agent/agent.test.ts
+++ b/server/src/agent/agent.test.ts
@@ -114,6 +114,32 @@ describe("agent domain — Tier 1 evaluation", () => {
     expect(TX).toEqual(txCopy);
   });
 
+  it("auto-approves a VALIDATED wallet-profile transition (config self-call)", () => {
+    // Transition tx: `to` is the Safe itself — an address no pattern file
+    // knows. Without the config rule this scored REVIEW-40 "Unknown
+    // recipient" (#136.3, the stuck onboarding transitions).
+    const transitionTx = { ...TX, to: TX.safeAddress } as PendingTransaction;
+    const decoded: DecodedKind = {
+      kind: "config",
+      transition: { endState: "guarded", validated: true },
+    };
+    const result = evaluateTransaction(transitionTx, SNAPSHOT, decoded, AT);
+    expect(result.verdict).toBe("APPROVE");
+    expect(result.riskScore).toBe(0);
+    expect(result.reasons.join(" ")).toContain("guarded");
+    expect(result.reasons.join(" ")).not.toContain("Unknown recipient");
+  });
+
+  it("keeps an UNVALIDATED config self-call review-worthy, with an honest reason", () => {
+    const configTx = { ...TX, to: TX.safeAddress } as PendingTransaction;
+    const result = evaluateTransaction(configTx, SNAPSHOT, { kind: "config" }, AT);
+    // Default thresholds (40/70): fixed score 40 maps to REVIEW.
+    expect(result.verdict).toBe("REVIEW");
+    expect(result.riskScore).toBe(40);
+    expect(result.reasons.join(" ")).toContain("Owner/configuration change");
+    expect(result.reasons.join(" ")).not.toContain("Unknown recipient");
+  });
+
   it("the two shapes are distinct entry points, not aliases of caller intent", () => {
     // Same tx, same snapshot — a real transfer decode and a synthetic swap
     // decode may legitimately score differently; what matters is each is

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -31,6 +31,7 @@ import { getUserDetails } from "./lib/supabase/index.js";
 import { getLinkBySafe } from "./lib/telegram/binding.js";
 import { buildAuthRequiredEnvelope, issueLinkCode, relinkRelayText } from "./lib/telegram/linking.js";
 import { classifyTelegramCaller, telegramMetaFromBody } from "./lib/telegram/gate.js";
+import { runtimeLiveness } from "./lib/runtime/liveness.js";
 
 const app = express();
 
@@ -209,7 +210,10 @@ app.get("/me", auth, async (req, res) => {
 });
 
 app.get("/health", (_req, res) => {
-  res.json({ ok: true });
+  // `runtime` is the public liveness signal (#136.5) — the login page's
+  // agent badge and any status surface must reflect THIS, never a hardcoded
+  // "online". Boolean only; no operational detail leaks on a public route.
+  res.json({ ok: true, runtime: runtimeLiveness().online ? "online" : "offline" });
 });
 
 const port = Number(process.env.PORT) || 3001;

--- a/server/src/lib/runtime/liveness.ts
+++ b/server/src/lib/runtime/liveness.ts
@@ -1,0 +1,36 @@
+/**
+ * Runtime liveness (#136.5) — the truth behind every "agent online" claim.
+ *
+ * The runtime long-polls /runtime/lease continuously (and heartbeats leased
+ * jobs), so any authenticated Runtime API call is proof of life. The stamp
+ * is in-process state: acceptable under the documented single-process
+ * constraint (PM2 instances: 1 — the same constraint the sponsor nonce
+ * manager already relies on).
+ *
+ * No stamp yet (fresh boot) reports offline until the first poll arrives —
+ * fail-closed, matching the screening path's own posture. RUNTIME_API_TOKEN
+ * unset means no runtime can ever authenticate: permanently offline.
+ */
+
+/** A poll gap beyond this reads as offline (default poll interval is seconds). */
+const LIVENESS_WINDOW_MS = Number(process.env.RUNTIME_LIVENESS_WINDOW_MS || 90_000);
+
+let lastSeenAt: number | null = null;
+
+/** Called from authenticated Runtime API handlers. */
+export function markRuntimeSeen(): void {
+  lastSeenAt = Date.now();
+}
+
+export interface RuntimeLiveness {
+  online: boolean;
+  /** Seconds since the last authenticated runtime call; null = never seen. */
+  lastSeenSecondsAgo: number | null;
+}
+
+export function runtimeLiveness(): RuntimeLiveness {
+  if (!process.env.RUNTIME_API_TOKEN) return { online: false, lastSeenSecondsAgo: null };
+  if (lastSeenAt === null) return { online: false, lastSeenSecondsAgo: null };
+  const ago = Date.now() - lastSeenAt;
+  return { online: ago <= LIVENESS_WINDOW_MS, lastSeenSecondsAgo: Math.round(ago / 1000) };
+}

--- a/server/src/lib/runtime/screening.ts
+++ b/server/src/lib/runtime/screening.ts
@@ -16,7 +16,8 @@ import { enqueueJob } from "./jobs.js";
 import { encodeWireValue } from "./jobsPolicy.js";
 import { getTransaction } from "../supabase/index.js";
 import { loadPolicySnapshot } from "../../agent/index.js";
-import { decodeSafeTxKind } from "../safe/kind.js";
+import { decodeSafeTxKind, type DecodedKind } from "../safe/kind.js";
+import { validateTransitionTx } from "../safe/transition.js";
 import { applyScreeningDecision, sendReviewNotifications } from "../screening/apply.js";
 import type { PendingTransaction } from "../../types.js";
 
@@ -34,8 +35,20 @@ export async function enqueueScreenJob(tx: PendingTransaction): Promise<boolean>
   try {
     const evaluatedAt = new Date();
     const snapshot = await loadPolicySnapshot(tx.safeAddress ?? "");
-    const decoded =
+    let decoded: DecodedKind | undefined =
       tx.txType === "safetx" && tx.safeTx ? decodeSafeTxKind(tx.safeTx, tx.safeAddress) : undefined;
+    if (decoded?.kind === "config") {
+      // Mark VALIDATED wallet-profile transitions so the engine auto-approves
+      // them (regardless of whether the proposer sent the wire flag) instead
+      // of scoring the Safe's own address as an unknown recipient. A config
+      // self-call that fails validation stays plain config → review-worthy.
+      try {
+        const target = await validateTransitionTx(tx);
+        decoded = { kind: "config", transition: { endState: target.endState, validated: true } };
+      } catch {
+        // Not a recognized transition — leave undecorated.
+      }
+    }
     const { data: row, error } = await supabase
       .from("transactions")
       .select("version")

--- a/server/src/lib/safe/transition.ts
+++ b/server/src/lib/safe/transition.ts
@@ -1,0 +1,206 @@
+/**
+ * Wallet-profile transition validation + post-execution persistence.
+ *
+ * Extracted from routes/queue.ts so three consumers share ONE simulation:
+ *   - /queue         hard-validates flagged transitions before accepting them
+ *   - screen jobs    mark validated owner-management self-calls in the decoded
+ *                    payload, so the risk engine auto-approves them instead of
+ *                    scoring the Safe's own address as an "unknown recipient"
+ *   - apply.ts       mirrors the executed owner set for transitions that
+ *                    landed through the screened path (async decision)
+ */
+import { decodeFunctionData, isAddressEqual, type Address, type Hex } from "viem";
+import { decodeMultiSendData } from "@safe-global/protocol-kit";
+import { getUserDetails, upsertUserDetails } from "../supabase/index.js";
+import { SAFE_ABI, MULTISEND_CALL_ONLY } from "../constants.js";
+import { classifyProfile, type WalletState } from "./profiles.js";
+import { getAgentAddress } from "./relayer.js";
+import { readSafeOwners } from "./onchain.js";
+import type { PendingTransaction } from "../../types.js";
+
+export interface TransitionTarget {
+  endState: WalletState;
+  endThreshold: number;
+  endOwners: string[];
+  /** Pre-transition profile/threshold — the state the signatures must satisfy. */
+  currentState: WalletState;
+  currentThreshold: number;
+  /** Non-agent owners BEFORE the transition (legacy-capability input). */
+  userOwnerCount: number;
+  derivationVersion: number | null;
+}
+
+/**
+ * Hard validation for wallet-profile transition txs (the only thing /queue
+ * skips the risk engine for): owner-management calls on the caller's own
+ * Safe that move between MANAGED states.
+ *
+ *   starter → guarded     addOwnerWithThreshold(agent, 2)
+ *   starter → protected   MultiSend[addOwner(backup, 1), addOwner(agent, 2)]
+ *   guarded → protected   addOwnerWithThreshold(backup, 2)   (legacy upgrade)
+ *   protected → detached  removeOwner(prev, agent, 2)        (exit)
+ *   backup key swap       swapOwner(prev, oldBackup, newBackup)
+ *
+ * Every added owner must be the agent or the REGISTERED backup key; the
+ * simulated end state must classify to a managed profile (or detached, for
+ * the exit). The profile must change — except for a backup-key swap, which
+ * legitimately keeps the wallet protected while replacing an owner.
+ */
+export async function validateTransitionTx(
+  pendingTx: PendingTransaction & { calldata?: string }
+): Promise<TransitionTarget> {
+  const { safeAddress } = pendingTx;
+  // For SafeTx proposals, validate the SIGNED payload (its hash was already
+  // recomputed and signature-verified) — not the loose display fields.
+  const to =
+    pendingTx.txType === "safetx" && pendingTx.safeTx ? pendingTx.safeTx.to : pendingTx.to;
+  const calldata =
+    pendingTx.txType === "safetx" && pendingTx.safeTx
+      ? pendingTx.safeTx.data
+      : pendingTx.calldata;
+  if (!to || !calldata) throw new Error("Transition tx requires to and calldata");
+
+  const record = await getUserDetails(safeAddress);
+  if (!record) throw new Error("Unknown Safe — complete onboarding first");
+
+  const agent = getAgentAddress();
+  const currentOwners =
+    record.safe_owners?.length
+      ? record.safe_owners
+      : [record.signer_address ?? "", agent];
+  const currentThreshold = record.safe_threshold ?? 2;
+  const currentState = classifyProfile(currentOwners, currentThreshold, agent);
+
+  // Unpack the inner owner-management calls: either a single self-call, or
+  // a MultiSendCallOnly batch of self-calls.
+  let innerCalls: { to: string; data: Hex }[];
+  if (isAddressEqual(to as Address, safeAddress as Address)) {
+    innerCalls = [{ to, data: calldata as Hex }];
+  } else if (isAddressEqual(to as Address, MULTISEND_CALL_ONLY as Address)) {
+    innerCalls = decodeMultiSendData(calldata).map((t: { to: string; data: string }) => ({
+      to: t.to,
+      data: t.data as Hex,
+    }));
+  } else {
+    throw new Error("Transition tx must target the Safe itself (or MultiSend it)");
+  }
+  if (innerCalls.length === 0) throw new Error("Transition tx has no calls");
+
+  // Simulate the end state call by call.
+  const owners = currentOwners.map((o) => o.toLowerCase());
+  let threshold = currentThreshold;
+  let swapped = false;
+
+  for (const call of innerCalls) {
+    if (!isAddressEqual(call.to as Address, safeAddress as Address)) {
+      throw new Error("Every transition call must target the Safe itself");
+    }
+    const decoded = decodeFunctionData({ abi: SAFE_ABI, data: call.data });
+    if (decoded.functionName === "addOwnerWithThreshold") {
+      const [newOwner, t] = decoded.args as readonly [Address, bigint];
+      const addr = newOwner.toLowerCase();
+      const isAgent = addr === agent.toLowerCase();
+      const isRegisteredBackup =
+        !!record.external_wallet_address &&
+        addr === record.external_wallet_address.toLowerCase();
+      if (!isAgent && !isRegisteredBackup) {
+        throw new Error(
+          "Transition may only add the agent or the registered backup key as owner"
+        );
+      }
+      if (owners.includes(addr)) throw new Error(`${newOwner} is already an owner`);
+      owners.push(addr);
+      threshold = Number(t);
+    } else if (decoded.functionName === "removeOwner") {
+      const [, removed, t] = decoded.args as readonly [Address, Address, bigint];
+      const addr = removed.toLowerCase();
+      if (addr !== agent.toLowerCase()) {
+        throw new Error("Transition may only remove the agent (detach)");
+      }
+      const idx = owners.indexOf(addr);
+      if (idx === -1) throw new Error("Agent is not an owner of this Safe");
+      owners.splice(idx, 1);
+      threshold = Number(t);
+    } else if (decoded.functionName === "swapOwner") {
+      const [, oldOwner, newOwner] = decoded.args as readonly [Address, Address, Address];
+      const oldAddr = oldOwner.toLowerCase();
+      const newAddr = newOwner.toLowerCase();
+      // Only the backup slot may be swapped — never the agent, never the
+      // account signer.
+      if (oldAddr === agent.toLowerCase()) {
+        throw new Error("Transition may not swap out the agent");
+      }
+      if (record.signer_address && oldAddr === record.signer_address.toLowerCase()) {
+        throw new Error("Transition may not swap out the account signer");
+      }
+      const isRegisteredBackup =
+        !!record.external_wallet_address &&
+        newAddr === record.external_wallet_address.toLowerCase();
+      if (!isRegisteredBackup || newAddr === agent.toLowerCase()) {
+        throw new Error("Swap may only install the registered backup key as owner");
+      }
+      const idx = owners.indexOf(oldAddr);
+      if (idx === -1) throw new Error(`${oldOwner} is not an owner of this Safe`);
+      if (owners.includes(newAddr)) throw new Error(`${newOwner} is already an owner`);
+      owners[idx] = newAddr;
+      swapped = true;
+    } else {
+      throw new Error(`Unsupported transition call: ${decoded.functionName}`);
+    }
+  }
+
+  const endState = classifyProfile(owners, threshold, agent);
+  if (endState !== "starter" && endState !== "guarded" && endState !== "protected" && endState !== "detached") {
+    throw new Error(`Transition ends in an unmanaged state (${endState})`);
+  }
+  if (endState === currentState && !swapped) {
+    throw new Error("Transition does not change the wallet profile");
+  }
+  // The simulated end state IS the post-execution truth (the tx is validated
+  // hard and executed atomically) — return it so finishTransition can persist
+  // a deterministic threshold and owner set instead of racing an RPC read.
+  return {
+    endState,
+    endThreshold: threshold,
+    endOwners: owners,
+    currentState,
+    currentThreshold,
+    userOwnerCount: currentOwners.filter(
+      (o) => o.toLowerCase() !== agent.toLowerCase()
+    ).length,
+    derivationVersion: record.derivation_version ?? null,
+  };
+}
+
+/**
+ * After an executed transition: mirror the new owner set + threshold onto the
+ * record. The threshold is taken from the VALIDATED simulation, never a
+ * post-execution chain read — a load-balanced RPC (1rpc.io) can serve the
+ * post-upgrade owners from one replica and the pre-upgrade threshold from
+ * another, persisting an inconsistent state (e.g. `[embedded, agent]` with
+ * threshold 1 → classifies as "unknown", no upgrade banner). Only the owner
+ * SET is read from chain (for its correct linked-list order, which detach
+ * later relies on), retried through replica lag until it matches the profile
+ * the transition is known to produce.
+ */
+export async function finishTransition(
+  safeAddress: string,
+  target: Pick<TransitionTarget, "endThreshold" | "endOwners">
+): Promise<void> {
+  // Match the SIMULATED owner set, not just the classification — a swap keeps
+  // the profile identical before and after, so classification alone can't
+  // tell a lagging replica from the executed swap.
+  const want = new Set(target.endOwners.map((o) => o.toLowerCase()));
+  const matches = (list: string[]) =>
+    list.length === want.size && list.every((o) => want.has(o.toLowerCase()));
+  let owners = await readSafeOwners(safeAddress);
+  for (let i = 0; i < 6 && !matches(owners); i++) {
+    await new Promise((r) => setTimeout(r, 1200));
+    owners = await readSafeOwners(safeAddress);
+  }
+  await upsertUserDetails(safeAddress, {
+    safe_owners: owners,
+    safe_threshold: target.endThreshold,
+    safe_deployed: true,
+  });
+}

--- a/server/src/lib/safe/transition.ts
+++ b/server/src/lib/safe/transition.ts
@@ -193,10 +193,18 @@ export async function finishTransition(
   const want = new Set(target.endOwners.map((o) => o.toLowerCase()));
   const matches = (list: string[]) =>
     list.length === want.size && list.every((o) => want.has(o.toLowerCase()));
-  let owners = await readSafeOwners(safeAddress);
+  let owners = await readSafeOwners(safeAddress).catch(() => [] as string[]);
   for (let i = 0; i < 6 && !matches(owners); i++) {
     await new Promise((r) => setTimeout(r, 1200));
-    owners = await readSafeOwners(safeAddress);
+    owners = await readSafeOwners(safeAddress).catch(() => owners);
+  }
+  if (!matches(owners)) {
+    // Replica lag (or RPC failure) outlasted the retry window. NEVER persist
+    // a known-stale owner set — it mis-classifies the profile (a finished
+    // guarded→protected showed guarded forever). The SIMULATED set is the
+    // validated post-execution membership; only its ORDER may differ from
+    // the chain's linked list, and the next successful mirror refines that.
+    owners = target.endOwners;
   }
   await upsertUserDetails(safeAddress, {
     safe_owners: owners,

--- a/server/src/lib/screening/apply.ts
+++ b/server/src/lib/screening/apply.ts
@@ -25,6 +25,27 @@ import { notify } from "../../notifications/index.js";
 import { classifyProfile } from "../safe/profiles.js";
 import { getAgentAddress } from "../safe/relayer.js";
 import { isRejectionActive } from "../safe/rejectionState.js";
+import { decodeTxKind } from "../safe/kind.js";
+import { validateTransitionTx, finishTransition } from "../safe/transition.js";
+import type { PendingTransaction } from "../../types.js";
+
+/**
+ * A screened wallet-profile transition that auto-executes here (the async
+ * path — decision landed after the propose window) still needs its owner
+ * set + threshold mirrored onto the record, exactly like the /queue sync
+ * path does. Validation re-runs against the still-pre-transition record;
+ * anything that isn't a transition simply no-ops. Idempotent with the
+ * /queue observer's own finishTransition call.
+ */
+async function mirrorExecutedTransition(tx: PendingTransaction): Promise<void> {
+  try {
+    if (decodeTxKind(tx).kind !== "config") return;
+    const target = await validateTransitionTx(tx);
+    await finishTransition(tx.safeAddress, target);
+  } catch {
+    // Not a recognized transition, or the record already reflects it.
+  }
+}
 
 export type ApplyOutcome =
   | { status: "applied_executed"; txHash?: string }
@@ -81,6 +102,9 @@ export async function applyScreeningDecision(
       // authenticated HTTP surface (see lib/authz.ts).
       const execResult = await runExecutionById(txId);
       if (execResult.status === "executed") {
+        mirrorExecutedTransition(tx).catch((err) =>
+          console.error("Transition mirror failed (self-heals on retry):", err)
+        );
         // tx_sent notification (TG + email) is fired by execute.ts
         recordOutcome(txWithRisk, "auto_approved", {
           riskScore: risk.riskScore,

--- a/server/src/routes/queue.ts
+++ b/server/src/routes/queue.ts
@@ -1,13 +1,16 @@
 import { Router, Request, Response, type IRouter } from "express";
-import { decodeFunctionData, isAddressEqual, type Address, type Hex } from "viem";
+import { type Hex } from "viem";
 import {
   createTransaction,
   getUserDetails,
   upsertUserDetails,
 } from "../lib/supabase/index.js";
-import { SAFE_ABI, MULTISEND_CALL_ONLY } from "../lib/constants.js";
-import { decodeMultiSendData } from "@safe-global/protocol-kit";
-import { classifyProfile, type WalletState } from "../lib/safe/profiles.js";
+import { upsertUserSettings } from "../agent/index.js";
+import {
+  validateTransitionTx,
+  finishTransition,
+  type TransitionTarget,
+} from "../lib/safe/transition.js";
 import { enqueueScreenJob, awaitScreeningOutcome } from "../lib/runtime/screening.js";
 import {
   computeSafeTxHash,
@@ -27,7 +30,9 @@ import type { PendingTransaction, SafeTxData } from "../types.js";
  * recover to a non-agent owner of this Safe (otherwise /queue would be a
  * signature oracle for arbitrary payloads).
  */
-async function validateSafeTxProposal(pendingTx: PendingTransaction): Promise<void> {
+async function validateSafeTxProposal(
+  pendingTx: PendingTransaction
+): Promise<{ forcedScreening: boolean }> {
   const { safeTx, safeTxHash, safeNonce, userSignature, rejectionSignature, safeAddress } =
     pendingTx;
   if (!safeTx || !safeTxHash || safeNonce === undefined || !userSignature || !rejectionSignature) {
@@ -94,10 +99,11 @@ async function validateSafeTxProposal(pendingTx: PendingTransaction): Promise<vo
   // Service) and finishes later via in-app co-sign or the Safe app;
   // /execute refuses the row until the signatures arrive.
   //
-  // Rejected outright only when no completing signature can ever exist:
-  // guarded wallets have one user key against the threshold, so the only
-  // possible second signer is the agent — queueing would park the nonce on
-  // a transaction nothing in the world can complete.
+  // Guarded wallets have one user key against the threshold, so the only
+  // possible second signer is the agent — screening is STRUCTURAL for them
+  // (#136.1). A guarded proposal claiming screening-off is not refused (that
+  // soft-locked wallets whose stored flag drifted to false): it is FORCED
+  // through screening, and the caller self-heals the stored flag.
   //
   // EXCEPTION — legacy v1 accounts WITHOUT a backup key: pre-refactor 2-of-2
   // Safes predate this model, and their users have relied on the agent as
@@ -111,16 +117,14 @@ async function validateSafeTxProposal(pendingTx: PendingTransaction): Promise<vo
   const legacyExempt =
     derivationVersion === DERIVATION_V1_4337 &&
     userOwnerCount < pendingTx.threshold;
+  let forcedScreening = false;
   if (
     pendingTx.screeningDisabled &&
     seenSigners.size < pendingTx.threshold &&
-    !legacyExempt
+    !legacyExempt &&
+    userOwnerCount < pendingTx.threshold
   ) {
-    if (userOwnerCount < pendingTx.threshold) {
-      throw new Error(
-        "Screening cannot be disabled for this wallet — your keys alone can never meet the signing threshold. Add a backup key first."
-      );
-    }
+    forcedScreening = true;
   }
 
   const rejectionTx: SafeTxData = {
@@ -142,171 +146,7 @@ async function validateSafeTxProposal(pendingTx: PendingTransaction): Promise<vo
   if (rejectionSigner !== signer) {
     throw new Error("rejectionSignature does not recover to the proposing owner");
   }
-}
-
-/**
- * Hard validation for wallet-profile transition txs (the only thing /queue
- * skips the risk engine for): owner-management calls on the caller's own
- * Safe that move between MANAGED states.
- *
- *   starter → guarded     addOwnerWithThreshold(agent, 2)
- *   starter → protected   MultiSend[addOwner(backup, 1), addOwner(agent, 2)]
- *   guarded → protected   addOwnerWithThreshold(backup, 2)   (legacy upgrade)
- *   protected → detached  removeOwner(prev, agent, 2)        (exit)
- *   backup key swap       swapOwner(prev, oldBackup, newBackup)
- *
- * Every added owner must be the agent or the REGISTERED backup key; the
- * simulated end state must classify to a managed profile (or detached, for
- * the exit). The profile must change — except for a backup-key swap, which
- * legitimately keeps the wallet protected while replacing an owner.
- */
-async function validateTransitionTx(
-  pendingTx: PendingTransaction & { calldata?: string }
-): Promise<{ endState: WalletState; endThreshold: number; endOwners: string[] }> {
-  const { safeAddress } = pendingTx;
-  // For SafeTx proposals, validate the SIGNED payload (its hash was already
-  // recomputed and signature-verified) — not the loose display fields.
-  const to =
-    pendingTx.txType === "safetx" && pendingTx.safeTx ? pendingTx.safeTx.to : pendingTx.to;
-  const calldata =
-    pendingTx.txType === "safetx" && pendingTx.safeTx
-      ? pendingTx.safeTx.data
-      : pendingTx.calldata;
-  if (!to || !calldata) throw new Error("Transition tx requires to and calldata");
-
-  const record = await getUserDetails(safeAddress);
-  if (!record) throw new Error("Unknown Safe — complete onboarding first");
-
-  const agent = getAgentAddress();
-  const currentOwners =
-    record.safe_owners?.length
-      ? record.safe_owners
-      : [record.signer_address ?? "", agent];
-  const currentThreshold = record.safe_threshold ?? 2;
-  const currentState = classifyProfile(currentOwners, currentThreshold, agent);
-
-  // Unpack the inner owner-management calls: either a single self-call, or
-  // a MultiSendCallOnly batch of self-calls.
-  let innerCalls: { to: string; data: Hex }[];
-  if (isAddressEqual(to as Address, safeAddress as Address)) {
-    innerCalls = [{ to, data: calldata as Hex }];
-  } else if (isAddressEqual(to as Address, MULTISEND_CALL_ONLY as Address)) {
-    innerCalls = decodeMultiSendData(calldata).map((t: { to: string; data: string }) => ({
-      to: t.to,
-      data: t.data as Hex,
-    }));
-  } else {
-    throw new Error("Transition tx must target the Safe itself (or MultiSend it)");
-  }
-  if (innerCalls.length === 0) throw new Error("Transition tx has no calls");
-
-  // Simulate the end state call by call.
-  const owners = currentOwners.map((o) => o.toLowerCase());
-  let threshold = currentThreshold;
-  let swapped = false;
-
-  for (const call of innerCalls) {
-    if (!isAddressEqual(call.to as Address, safeAddress as Address)) {
-      throw new Error("Every transition call must target the Safe itself");
-    }
-    const decoded = decodeFunctionData({ abi: SAFE_ABI, data: call.data });
-    if (decoded.functionName === "addOwnerWithThreshold") {
-      const [newOwner, t] = decoded.args as readonly [Address, bigint];
-      const addr = newOwner.toLowerCase();
-      const isAgent = addr === agent.toLowerCase();
-      const isRegisteredBackup =
-        !!record.external_wallet_address &&
-        addr === record.external_wallet_address.toLowerCase();
-      if (!isAgent && !isRegisteredBackup) {
-        throw new Error(
-          "Transition may only add the agent or the registered backup key as owner"
-        );
-      }
-      if (owners.includes(addr)) throw new Error(`${newOwner} is already an owner`);
-      owners.push(addr);
-      threshold = Number(t);
-    } else if (decoded.functionName === "removeOwner") {
-      const [, removed, t] = decoded.args as readonly [Address, Address, bigint];
-      const addr = removed.toLowerCase();
-      if (addr !== agent.toLowerCase()) {
-        throw new Error("Transition may only remove the agent (detach)");
-      }
-      const idx = owners.indexOf(addr);
-      if (idx === -1) throw new Error("Agent is not an owner of this Safe");
-      owners.splice(idx, 1);
-      threshold = Number(t);
-    } else if (decoded.functionName === "swapOwner") {
-      const [, oldOwner, newOwner] = decoded.args as readonly [Address, Address, Address];
-      const oldAddr = oldOwner.toLowerCase();
-      const newAddr = newOwner.toLowerCase();
-      // Only the backup slot may be swapped — never the agent, never the
-      // account signer.
-      if (oldAddr === agent.toLowerCase()) {
-        throw new Error("Transition may not swap out the agent");
-      }
-      if (record.signer_address && oldAddr === record.signer_address.toLowerCase()) {
-        throw new Error("Transition may not swap out the account signer");
-      }
-      const isRegisteredBackup =
-        !!record.external_wallet_address &&
-        newAddr === record.external_wallet_address.toLowerCase();
-      if (!isRegisteredBackup || newAddr === agent.toLowerCase()) {
-        throw new Error("Swap may only install the registered backup key as owner");
-      }
-      const idx = owners.indexOf(oldAddr);
-      if (idx === -1) throw new Error(`${oldOwner} is not an owner of this Safe`);
-      if (owners.includes(newAddr)) throw new Error(`${newOwner} is already an owner`);
-      owners[idx] = newAddr;
-      swapped = true;
-    } else {
-      throw new Error(`Unsupported transition call: ${decoded.functionName}`);
-    }
-  }
-
-  const endState = classifyProfile(owners, threshold, agent);
-  if (endState !== "starter" && endState !== "guarded" && endState !== "protected" && endState !== "detached") {
-    throw new Error(`Transition ends in an unmanaged state (${endState})`);
-  }
-  if (endState === currentState && !swapped) {
-    throw new Error("Transition does not change the wallet profile");
-  }
-  // The simulated end state IS the post-execution truth (the tx is validated
-  // hard and executed atomically) — return it so finishTransition can persist
-  // a deterministic threshold and owner set instead of racing an RPC read.
-  return { endState, endThreshold: threshold, endOwners: owners };
-}
-
-/**
- * After an executed transition: mirror the new owner set + threshold onto the
- * record. The threshold is taken from the VALIDATED simulation, never a
- * post-execution chain read — a load-balanced RPC (1rpc.io) can serve the
- * post-upgrade owners from one replica and the pre-upgrade threshold from
- * another, persisting an inconsistent state (e.g. `[embedded, agent]` with
- * threshold 1 → classifies as "unknown", no upgrade banner). Only the owner
- * SET is read from chain (for its correct linked-list order, which detach
- * later relies on), retried through replica lag until it matches the profile
- * the transition is known to produce.
- */
-async function finishTransition(
-  safeAddress: string,
-  target: { endState: WalletState; endThreshold: number; endOwners: string[] }
-): Promise<void> {
-  // Match the SIMULATED owner set, not just the classification — a swap keeps
-  // the profile identical before and after, so classification alone can't
-  // tell a lagging replica from the executed swap.
-  const want = new Set(target.endOwners.map((o) => o.toLowerCase()));
-  const matches = (list: string[]) =>
-    list.length === want.size && list.every((o) => want.has(o.toLowerCase()));
-  let owners = await readSafeOwners(safeAddress);
-  for (let i = 0; i < 6 && !matches(owners); i++) {
-    await new Promise((r) => setTimeout(r, 1200));
-    owners = await readSafeOwners(safeAddress);
-  }
-  await upsertUserDetails(safeAddress, {
-    safe_owners: owners,
-    safe_threshold: target.endThreshold,
-    safe_deployed: true,
-  });
+  return { forcedScreening };
 }
 
 export function createQueueRouter(): IRouter {
@@ -328,18 +168,27 @@ export function createQueueRouter(): IRouter {
       const isUpgrade = pendingTx.upgrade === true || pendingTx.transition === true;
       // The transition's simulated end state (owners+threshold), captured at
       // validation and reused to persist a deterministic post-execution profile.
-      let transitionTarget:
-        | { endState: WalletState; endThreshold: number; endOwners: string[] }
-        | undefined;
+      let transitionTarget: TransitionTarget | undefined;
 
+      let forcedScreening = false;
       if (isSafeTx) {
         try {
-          await validateSafeTxProposal(pendingTx);
+          ({ forcedScreening } = await validateSafeTxProposal(pendingTx));
         } catch (err) {
           const msg = err instanceof Error ? err.message : "Invalid SafeTx proposal";
           res.status(400).json({ error: msg });
           return;
         }
+      }
+      if (forcedScreening) {
+        // Guarded wallet with a drifted screening_mode=false (#136.1): the
+        // agent is the only possible co-signer, so screening is structural.
+        // Screen the proposal instead of refusing it, and converge the stored
+        // flag so status/settings stop reporting the impossible state.
+        pendingTx.screeningDisabled = false;
+        upsertUserSettings(pendingTx.safeAddress, { screening_mode: true }).catch((err) =>
+          console.error("screening_mode self-heal failed:", err)
+        );
       }
 
       if (isUpgrade) {
@@ -405,9 +254,16 @@ export function createQueueRouter(): IRouter {
         }
       }
 
-      // ── Upgrade tx: validated hard above, skips the risk engine ─────
-      // Auto-execute through the legacy 4337 path (agent co-signs, gasless),
-      // then persist the new on-chain owner set and flip to SafeTx mode.
+      // ── Transition tx: hard-validated above ─────────────────────────
+      // Two execution routes, chosen by WHO must sign (#136.3):
+      //  - user signatures meet the current threshold (starter transitions,
+      //    co-signed proposals) or the legacy v1 capability applies → direct
+      //    synchronous execute, exactly as before (works without a runtime).
+      //  - the agent must co-sign (threshold-2 target, v2) → THROUGH
+      //    screening: the engine auto-approves the validated transition, the
+      //    decision leaves the runtime record D4 signing requires, and
+      //    auto-execute completes. The record-less direct execute would be
+      //    refused by the runtime's signing authority.
       if (isUpgrade) {
         // Set above when isUpgrade validation passed; guard for the type system.
         if (!transitionTarget) {
@@ -433,6 +289,48 @@ export function createQueueRouter(): IRouter {
         } catch {
           // Undeployed Safe (readSafeOwners reverts) or transient RPC — fall
           // through to the normal execute path.
+        }
+
+        const userSigCount = isSafeTx ? 1 + (pendingTx.userSignatures?.length ?? 0) : 0;
+        const legacyCapable =
+          (transitionTarget.derivationVersion ?? DERIVATION_V1_4337) === DERIVATION_V1_4337 &&
+          transitionTarget.userOwnerCount < transitionTarget.currentThreshold;
+        const needsAgentCosign =
+          isSafeTx && userSigCount < transitionTarget.currentThreshold && !legacyCapable;
+
+        if (needsAgentCosign) {
+          const enqueued = await enqueueScreenJob(pendingTx);
+          const outcome = enqueued ? await awaitScreeningOutcome(pendingTx.id) : null;
+          if (outcome?.kind === "executed") {
+            let upgradeWarning: string | undefined;
+            try {
+              await finishTransition(pendingTx.safeAddress, transitionTarget);
+            } catch (err) {
+              upgradeWarning = err instanceof Error ? err.message : String(err);
+              console.error("finishTransition failed (will self-heal on retry):", upgradeWarning);
+            }
+            res.json({
+              success: true,
+              id: pendingTx.id,
+              autoExecuted: true,
+              upgraded: true,
+              txHash: outcome.txHash,
+              ...(serviceWarning && { serviceWarning }),
+              ...(upgradeWarning && { upgradeWarning }),
+            });
+            return;
+          }
+          // Decision (and execution) lands asynchronously — apply.ts mirrors
+          // the owner set for validated transitions when it auto-executes.
+          // No runtime → fail-closed: the transition stays queued, upgraded:false.
+          res.json({
+            success: true,
+            id: pendingTx.id,
+            upgraded: false,
+            screening: outcome ? outcome.kind : "pending",
+            ...(serviceWarning && { serviceWarning }),
+          });
+          return;
         }
 
         try {

--- a/server/src/routes/queue.ts
+++ b/server/src/routes/queue.ts
@@ -270,18 +270,20 @@ export function createQueueRouter(): IRouter {
           res.status(500).json({ error: "Transition target unresolved" });
           return;
         }
-        // Idempotency: if a previous attempt already added the owner on-chain
-        // but the DB flip failed (or a retry races), addOwnerWithThreshold
-        // would revert with "already an owner" — reconcile from chain instead.
+        // Idempotency: if a previous attempt already executed on-chain but the
+        // DB flip failed (or a retry races), re-running the calls would revert
+        // ("already an owner" / "not an owner") — reconcile from chain instead.
+        // The check is the FULL owner set matching the transition's simulated
+        // END state: backup-key membership alone falsely completed detach and
+        // swap, where the backup is an owner BEFORE the transition too.
         try {
-          const record = await getUserDetails(pendingTx.safeAddress);
           const onChainOwners = (await readSafeOwners(pendingTx.safeAddress)).map((o) =>
             o.toLowerCase()
           );
-          if (
-            record?.external_wallet_address &&
-            onChainOwners.includes(record.external_wallet_address.toLowerCase())
-          ) {
+          const want = new Set(transitionTarget.endOwners.map((o) => o.toLowerCase()));
+          const alreadyAtEndState =
+            onChainOwners.length === want.size && onChainOwners.every((o) => want.has(o));
+          if (alreadyAtEndState) {
             await finishTransition(pendingTx.safeAddress, transitionTarget);
             res.json({ success: true, id: pendingTx.id, upgraded: true, alreadyUpgraded: true });
             return;

--- a/server/src/routes/runtime.ts
+++ b/server/src/routes/runtime.ts
@@ -15,6 +15,7 @@ import { leaseNextJob, heartbeatJob, submitJobResult, getJob, getDeadLetterJobs 
 import type { JobResultSubmission } from "../lib/runtime/jobsPolicy.js";
 import { loadPolicySnapshot, type RiskResult } from "../agent/index.js";
 import { applyScreeningDecision } from "../lib/screening/apply.js";
+import { markRuntimeSeen } from "../lib/runtime/liveness.js";
 
 /**
  * A screen result must carry a complete, well-formed decision BEFORE it can
@@ -56,6 +57,9 @@ function runtimeAuth(req: Request, res: Response, next: NextFunction): void {
     res.status(401).json({ error: "Invalid runtime credential" });
     return;
   }
+  // Every authenticated runtime call (the lease long-poll above all) is
+  // proof of life — the signal behind /status agent liveness (#136.5).
+  markRuntimeSeen();
   next();
 }
 

--- a/server/src/routes/status.ts
+++ b/server/src/routes/status.ts
@@ -9,6 +9,21 @@ import {
 import type { GlobalLimitsRow } from "../lib/supabase/types.js";
 import { assertOwnsSafe } from "../lib/authz.js";
 import { ensureLinkMeta, getLinkBySafe } from "../lib/telegram/binding.js";
+import { getUserDetails } from "../lib/supabase/index.js";
+import { classifyProfile, type WalletState } from "../lib/safe/profiles.js";
+import { getAgentAddress } from "../lib/safe/relayer.js";
+import { runtimeLiveness } from "../lib/runtime/liveness.js";
+
+/** Live wallet profile from the record's mirrored owner set (never stored). */
+async function profileForSafe(safe: string): Promise<WalletState> {
+  const record = await getUserDetails(safe).catch(() => null);
+  if (!record) return "unknown";
+  const agent = getAgentAddress();
+  const owners = record.safe_owners?.length
+    ? record.safe_owners
+    : [record.signer_address ?? "", agent];
+  return classifyProfile(owners, record.safe_threshold ?? 2, agent);
+}
 
 export function createStatusRouter(): IRouter {
   const router = Router();
@@ -20,14 +35,31 @@ export function createStatusRouter(): IRouter {
       const safe = assertOwnsSafe(req, res, req.query.safe as string | undefined);
       if (!safe) return;
 
-      const [settings, patterns, link] = await Promise.all([
+      const [settings, patterns, link, profile] = await Promise.all([
         getUserSettings(safe),
         loadPolicySnapshot(safe),
         getLinkBySafe(safe).then((l) => (l ? ensureLinkMeta(l) : l)),
+        profileForSafe(safe),
       ]);
 
+      // EFFECTIVE screening mode (#136.1): guarded ⇒ structurally ON — the
+      // agent is the only possible co-signer, so a stored false is drift, not
+      // a choice. Report the effective value and converge the stored flag.
+      const screeningLocked = profile === "guarded";
+      const screeningMode = screeningLocked ? true : settings.screening_mode;
+      if (screeningLocked && !settings.screening_mode) {
+        upsertUserSettings(safe, { screening_mode: true }).catch((err) =>
+          console.error("screening_mode self-heal failed:", err)
+        );
+      }
+
       res.json({
-        screeningMode: settings.screening_mode,
+        screeningMode,
+        /** Guarded: screening is structural — the toggle is locked ON. */
+        screeningLocked,
+        profile,
+        /** Runtime liveness — the truth behind any "agent online" surface. */
+        agent: runtimeLiveness(),
         lastCheck: settings.last_check,
         totalDecisions: (settings.decisions ?? []).length,
         telegramLinked: Boolean(link),
@@ -88,6 +120,17 @@ export function createStatusRouter(): IRouter {
       if (screeningMode !== undefined) {
         if (typeof screeningMode !== "boolean") {
           res.status(400).json({ error: "screeningMode must be a boolean" });
+          return;
+        }
+        // Guarded ⇒ screening is structural (#136.1): the stored flag may
+        // never be written false while the agent is the only possible
+        // co-signer. (Unlink's SQL consequence still sets it — /status and
+        // /queue report/enforce the effective value regardless.)
+        if (screeningMode === false && (await profileForSafe(safe)) === "guarded") {
+          res.status(400).json({
+            error:
+              "Screening cannot be turned off for this wallet — your keys alone can never meet the signing threshold. Add a backup key to control screening.",
+          });
           return;
         }
         settingsPatch.screening_mode = screeningMode;

--- a/server/src/routes/status.ts
+++ b/server/src/routes/status.ts
@@ -15,14 +15,21 @@ import { getAgentAddress } from "../lib/safe/relayer.js";
 import { runtimeLiveness } from "../lib/runtime/liveness.js";
 
 /** Live wallet profile from the record's mirrored owner set (never stored). */
-async function profileForSafe(safe: string): Promise<WalletState> {
+async function profileForSafe(
+  safe: string
+): Promise<{ profile: WalletState; structuralScreening: boolean }> {
   const record = await getUserDetails(safe).catch(() => null);
-  if (!record) return "unknown";
+  if (!record) return { profile: "unknown", structuralScreening: false };
   const agent = getAgentAddress();
   const owners = record.safe_owners?.length
     ? record.safe_owners
     : [record.signer_address ?? "", agent];
-  return classifyProfile(owners, record.safe_threshold ?? 2, agent);
+  const profile = classifyProfile(owners, record.safe_threshold ?? 2, agent);
+  // Guarded v2 ⇒ screening is structural. Legacy v1 guarded (pre-refactor
+  // 2-of-2) keeps its historical choice: the agent co-signs even unscreened
+  // (the legacy capability), so pausing is legitimate there.
+  const structuralScreening = profile === "guarded" && (record.derivation_version ?? 1) >= 2;
+  return { profile, structuralScreening };
 }
 
 export function createStatusRouter(): IRouter {
@@ -35,17 +42,18 @@ export function createStatusRouter(): IRouter {
       const safe = assertOwnsSafe(req, res, req.query.safe as string | undefined);
       if (!safe) return;
 
-      const [settings, patterns, link, profile] = await Promise.all([
+      const [settings, patterns, link, { profile, structuralScreening }] = await Promise.all([
         getUserSettings(safe),
         loadPolicySnapshot(safe),
         getLinkBySafe(safe).then((l) => (l ? ensureLinkMeta(l) : l)),
         profileForSafe(safe),
       ]);
 
-      // EFFECTIVE screening mode (#136.1): guarded ⇒ structurally ON — the
-      // agent is the only possible co-signer, so a stored false is drift, not
-      // a choice. Report the effective value and converge the stored flag.
-      const screeningLocked = profile === "guarded";
+      // EFFECTIVE screening mode (#136.1): guarded v2 ⇒ structurally ON —
+      // the agent is the only possible co-signer, so a stored false is
+      // drift, not a choice. Report the effective value and converge the
+      // stored flag.
+      const screeningLocked = structuralScreening;
       const screeningMode = screeningLocked ? true : settings.screening_mode;
       if (screeningLocked && !settings.screening_mode) {
         upsertUserSettings(safe, { screening_mode: true }).catch((err) =>
@@ -122,11 +130,11 @@ export function createStatusRouter(): IRouter {
           res.status(400).json({ error: "screeningMode must be a boolean" });
           return;
         }
-        // Guarded ⇒ screening is structural (#136.1): the stored flag may
+        // Guarded v2 ⇒ screening is structural (#136.1): the stored flag may
         // never be written false while the agent is the only possible
         // co-signer. (Unlink's SQL consequence still sets it — /status and
         // /queue report/enforce the effective value regardless.)
-        if (screeningMode === false && (await profileForSafe(safe)) === "guarded") {
+        if (screeningMode === false && (await profileForSafe(safe)).structuralScreening) {
           res.status(400).json({
             error:
               "Screening cannot be turned off for this wallet — your keys alone can never meet the signing threshold. Add a backup key to control screening.",

--- a/server/src/routes/users.ts
+++ b/server/src/routes/users.ts
@@ -14,9 +14,10 @@ import { assertOwnsSafe, sameAddress } from "../lib/authz.js";
  * Decides whether the caller may write the `user_details` row for `safeAddress`.
  *
  * This route can't authorize against `req.user` the way the others do. `req.user`
- * is found by `signer_address`, and during onboarding that column is empty until
- * the very last step — the username and Telegram writes happen before it. Gating
- * on `req.user` would therefore reject every new user.
+ * is found by `signer_address`, which the onboarding sync now stamps at the
+ * step-0 commit — but the very FIRST write of a brand-new account still races
+ * it, and rows from failed/legacy syncs can lack it. Gating on `req.user`
+ * would therefore reject those users.
  *
  * So the anchor is the embedded wallet the Privy token proves, which exists from
  * the first request. A row belongs to whoever's wallet it names; a row that names


### PR DESCRIPTION
Implements issue #136 across all nine items, every change additive and existing-flow-safe (no DB migrations; 190 tests green; all packages build).

## Item 1 — guarded screening soft-lock (critical)
Screening is now **structural** for guarded v2 wallets, enforced where it matters instead of trusting a client effect:
- `/queue` no longer refuses a guarded proposal claiming screening-off — it **forces the proposal through screening** and self-heals `user_settings.screening_mode` (this un-strands existing soft-locked wallets with zero data migration).
- `GET /status` reports the **effective** mode (`guarded v2 ⇒ true`, + `screeningLocked`, + live `profile`); `PATCH` refuses `screeningMode:false` for guarded v2. Legacy v1 guarded keeps its historical pause choice (legacy capability).
- Settings shows the toggle locked-**ON** with copy that finally mentions the email fallback; `isScreeningActive` counts locked screening as active, so no surface claims "Paused" while the server screens everything.

## Item 3 — transitions stuck in REVIEW
Root cause found: `decodeSafeTxKind` classifies transitions as `{kind:"config"}` but the engine had **no config branch**, so the Safe's own address scored as an unknown recipient → REVIEW 40. Fixed at three layers:
- **Engine rule** (screening pkg): a *validated* wallet-profile transition auto-APPROVEs (score 0); any other config self-call scores an honest fixed 40 through the user's thresholds. Contract-tested. Works **with or without the wire flag**.
- **Job assembly** marks validated transitions in the decoded payload (`validateTransitionTx` moved to `lib/safe/transition.ts`, shared by /queue, the enqueuer, and apply.ts).
- **Threshold-2 transitions route THROUGH screening** so D4 signing has its own runtime record — the record-less direct execute was refused by the signing authority since D4 (guarded→protected, detach, swap were latently broken). Starter and legacy-v1 transitions keep the synchronous fast path (still work with no runtime). `apply.ts` mirrors the owner set when a screened transition lands after the propose window.

## Item 4 — resolution dead-end
`useSafeAddress` gains an error channel after 3 consecutive failures; onboarding step 0 shows "Can't reach Zhentan — retrying" with a manual retry instead of eternal "Creating your vault..."; AuthGuard's loader says the same instead of "Securing your session".

## Item 5 — agent liveness
- Every authenticated Runtime API call stamps liveness (the lease long-poll is a continuous heartbeat); exposed as `agent` in `/status` and a public `runtime: online|offline` field in `/health`.
- RightRail/TopBar show an amber offline state when screening is on but the runtime isn't polling; the **login badge reads /health** instead of the hardcoded "Agent · online"; SendPanel's pending card explains an offline agent (and protected wallets get "no need to wait — co-sign executes now").

## Item 6 — Telegram send-gate
The hard block is now a **soft gate**: the modal explains reviews reach email + dashboard and offers "Send anyway" alongside "Connect Telegram". Onboarding's Telegram step shows the consequence note for guarded creations instead of a silent skip.

## Items 2 + 8 — upgrade-path parity
- `TelegramConnectCard` extracted (Mao watch card, pure open-bot link, RFC 8628 code entry) and used by ActivationDialog **and** UpgradeDialog; the UpgradeDialog Telegram step watches the binding while open and is now offered on the guarded flow too.
- UpgradeDialog's backup-key skip carries the **same lockout disclosure** onboarding requires; screened-path transitions show a real **pending step** (polls until the profile flips) instead of a false "Wallet upgraded"; dead `needsUpgrade`/`backupKeyLinked` API removed.
- Note: onboarding's ConnectStep keeps its own (behaviorally identical) markup — visual unification onto the shared card left for a cosmetics pass.

## Item 7 — first-run honesty
Profile-aware main tour (starter users no longer hear "every signature gets screened" / "You're guarded"), a new "Fund your vault" step anchored on Receive, a $0-balance funding nudge on BalanceCard, and the Assets badge counts real holdings instead of the 5 placeholder rows (which are also no longer clickable — some carried Ethereum-mainnet tokenIds).

## Item 9 — polish
`privyUser` console.log removed; username availability-check failure says "Couldn't check" instead of "Available"; blank step-2 card replaced with a wait state; single Continue CTA on the TG step; disabled screening toggle explains itself (aria-label + title); stale `users.ts` comment fixed.

## Deliberately not in this PR
- The PWA `start_url` double-redirect (middleware change, riskier than its payoff — needs its own look).
- ReceivePanel "vault not on-chain yet" caveat / `serviceWarning` toast (deploy failures remain console-only).
- UpgradeBanner in-flight indicator + dismiss affordance (needs shared transition state; dismiss is a product call on the "persistent nudge" behavior).
- #137 (relink displaced-chat retirement) — tracked separately.

## Verification
- Server: 160 tests green (incl. 2 new engine tests for the config rule); layering lint ok.
- Runtime: 30 tests green. Client: tsc clean, production build clean; all workspace packages build.
- Existing-flow safety: relay-only/co-sign sends untouched; legacy v1 exemptions preserved everywhere (queue guard, transitions, screening lock); protected screening toggle unchanged; fast-path transitions byte-identical for the flows that worked; older-server client renders exactly as before (all new /status fields optional).

Closes #136.

🤖 Generated with [Claude Code](https://claude.com/claude-code)